### PR TITLE
Fix: Add vertices field support for polygon geofences

### DIFF
--- a/packages/tracelet_android/android/src/main/kotlin/com/tracelet/tracelet_android/db/TraceletDatabase.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/tracelet/tracelet_android/db/TraceletDatabase.kt
@@ -21,7 +21,7 @@ class TraceletDatabase private constructor(context: Context) :
 
     companion object {
         private const val DB_NAME = "tracelet.db"
-        private const val DB_VERSION = 3
+        private const val DB_VERSION = 4
 
         // Location table
         const val TABLE_LOCATIONS = "locations"
@@ -57,6 +57,7 @@ class TraceletDatabase private constructor(context: Context) :
         const val COL_NOTIFY_ON_DWELL = "notify_on_dwell"
         const val COL_LOITERING_DELAY = "loitering_delay"
         const val COL_GF_EXTRAS = "gf_extras"
+        const val COL_VERTICES = "vertices"
 
         // Log table
         const val TABLE_LOGS = "logs"
@@ -135,7 +136,8 @@ class TraceletDatabase private constructor(context: Context) :
                 $COL_NOTIFY_ON_EXIT INTEGER DEFAULT 1,
                 $COL_NOTIFY_ON_DWELL INTEGER DEFAULT 0,
                 $COL_LOITERING_DELAY INTEGER DEFAULT 0,
-                $COL_GF_EXTRAS TEXT
+                $COL_GF_EXTRAS TEXT,
+                $COL_VERTICES TEXT
             )
         """.trimIndent())
 
@@ -208,6 +210,12 @@ class TraceletDatabase private constructor(context: Context) :
                     $COL_PZ_ACTION INTEGER NOT NULL DEFAULT 0,
                     $COL_PZ_DEGRADED_ACCURACY REAL DEFAULT 1000.0
                 )
+            """.trimIndent())
+        }
+        // v3 → v4: Add vertices column to geofences table
+        if (oldVersion < 4) {
+            db.execSQL("""
+                ALTER TABLE $TABLE_GEOFENCES ADD COLUMN $COL_VERTICES TEXT
             """.trimIndent())
         }
     }
@@ -359,6 +367,23 @@ class TraceletDatabase private constructor(context: Context) :
             put(COL_NOTIFY_ON_DWELL, if (geofence["notifyOnDwell"] == true) 1 else 0)
             put(COL_LOITERING_DELAY, (geofence["loiteringDelay"] as? Number)?.toInt() ?: 0)
             put(COL_GF_EXTRAS, geofence["extras"]?.toString())
+
+            // Serialize vertices as JSON
+            val vertices = geofence["vertices"] as? List<*>
+            if (vertices != null && vertices.isNotEmpty()) {
+                val verticesJson = org.json.JSONArray()
+                for (vertex in vertices) {
+                    if (vertex is List<*> && vertex.size >= 2) {
+                        val vertexArray = org.json.JSONArray()
+                        vertexArray.put((vertex[0] as? Number)?.toDouble() ?: 0.0)
+                        vertexArray.put((vertex[1] as? Number)?.toDouble() ?: 0.0)
+                        verticesJson.put(vertexArray)
+                    }
+                }
+                put(COL_VERTICES, verticesJson.toString())
+            } else {
+                put(COL_VERTICES, null as String?)
+            }
         }
         writableDatabase.insertWithOnConflict(TABLE_GEOFENCES, null, values, SQLiteDatabase.CONFLICT_REPLACE)
         return true
@@ -533,6 +558,26 @@ class TraceletDatabase private constructor(context: Context) :
     }
 
     private fun cursorToGeofence(c: Cursor): Map<String, Any?> {
+        // Parse vertices from JSON
+        val verticesJson = c.getString(c.getColumnIndexOrThrow(COL_VERTICES))
+        val vertices = mutableListOf<List<Double>>()
+        if (verticesJson != null && verticesJson.isNotEmpty()) {
+            try {
+                val jsonArray = org.json.JSONArray(verticesJson)
+                for (i in 0 until jsonArray.length()) {
+                    val vertexArray = jsonArray.getJSONArray(i)
+                    if (vertexArray.length() >= 2) {
+                        vertices.add(listOf(
+                            vertexArray.getDouble(0),
+                            vertexArray.getDouble(1)
+                        ))
+                    }
+                }
+            } catch (e: Exception) {
+                // Ignore parse errors, return empty vertices
+            }
+        }
+
         return mapOf(
             "identifier" to c.getString(c.getColumnIndexOrThrow(COL_IDENTIFIER)),
             "latitude" to c.getDouble(c.getColumnIndexOrThrow(COL_LATITUDE)),
@@ -543,6 +588,7 @@ class TraceletDatabase private constructor(context: Context) :
             "notifyOnDwell" to (c.getInt(c.getColumnIndexOrThrow(COL_NOTIFY_ON_DWELL)) == 1),
             "loiteringDelay" to c.getInt(c.getColumnIndexOrThrow(COL_LOITERING_DELAY)),
             "extras" to c.getString(c.getColumnIndexOrThrow(COL_GF_EXTRAS)),
+            "vertices" to vertices,
         )
     }
 

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletDatabase.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletDatabase.swift
@@ -86,7 +86,8 @@ final class TraceletDatabase {
                 notify_on_exit INTEGER DEFAULT 1,
                 notify_on_dwell INTEGER DEFAULT 0,
                 loitering_delay INTEGER DEFAULT 0,
-                extras TEXT
+                extras TEXT,
+                vertices TEXT
             )
         """)
 
@@ -306,8 +307,8 @@ final class TraceletDatabase {
             let sql = """
                 INSERT OR REPLACE INTO geofences
                 (identifier, latitude, longitude, radius, notify_on_entry, notify_on_exit,
-                 notify_on_dwell, loitering_delay, extras)
-                VALUES (?,?,?,?,?,?,?,?,?)
+                 notify_on_dwell, loitering_delay, extras, vertices)
+                VALUES (?,?,?,?,?,?,?,?,?,?)
             """
             var stmt: OpaquePointer?
             guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
@@ -325,6 +326,27 @@ final class TraceletDatabase {
             let extrasJson = extras.flatMap { try? JSONSerialization.data(withJSONObject: $0) }
                 .flatMap { String(data: $0, encoding: .utf8) }
             sqlite3_bind_text(stmt, 9, nsString(extrasJson ?? ""), -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+
+            // Serialize vertices as JSON
+            if let vertices = data["vertices"] as? [[Any]], !vertices.isEmpty {
+                var verticesArray: [[Double]] = []
+                for vertex in vertices {
+                    if vertex.count >= 2,
+                       let lat = vertex[0] as? Double,
+                       let lng = vertex[1] as? Double {
+                        verticesArray.append([lat, lng])
+                    }
+                }
+                if let verticesData = try? JSONSerialization.data(withJSONObject: verticesArray),
+                   let verticesJson = String(data: verticesData, encoding: .utf8) {
+                    sqlite3_bind_text(stmt, 10, nsString(verticesJson), -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+                } else {
+                    sqlite3_bind_null(stmt, 10)
+                }
+            } else {
+                sqlite3_bind_null(stmt, 10)
+            }
+
             success = sqlite3_step(stmt) == SQLITE_DONE
         }
         return success
@@ -723,6 +745,16 @@ final class TraceletDatabase {
         let extras: [String: Any]? = extrasStr.isEmpty ? nil :
             (try? JSONSerialization.jsonObject(with: Data(extrasStr.utf8)) as? [String: Any])
 
+        // Parse vertices from JSON
+        let verticesStr = columnText(stmt, 9)
+        var vertices: [[Double]] = []
+        if !verticesStr.isEmpty {
+            if let verticesData = verticesStr.data(using: .utf8),
+               let verticesArray = try? JSONSerialization.jsonObject(with: verticesData) as? [[Double]] {
+                vertices = verticesArray
+            }
+        }
+
         return [
             "identifier": columnText(stmt, 0),
             "latitude": sqlite3_column_double(stmt, 1),
@@ -733,6 +765,7 @@ final class TraceletDatabase {
             "notifyOnDwell": sqlite3_column_int(stmt, 6) == 1,
             "loiteringDelay": Int(sqlite3_column_int(stmt, 7)),
             "extras": extras as Any,
+            "vertices": vertices,
         ]
     }
 


### PR DESCRIPTION
## Problem

When adding polygon geofences with vertices parameter, the polygon data was not being persisted to the database. This caused polygon geofences to fail to display or function correctly after being saved.

## Root Cause

The Geofence model in Dart already had the vertices field defined, but the database schemas on both Android and iOS platforms were missing the corresponding column to store this data. When addGeofence() was called, the vertices data was silently dropped during database insertion.

## Solution

Android (TraceletDatabase.kt):
  - Added vertices TEXT column to the geofences table schema
  - Incremented database version from 3 to 4
  - Added migration logic in onUpgrade() to add the column for existing databases
  - Updated insertGeofence() to serialize vertices as JSON array ([[lat1,lng1],[lat2,lng2],...])
  - Updated cursorToGeofence() to deserialize vertices from JSON when reading

iOS (TraceletDatabase.swift):
  - Added vertices TEXT column to the geofences table schema
  - Updated insertGeofence() to serialize vertices as JSON array
  - Updated geofenceRowToMap() to deserialize vertices from JSON when reading

## Breaking Changes

None. This is a backward-compatible fix. Existing circular geofences continue to work as before.