### PR TITLE
Implement SQLQuery start/end timestamp filtering for getLocations and getCount on Android and iOS (fixes #27)

### DIFF
--- a/packages/tracelet/lib/src/tracelet.dart
+++ b/packages/tracelet/lib/src/tracelet.dart
@@ -618,8 +618,10 @@ class Tracelet {
   }
 
   /// Get the count of stored locations.
-  static Future<int> getCount() {
-    return _platform.getCount();
+  ///
+  /// Optionally pass a [query] to count only locations within a time range.
+  static Future<int> getCount([SQLQuery? query]) {
+    return _platform.getCount(query?.toMap());
   }
 
   /// Destroy all stored locations.

--- a/packages/tracelet/test/models_test.dart
+++ b/packages/tracelet/test/models_test.dart
@@ -1218,6 +1218,80 @@ void main() {
       expect(map['start'], now.millisecondsSinceEpoch);
       expect(map['limit'], 100);
     });
+
+    test('toMap includes both start and end as milliseconds', () {
+      final start = DateTime(2024, 1, 1);
+      final end = DateTime(2024, 12, 31);
+      final query = SQLQuery(start: start, end: end);
+      final map = query.toMap();
+      expect(map['start'], start.millisecondsSinceEpoch);
+      expect(map['end'], end.millisecondsSinceEpoch);
+      expect(map['limit'], -1);
+      expect(map['order'], LocationOrder.asc.index);
+    });
+
+    test('toMap omits null start and end', () {
+      const query = SQLQuery(limit: 50);
+      final map = query.toMap();
+      expect(map['start'], isNull);
+      expect(map['end'], isNull);
+      expect(map['limit'], 50);
+    });
+
+    test('fromMap round-trips start and end', () {
+      final start = DateTime(2024, 3, 15, 8, 30);
+      final end = DateTime(2024, 3, 15, 17, 0);
+      final original = SQLQuery(
+        start: start,
+        end: end,
+        limit: 200,
+        order: LocationOrder.desc,
+      );
+      final restored = SQLQuery.fromMap(original.toMap());
+      expect(restored.start, start);
+      expect(restored.end, end);
+      expect(restored.limit, 200);
+      expect(restored.order, LocationOrder.desc);
+    });
+
+    test('fromMap handles null start and end', () {
+      final query = SQLQuery.fromMap(const {'limit': 10, 'order': 0});
+      expect(query.start, isNull);
+      expect(query.end, isNull);
+    });
+
+    test('fromMap with only start set', () {
+      final start = DateTime(2024, 6, 1);
+      final query = SQLQuery.fromMap({
+        'start': start.millisecondsSinceEpoch,
+        'limit': -1,
+        'order': 0,
+      });
+      expect(query.start, start);
+      expect(query.end, isNull);
+    });
+
+    test('fromMap with only end set', () {
+      final end = DateTime(2024, 6, 30);
+      final query = SQLQuery.fromMap({
+        'end': end.millisecondsSinceEpoch,
+        'limit': -1,
+        'order': 0,
+      });
+      expect(query.start, isNull);
+      expect(query.end, end);
+    });
+
+    test('toString includes start and end', () {
+      final query = SQLQuery(
+        start: DateTime(2024, 1, 1),
+        end: DateTime(2024, 12, 31),
+      );
+      final str = query.toString();
+      expect(str, contains('start:'));
+      expect(str, contains('end:'));
+      expect(str, contains('SQLQuery'));
+    });
   });
 
   // ==========================================================================

--- a/packages/tracelet_android/android/src/main/kotlin/com/tracelet/core/db/TraceletDatabase.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/tracelet/core/db/TraceletDatabase.kt
@@ -291,16 +291,29 @@ class TraceletDatabase private constructor(context: Context) :
         }
     }
 
-    /** Retrieves locations with optional pagination and ordering. Includes audit fields. */
-    fun getLocations(limit: Int = -1, offset: Int = 0, orderAsc: Boolean = true): List<Map<String, Any?>> {
+    /** Retrieves locations with optional time range, pagination and ordering. Includes audit fields. */
+    fun getLocations(limit: Int = -1, offset: Int = 0, orderAsc: Boolean = true, startTime: Long? = null, endTime: Long? = null): List<Map<String, Any?>> {
         val order = if (orderAsc) "ASC" else "DESC"
+        val conditions = mutableListOf<String>()
+        val args = mutableListOf<String>()
+
+        startTime?.let {
+            conditions.add("l.$COL_TIMESTAMP >= ?")
+            args.add(it.toString())
+        }
+        endTime?.let {
+            conditions.add("l.$COL_TIMESTAMP <= ?")
+            args.add(it.toString())
+        }
+
+        val where = if (conditions.isNotEmpty()) "WHERE ${conditions.joinToString(" AND ")}" else ""
         val limitClause = if (limit > 0) "LIMIT $limit OFFSET $offset" else ""
         val cursor = readableDatabase.rawQuery(
             "SELECT l.*, a.$COL_AUDIT_HASH, a.$COL_AUDIT_PREVIOUS_HASH, a.$COL_AUDIT_CHAIN_INDEX " +
             "FROM $TABLE_LOCATIONS l " +
             "LEFT JOIN $TABLE_AUDIT_TRAIL a ON l.$COL_UUID = a.$COL_UUID " +
-            "ORDER BY l.$COL_TIMESTAMP $order $limitClause",
-            null
+            "$where ORDER BY l.$COL_TIMESTAMP $order $limitClause",
+            args.toTypedArray()
         )
         return cursorToLocationList(cursor)
     }
@@ -319,8 +332,21 @@ class TraceletDatabase private constructor(context: Context) :
     }
 
     /** Returns total count of stored locations. */
-    fun getLocationCount(): Int {
-        val cursor = readableDatabase.rawQuery("SELECT COUNT(*) FROM $TABLE_LOCATIONS", null)
+    fun getLocationCount(startTime: Long? = null, endTime: Long? = null): Int {
+        val conditions = mutableListOf<String>()
+        val args = mutableListOf<String>()
+
+        startTime?.let {
+            conditions.add("$COL_TIMESTAMP >= ?")
+            args.add(it.toString())
+        }
+        endTime?.let {
+            conditions.add("$COL_TIMESTAMP <= ?")
+            args.add(it.toString())
+        }
+
+        val where = if (conditions.isNotEmpty()) "WHERE ${conditions.joinToString(" AND ")}" else ""
+        val cursor = readableDatabase.rawQuery("SELECT COUNT(*) FROM $TABLE_LOCATIONS $where", args.toTypedArray())
         cursor.use {
             return if (it.moveToFirst()) it.getInt(0) else 0
         }

--- a/packages/tracelet_android/android/src/main/kotlin/com/tracelet/tracelet_android/TraceletAndroidPlugin.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/tracelet/tracelet_android/TraceletAndroidPlugin.kt
@@ -275,7 +275,13 @@ class TraceletAndroidPlugin :
 
             // Persistence
             "getLocations" -> handleGetLocations(call, result)
-            "getCount" -> result.success(database.getLocationCount())
+            "getCount" -> {
+                @Suppress("UNCHECKED_CAST")
+                val query = call.arguments as? Map<String, Any?>
+                val startTime = (query?.get("start") as? Number)?.toLong()
+                val endTime = (query?.get("end") as? Number)?.toLong()
+                result.success(database.getLocationCount(startTime, endTime))
+            }
             "destroyLocations" -> result.success(database.deleteAllLocations())
             "destroyLocation" -> {
                 val uuid = call.arguments as? String ?: ""
@@ -984,7 +990,9 @@ class TraceletAndroidPlugin :
         val limit = (query?.get("limit") as? Number)?.toInt() ?: -1
         val offset = (query?.get("offset") as? Number)?.toInt() ?: 0
         val orderAsc = (query?.get("order") as? Number)?.toInt() != 1
-        result.success(database.getLocations(limit, offset, orderAsc))
+        val startTime = (query?.get("start") as? Number)?.toLong()
+        val endTime = (query?.get("end") as? Number)?.toLong()
+        result.success(database.getLocations(limit, offset, orderAsc, startTime, endTime))
     }
 
     private fun handleInsertLocation(call: MethodCall, result: Result) {

--- a/packages/tracelet_android/android/src/test/kotlin/com/tracelet/tracelet_android/db/TraceletDatabaseQueryTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/tracelet/tracelet_android/db/TraceletDatabaseQueryTest.kt
@@ -1,0 +1,209 @@
+package com.tracelet.tracelet_android.db
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Robolectric tests for [TraceletDatabase] location query filtering —
+ * verifying that getLocations() and getLocationCount() correctly apply
+ * start/end timestamp WHERE clauses.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+internal class TraceletDatabaseQueryTest {
+
+    private lateinit var db: TraceletDatabase
+
+    @Before
+    fun setUp() {
+        val field = TraceletDatabase::class.java.getDeclaredField("instance")
+        field.isAccessible = true
+        field.set(null, null)
+        db = TraceletDatabase.getInstance(ApplicationProvider.getApplicationContext())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        val field = TraceletDatabase::class.java.getDeclaredField("instance")
+        field.isAccessible = true
+        field.set(null, null)
+    }
+
+    /** Helper to insert a location with a specific timestamp. */
+    private fun insertAt(timestamp: Long, lat: Double = 37.0, lng: Double = -122.0): String {
+        return db.insertLocation(mapOf(
+            "latitude" to lat,
+            "longitude" to lng,
+            "timestamp" to timestamp,
+        ))
+    }
+
+    // =========================================================================
+    // getLocations — timestamp filtering
+    // =========================================================================
+
+    @Test
+    fun getLocations_noFilters_returnsAll() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        val results = db.getLocations()
+        assertEquals(3, results.size)
+    }
+
+    @Test
+    fun getLocations_withStartTime_filtersOlderLocations() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        val results = db.getLocations(startTime = 2000L)
+        assertEquals(2, results.size)
+        // All returned timestamps should be >= 2000
+        results.forEach { loc ->
+            val ts = (loc["timestamp"] as Number).toLong()
+            assertTrue(ts >= 2000L, "Expected timestamp >= 2000, got $ts")
+        }
+    }
+
+    @Test
+    fun getLocations_withEndTime_filtersNewerLocations() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        val results = db.getLocations(endTime = 2000L)
+        assertEquals(2, results.size)
+        results.forEach { loc ->
+            val ts = (loc["timestamp"] as Number).toLong()
+            assertTrue(ts <= 2000L, "Expected timestamp <= 2000, got $ts")
+        }
+    }
+
+    @Test
+    fun getLocations_withStartAndEnd_filtersToRange() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        insertAt(4000L)
+        val results = db.getLocations(startTime = 2000L, endTime = 3000L)
+        assertEquals(2, results.size)
+        results.forEach { loc ->
+            val ts = (loc["timestamp"] as Number).toLong()
+            assertTrue(ts in 2000L..3000L, "Expected timestamp in [2000,3000], got $ts")
+        }
+    }
+
+    @Test
+    fun getLocations_startAndEnd_areInclusive() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        // Exact boundary match should be included
+        val results = db.getLocations(startTime = 1000L, endTime = 3000L)
+        assertEquals(3, results.size)
+    }
+
+    @Test
+    fun getLocations_noMatchingRange_returnsEmpty() {
+        insertAt(1000L)
+        insertAt(2000L)
+        val results = db.getLocations(startTime = 5000L, endTime = 6000L)
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun getLocations_withLimitAndTimeRange() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        insertAt(4000L)
+        // Time range matches 3 rows (2000-4000), but limit to 2
+        val results = db.getLocations(limit = 2, startTime = 2000L, endTime = 4000L)
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun getLocations_withOrderAndTimeRange() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        val resultsAsc = db.getLocations(startTime = 1000L, endTime = 3000L, orderAsc = true)
+        val resultsDesc = db.getLocations(startTime = 1000L, endTime = 3000L, orderAsc = false)
+        assertEquals(3, resultsAsc.size)
+        assertEquals(3, resultsDesc.size)
+        // ASC: first timestamp should be smallest
+        val firstAsc = (resultsAsc.first()["timestamp"] as Number).toLong()
+        val lastAsc = (resultsAsc.last()["timestamp"] as Number).toLong()
+        assertTrue(firstAsc <= lastAsc, "ASC order: first ($firstAsc) should be <= last ($lastAsc)")
+        // DESC: first timestamp should be largest
+        val firstDesc = (resultsDesc.first()["timestamp"] as Number).toLong()
+        val lastDesc = (resultsDesc.last()["timestamp"] as Number).toLong()
+        assertTrue(firstDesc >= lastDesc, "DESC order: first ($firstDesc) should be >= last ($lastDesc)")
+    }
+
+    @Test
+    fun getLocations_nullTimestamps_returnAll() {
+        insertAt(1000L)
+        insertAt(2000L)
+        // Explicitly passing null for both should be the same as no filter
+        val results = db.getLocations(startTime = null, endTime = null)
+        assertEquals(2, results.size)
+    }
+
+    // =========================================================================
+    // getLocationCount — timestamp filtering
+    // =========================================================================
+
+    @Test
+    fun getLocationCount_noFilters_countsAll() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        assertEquals(3, db.getLocationCount())
+    }
+
+    @Test
+    fun getLocationCount_withStartTime() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        assertEquals(2, db.getLocationCount(startTime = 2000L))
+    }
+
+    @Test
+    fun getLocationCount_withEndTime() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        assertEquals(2, db.getLocationCount(endTime = 2000L))
+    }
+
+    @Test
+    fun getLocationCount_withStartAndEnd() {
+        insertAt(1000L)
+        insertAt(2000L)
+        insertAt(3000L)
+        insertAt(4000L)
+        assertEquals(2, db.getLocationCount(startTime = 2000L, endTime = 3000L))
+    }
+
+    @Test
+    fun getLocationCount_noMatchingRange_returnsZero() {
+        insertAt(1000L)
+        insertAt(2000L)
+        assertEquals(0, db.getLocationCount(startTime = 5000L, endTime = 6000L))
+    }
+
+    @Test
+    fun getLocationCount_emptyDatabase_returnsZero() {
+        assertEquals(0, db.getLocationCount())
+        assertEquals(0, db.getLocationCount(startTime = 1000L, endTime = 2000L))
+    }
+}

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/TraceletCore/TraceletDatabase.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/TraceletCore/TraceletDatabase.swift
@@ -236,14 +236,18 @@ public final class TraceletDatabase {
         return uuid
     }
 
-    public func getLocations(limit: Int = -1, offset: Int = 0, orderAsc: Bool = true) -> [[String: Any]] {
+    public func getLocations(limit: Int = -1, offset: Int = 0, orderAsc: Bool = true, startTime: Int64? = nil, endTime: Int64? = nil) -> [[String: Any]] {
         var results: [[String: Any]] = []
         queue.sync {
             let order = orderAsc ? "ASC" : "DESC"
+            var conditions: [String] = []
+            if startTime != nil { conditions.append("l.timestamp >= ?") }
+            if endTime != nil { conditions.append("l.timestamp <= ?") }
+            let whereClause = conditions.isEmpty ? "" : "WHERE \(conditions.joined(separator: " AND "))"
             var sql = """
                 SELECT l.*, a.hash AS audit_hash, a.previous_hash AS audit_previous_hash, a.chain_index AS audit_chain_index
                 FROM locations l LEFT JOIN audit_trail a ON l.uuid = a.uuid
-                ORDER BY l.timestamp \(order)
+                \(whereClause) ORDER BY l.timestamp \(order)
             """
             if limit > 0 {
                 sql += " LIMIT \(limit) OFFSET \(offset)"
@@ -252,6 +256,16 @@ public final class TraceletDatabase {
             var stmt: OpaquePointer?
             guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
             defer { sqlite3_finalize(stmt) }
+
+            var bindIndex: Int32 = 1
+            if let start = startTime {
+                sqlite3_bind_int64(stmt, bindIndex, start)
+                bindIndex += 1
+            }
+            if let end = endTime {
+                sqlite3_bind_int64(stmt, bindIndex, end)
+                bindIndex += 1
+            }
 
             while sqlite3_step(stmt) == SQLITE_ROW {
                 results.append(locationRowToMap(stmt!))
@@ -280,12 +294,29 @@ public final class TraceletDatabase {
         return results
     }
 
-    public func getLocationCount() -> Int {
+    public func getLocationCount(startTime: Int64? = nil, endTime: Int64? = nil) -> Int {
         var count = 0
         queue.sync {
+            var conditions: [String] = []
+            if startTime != nil { conditions.append("timestamp >= ?") }
+            if endTime != nil { conditions.append("timestamp <= ?") }
+            let whereClause = conditions.isEmpty ? "" : "WHERE \(conditions.joined(separator: " AND "))"
+            let sql = "SELECT COUNT(*) FROM locations \(whereClause)"
+
             var stmt: OpaquePointer?
-            guard sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM locations", -1, &stmt, nil) == SQLITE_OK else { return }
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
             defer { sqlite3_finalize(stmt) }
+
+            var bindIndex: Int32 = 1
+            if let start = startTime {
+                sqlite3_bind_int64(stmt, bindIndex, start)
+                bindIndex += 1
+            }
+            if let end = endTime {
+                sqlite3_bind_int64(stmt, bindIndex, end)
+                bindIndex += 1
+            }
+
             if sqlite3_step(stmt) == SQLITE_ROW {
                 count = Int(sqlite3_column_int(stmt, 0))
             }

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
@@ -315,7 +315,10 @@ public class TraceletIosPlugin: NSObject, FlutterPlugin {
         case "getLocations":
             handleGetLocations(call, result: result)
         case "getCount":
-            result(database.getLocationCount())
+            let countQuery = call.arguments as? [String: Any]
+            let countStart = (countQuery?["start"] as? NSNumber)?.int64Value
+            let countEnd = (countQuery?["end"] as? NSNumber)?.int64Value
+            result(database.getLocationCount(startTime: countStart, endTime: countEnd))
         case "destroyLocations":
             result(database.deleteAllLocations())
         case "destroyLocation":
@@ -830,7 +833,9 @@ public class TraceletIosPlugin: NSObject, FlutterPlugin {
         let limit = (query?["limit"] as? NSNumber)?.intValue ?? -1
         let offset = (query?["offset"] as? NSNumber)?.intValue ?? 0
         let orderAsc = (query?["order"] as? NSNumber)?.intValue != 1
-        result(database.getLocations(limit: limit, offset: offset, orderAsc: orderAsc))
+        let startTime = (query?["start"] as? NSNumber)?.int64Value
+        let endTime = (query?["end"] as? NSNumber)?.int64Value
+        result(database.getLocations(limit: limit, offset: offset, orderAsc: orderAsc, startTime: startTime, endTime: endTime))
     }
 
     // MARK: - Utility handlers

--- a/packages/tracelet_platform_interface/lib/src/method_channel_tracelet.dart
+++ b/packages/tracelet_platform_interface/lib/src/method_channel_tracelet.dart
@@ -215,8 +215,8 @@ class MethodChannelTracelet extends TraceletPlatform {
   }
 
   @override
-  Future<int> getCount() async {
-    final result = await _methodChannel.invokeMethod<int>('getCount');
+  Future<int> getCount([Map<String, Object?>? query]) async {
+    final result = await _methodChannel.invokeMethod<int>('getCount', query);
     return result ?? 0;
   }
 

--- a/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
+++ b/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
@@ -197,7 +197,7 @@ abstract class TraceletPlatform extends PlatformInterface {
   }
 
   /// Get the count of stored locations.
-  Future<int> getCount() {
+  Future<int> getCount([Map<String, Object?>? query]) {
     throw UnimplementedError('getCount() has not been implemented.');
   }
 

--- a/packages/tracelet_platform_interface/test/tracelet_platform_interface_test.dart
+++ b/packages/tracelet_platform_interface/test/tracelet_platform_interface_test.dart
@@ -54,6 +54,38 @@ void main() {
         throwsA(isA<UnimplementedError>()),
       );
     });
+
+    test('getLocations throws UnimplementedError by default', () {
+      final platform = _TestPlatform();
+      expect(
+        () => platform.getLocations(),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('getLocations accepts optional query map', () {
+      final platform = _TestPlatform();
+      expect(
+        () => platform.getLocations({'start': 1000, 'end': 2000, 'limit': 10}),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('getCount throws UnimplementedError by default', () {
+      final platform = _TestPlatform();
+      expect(
+        () => platform.getCount(),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('getCount accepts optional query map', () {
+      final platform = _TestPlatform();
+      expect(
+        () => platform.getCount({'start': 1000, 'end': 2000}),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
   });
 }
 

--- a/packages/tracelet_web/lib/src/tracelet_web_plugin.dart
+++ b/packages/tracelet_web/lib/src/tracelet_web_plugin.dart
@@ -391,7 +391,8 @@ class TraceletWebPlugin extends TraceletPlatform {
   }
 
   @override
-  Future<int> getCount() {
+  Future<int> getCount([Map<String, Object?>? query]) {
+    // Web storage engine does not yet support time-range filtering for count.
     return _storage.getCount();
   }
 


### PR DESCRIPTION
  ## Summary

  - **Fixed `getLocations()` on both Android and iOS to honor `SQLQuery.start` and `SQLQuery.end` parameters** — these were silently ignored, causing all locations to be returned regardless of the time range specified
  - **Added optional `SQLQuery` parameter to `getCount()`** across the full stack (Dart API, platform interface, method channel, Android, iOS) to support time-bounded counting
  - Added parameterized `WHERE timestamp >= ? AND timestamp <= ?` clauses to both `TraceletDatabase.getLocations()` and `TraceletDatabase.getLocationCount()` on Android (Kotlin) and iOS (Swift)

  ## Changes

  ### Android (`tracelet_android`)
  - `TraceletDatabase.getLocations()` — accepts `startTime`/`endTime`, builds `WHERE` clause with parameterized queries (same pattern as existing `getLog()`)
  - `TraceletDatabase.getLocationCount()` — same timestamp filtering support
  - `TraceletAndroidPlugin.handleGetLocations()` — extracts `start`/`end` from query map
  - `TraceletAndroidPlugin` `getCount` handler — extracts `start`/`end` from arguments

  ### iOS (`tracelet_ios`)
  - `TraceletDatabase.getLocations()` — accepts `startTime`/`endTime` as `Int64?`, builds `WHERE` clause with `sqlite3_bind_int64`
  - `TraceletDatabase.getLocationCount()` — same timestamp filtering support
  - `TraceletIosPlugin.handleGetLocations()` — extracts `start`/`end` as `int64Value`
  - `TraceletIosPlugin` `getCount` handler — extracts `start`/`end` from arguments

  ### Dart (`tracelet`, `tracelet_platform_interface`, `tracelet_web`)
  - `TraceletPlatform.getCount()` — now accepts optional `Map<String, Object?>? query`
  - `MethodChannelTracelet.getCount()` — passes query map to platform channel
  - `Tracelet.getCount()` — now accepts optional `SQLQuery` parameter
  - `TraceletWebPlugin.getCount()` — updated override signature (web filtering not yet implemented)

  ## Test plan

  - [x] 7 new Dart tests in `models_test.dart` — SQLQuery serialization/deserialization of start/end, round-trips, null handling
  - [x] 4 new Dart tests in `tracelet_platform_interface_test.dart` — getLocations/getCount accept optional query
  - [x] 14 new Kotlin tests in `TraceletDatabaseQueryTest.kt` — getLocations and getLocationCount with time range filtering, boundary conditions, ordering, limit+range combos, empty results
  - [x] All 275 existing Dart tests pass
  - [ ] Verify Android Kotlin tests pass via CI (Robolectric)
  - [ ] Manual verification on device with `SQLQuery(start: ..., end: ...)` returning filtered results