### PR TITLE
fix(android): correct notification priority mapping in Pigeon path

### DIFF
--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -207,7 +207,7 @@ class TraceletHostApiImpl(
                 put("notificationColor", c.android.foregroundService.notificationColor)
                 put("notificationSmallIcon", c.android.foregroundService.notificationSmallIcon)
                 put("notificationLargeIcon", c.android.foregroundService.notificationLargeIcon)
-                put("notificationPriority", c.android.foregroundService.notificationPriority.raw)
+                put("notificationPriority", c.android.foregroundService.notificationPriority.raw - 2)
                 put("notificationOngoing", c.android.foregroundService.notificationOngoing)
                 put("showNotificationOnPauseOnly", c.android.foregroundService.showNotificationOnPauseOnly)
                 put("actions", c.android.foregroundService.actions)


### PR DESCRIPTION
The Pigeon-based TraceletHostApiImpl was sending raw enum values (0–4) for notificationPriority, but LocationService.createNotificationChannel() expects Android's priority range (-2 to 2). This caused all priority settings to be misinterpreted — e.g. NotificationPriority.min (raw=0) was treated as IMPORTANCE_DEFAULT instead of IMPORTANCE_MIN.

The Dart method channel path already applied the correct offset (index - 2), but the Pigeon path did not.

Applies `raw - 2` to align with the native SDK's NotificationPriority enum values: MIN(-2), LOW(-1), DEFAULT(0), HIGH(1), MAX(2).