### PR TITLE
fix(ci): resolve iOS Rust Core build and missing test dir failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,12 @@ jobs:
         run: melos bootstrap
       - name: Run tests
         working-directory: packages/${{ matrix.package }}
-        run: flutter test --coverage
+        run: |
+          if [ -d "test" ]; then
+            flutter test --coverage
+          else
+            echo "No test directory found, skipping tests."
+          fi
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v7

--- a/sdk/rust-core/build-ios.sh
+++ b/sdk/rust-core/build-ios.sh
@@ -64,6 +64,7 @@ sed -i '' 's/canImport(tracelet_syncFFI)/SWIFT_PACKAGE/g' "$OUT_DIR/sync/tracele
 sed -i '' 's/import tracelet_syncFFI/import TraceletSyncFFI\
 import TraceletSDK/g' "$OUT_DIR/sync/tracelet_sync.swift"
 
+mkdir -p "../../packages/tracelet_sync/ios/tracelet_sync/Sources/tracelet_sync"
 cp "$OUT_DIR/sync/tracelet_sync.swift" "../../packages/tracelet_sync/ios/tracelet_sync/Sources/tracelet_sync/"
 cp "$OUT_DIR/sync/tracelet_syncFFI.h" "../../packages/tracelet_sync/ios/tracelet_sync/Sources/tracelet_sync/"
 


### PR DESCRIPTION
- Add mkdir -p before copying UniFFI-generated Swift bindings in build-ios.sh, fixing "directory does not exist" error for tracelet_sync iOS artifacts.
- Skip flutter test step in CI for packages without a test/ directory (tracelet_sync, tracelet_firebase, tracelet_supabase).