### PR TITLE
fix(android)!: throw NOT_READY before ready() to match iOS

### DIFF
--- a/example/integration_test/readiness_guard_test.dart
+++ b/example/integration_test/readiness_guard_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:tracelet/tracelet.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // IMPORTANT: do NOT call Tracelet.ready() anywhere in this file.
+  // Every call below must hit the native NOT_READY guard, on both platforms.
+  group('Readiness guards (NOT_READY before ready())', () {
+    Future<void> expectNotReady(Future<void> Function() call) async {
+      try {
+        await call();
+        fail('Expected PlatformException(NOT_READY) but the call succeeded');
+      } on PlatformException catch (e) {
+        expect(e.code, 'NOT_READY', reason: 'wrong error code: ${e.code}');
+        expect(
+          e.message,
+          isNotNull,
+          reason: 'NOT_READY error should carry a message',
+        );
+      }
+    }
+
+    testWidgets('start', (_) => expectNotReady(Tracelet.start));
+    testWidgets('startGeofences', (_) => expectNotReady(Tracelet.startGeofences));
+    testWidgets('startPeriodic', (_) => expectNotReady(Tracelet.startPeriodic));
+    testWidgets('startSchedule', (_) => expectNotReady(Tracelet.startSchedule));
+    testWidgets('stopSchedule', (_) => expectNotReady(Tracelet.stopSchedule));
+    testWidgets('changePace', (_) => expectNotReady(() => Tracelet.changePace(true)));
+    testWidgets('reset', (_) => expectNotReady(Tracelet.reset));
+    testWidgets('getCurrentPosition', (_) => expectNotReady(Tracelet.getCurrentPosition));
+  });
+}

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -326,6 +326,10 @@ class TraceletHostApiImpl(
     }
 
     override fun start(callback: (Result<TlState>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before start()", null)))
+            return
+        }
         try {
             val err = sdk.start()
             if (err != null) callback(Result.failure(wrapException(err)))
@@ -341,6 +345,10 @@ class TraceletHostApiImpl(
     }
 
     override fun startGeofences(callback: (Result<TlState>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before startGeofences()", null)))
+            return
+        }
         try {
             val err = sdk.startGeofences()
             if (err != null) callback(Result.failure(wrapException(err)))
@@ -349,6 +357,10 @@ class TraceletHostApiImpl(
     }
 
     override fun startPeriodic(callback: (Result<TlState>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before startPeriodic()", null)))
+            return
+        }
         try {
             val err = sdk.startPeriodic()
             if (err != null) callback(Result.failure(wrapException(err)))
@@ -379,6 +391,10 @@ class TraceletHostApiImpl(
     }
 
     override fun reset(config: TlConfig?, callback: (Result<TlState>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before reset()", null)))
+            return
+        }
         try {
             sdk.reset(config?.let { tlConfigToSdkMap(it) })
             callback(Result.success(mapToTlState(sdk.getState())))
@@ -391,6 +407,10 @@ class TraceletHostApiImpl(
 
     @Suppress("UNCHECKED_CAST")
     override fun getCurrentPosition(options: TlCurrentPositionOptions, callback: (Result<TlLocation>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before getCurrentPosition()", null)))
+            return
+        }
         try {
             sdk.getCurrentPosition(tlOptionsToMap(options)) { loc ->
                 if (loc != null) callback(Result.success(mapToTlLocation(loc as Map<String, Any?>)))
@@ -423,6 +443,10 @@ class TraceletHostApiImpl(
     }
 
     override fun changePace(isMoving: Boolean, callback: (Result<Boolean>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before changePace()", null)))
+            return
+        }
         try {
             sdk.changePace(isMoving)
             callback(Result.success(true))
@@ -794,6 +818,10 @@ class TraceletHostApiImpl(
     // =========================================================================
 
     override fun startSchedule(callback: (Result<TlState>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before startSchedule()", null)))
+            return
+        }
         try {
             sdk.startSchedule()
             callback(Result.success(mapToTlState(sdk.getState())))
@@ -801,6 +829,10 @@ class TraceletHostApiImpl(
     }
 
     override fun stopSchedule(callback: (Result<TlState>) -> Unit) {
+        if (!sdk.isReady) {
+            callback(Result.failure(FlutterError("NOT_READY", "Call ready() before stopSchedule()", null)))
+            return
+        }
         try {
             sdk.stopSchedule()
             callback(Result.success(mapToTlState(sdk.getState())))

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImplReadinessTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImplReadinessTest.kt
@@ -1,0 +1,89 @@
+package com.ikolvi.tracelet.flutter
+
+import android.content.Context
+import com.ikolvi.tracelet.FlutterError
+import com.ikolvi.tracelet.TlCurrentPositionOptions
+import com.ikolvi.tracelet.TlLocation
+import com.ikolvi.tracelet.TlState
+import com.ikolvi.tracelet.flutter.service.HeadlessTaskService
+import com.ikolvi.tracelet.sdk.TraceletSdk
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the plugin-layer readiness guards: when the SDK is not yet
+ * initialized via ready(), each guarded method must fail the Pigeon callback
+ * with FlutterError("NOT_READY", "Call ready() before <method>()"), matching iOS.
+ */
+class TraceletHostApiImplReadinessTest {
+
+    private fun newHostApiNotReady(): TraceletHostApiImpl {
+        val context = mock(Context::class.java)
+        // TraceletSdk.getInstance() constructs with context.applicationContext;
+        // make the mock return itself so the (lazy-subsystem) construction works.
+        whenever(context.applicationContext).thenReturn(context)
+        // getInstance returns a process-global singleton; force not-ready so the
+        // guards fire deterministically regardless of any prior test state.
+        // isReady has a private setter, so write its backing field via reflection.
+        // The host API reads it via its own getInstance(context) → same singleton.
+        val sdk = TraceletSdk.getInstance(context)
+        TraceletSdk::class.java.getDeclaredField("isReady").apply {
+            isAccessible = true
+            setBoolean(sdk, false)
+        }
+        return TraceletHostApiImpl(context, mock(HeadlessTaskService::class.java))
+    }
+
+    private fun <T> capture(block: TraceletHostApiImpl.((Result<T>) -> Unit) -> Unit): Throwable? {
+        val api = newHostApiNotReady()
+        var result: Result<T>? = null
+        block(api) { result = it }
+        assertTrue(result!!.isFailure, "expected a failure Result")
+        return result!!.exceptionOrNull()
+    }
+
+    private fun assertNotReady(err: Throwable?, expectedMessage: String) {
+        assertTrue(err is FlutterError, "expected FlutterError, got ${err?.javaClass}")
+        err as FlutterError
+        assertEquals("NOT_READY", err.code)
+        assertEquals(expectedMessage, err.message)
+    }
+
+    @Test
+    fun start_notReady() =
+        assertNotReady(capture<TlState> { start(it) }, "Call ready() before start()")
+
+    @Test
+    fun startGeofences_notReady() =
+        assertNotReady(capture<TlState> { startGeofences(it) }, "Call ready() before startGeofences()")
+
+    @Test
+    fun startPeriodic_notReady() =
+        assertNotReady(capture<TlState> { startPeriodic(it) }, "Call ready() before startPeriodic()")
+
+    @Test
+    fun reset_notReady() =
+        assertNotReady(capture<TlState> { reset(null, it) }, "Call ready() before reset()")
+
+    @Test
+    fun startSchedule_notReady() =
+        assertNotReady(capture<TlState> { startSchedule(it) }, "Call ready() before startSchedule()")
+
+    @Test
+    fun stopSchedule_notReady() =
+        assertNotReady(capture<TlState> { stopSchedule(it) }, "Call ready() before stopSchedule()")
+
+    @Test
+    fun changePace_notReady() =
+        assertNotReady(capture<Boolean> { changePace(true, it) }, "Call ready() before changePace()")
+
+    @Test
+    fun getCurrentPosition_notReady() =
+        assertNotReady(
+            capture<TlLocation> { getCurrentPosition(mock(TlCurrentPositionOptions::class.java), it) },
+            "Call ready() before getCurrentPosition()",
+        )
+}


### PR DESCRIPTION
start/startGeofences/startPeriodic/reset/getCurrentPosition/changePace/ startSchedule/stopSchedule now fail the Pigeon callback with FlutterError("NOT_READY", "Call ready() before <method>()") when called before ready(), matching iOS exactly. Previously some of these silently no-opped on Android, masking misuse and (for setConfig-style flows) dropping configuration.

Guards live at the plugin boundary (TraceletHostApiImpl); the SDK's own internal isReady no-ops are left intact for direct native-SDK consumers.

Adds JVM unit tests (TraceletHostApiImplReadinessTest, 8/8) and a cross-platform integration test (readiness_guard_test.dart).

BREAKING CHANGE: call ready() before start, startGeofences, startPeriodic, reset, getCurrentPosition, changePace, startSchedule, or stopSchedule on Android; they now throw PlatformException(NOT_READY) instead of no-opping.