### PR TITLE
Feat/3.3.0 program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ website/app/es/
 website/app/ml/
 website/app/ta/
 website/app/ru/
+.supermemory/

--- a/example/integration_test/behavior_features_test.dart
+++ b/example/integration_test/behavior_features_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:tracelet/tracelet.dart';
+
+/// Integration tests for the 3.3.0 behavior features — driving telematics,
+/// transport-mode classifier, and crash/fall detection — exercised against the
+/// real native runtime (engines instantiated in TraceletSdk, fed by the
+/// location/accel pipeline).
+///
+/// The detection *logic* is covered by the Rust unit suite; these tests verify
+/// the native wiring loads, config flows end-to-end, the event streams are
+/// live, and — critically — that with the features OFF there is no behavior
+/// change (no driving/impact events, normal tracking).
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() async {
+    await Tracelet.stop();
+  });
+
+  group('config round-trips through the native runtime', () {
+    testWidgets('telematics/classifier/impact enable flows without error', (
+      tester,
+    ) async {
+      await Tracelet.ready(
+        const Config(
+          telematics: TelematicsConfig(
+            enableDrivingEvents: true,
+            speedLimitKmh: 50,
+          ),
+          classifier: ClassifierConfig(enableFusedClassifier: true),
+          impact: ImpactConfig(enableCrashDetection: true),
+        ),
+      );
+      final state = await Tracelet.getState();
+      expect(state, isA<State>());
+
+      // Reconfiguring at runtime via setConfig must also succeed.
+      await Tracelet.setConfig(
+        const Config(
+          telematics: TelematicsConfig(
+            enableDrivingEvents: true,
+            speedLimitKmh: 80,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('event streams are live', () {
+    testWidgets('subscribing to all three streams does not throw', (
+      tester,
+    ) async {
+      await Tracelet.ready(
+        const Config(
+          telematics: TelematicsConfig(enableDrivingEvents: true),
+          classifier: ClassifierConfig(enableFusedClassifier: true),
+          impact: ImpactConfig(enableCrashDetection: true),
+        ),
+      );
+      final subs = <StreamSubscription<dynamic>>[
+        Tracelet.drivingEventStream.listen((_) {}),
+        Tracelet.impactStream.listen((_) {}),
+        Tracelet.modeChangeStream.listen((_) {}),
+      ];
+      await Tracelet.start();
+      await tester.pump(const Duration(seconds: 2));
+      for (final s in subs) {
+        await s.cancel();
+      }
+      expect(true, isTrue);
+    });
+
+    testWidgets('cancelImpact is a safe no-op for an unknown id', (
+      tester,
+    ) async {
+      await Tracelet.ready(
+        const Config(impact: ImpactConfig(enableCrashDetection: true)),
+      );
+      final ok = await Tracelet.cancelImpact(999999);
+      expect(ok, isFalse);
+    });
+  });
+
+  group('no-regression: features OFF (defaults)', () {
+    testWidgets('default Config emits no driving/impact events', (
+      tester,
+    ) async {
+      var driving = 0;
+      var impact = 0;
+      final subs = <StreamSubscription<dynamic>>[
+        Tracelet.drivingEventStream.listen((_) => driving++),
+        Tracelet.impactStream.listen((_) => impact++),
+      ];
+
+      await Tracelet.ready(const Config());
+      await Tracelet.start();
+      await tester.pump(const Duration(seconds: 3));
+
+      for (final s in subs) {
+        await s.cancel();
+      }
+      expect(driving, 0, reason: 'no driving events when feature is off');
+      expect(impact, 0, reason: 'no impact events when feature is off');
+    });
+  });
+}

--- a/example/lib/behavior_page.dart
+++ b/example/lib/behavior_page.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' as tl;
+
+/// Demo page for the 3.3.0 behavior features: driving telematics, crash/fall
+/// detection, and the fused transport-mode classifier.
+///
+/// Kept on its own page so the (already large) dashboard/issues pages stay lean.
+/// Toggling a feature calls `Tracelet.setConfig` on the running instance and
+/// subscribes to the corresponding event stream.
+class BehaviorPage extends StatefulWidget {
+  const BehaviorPage({super.key});
+
+  @override
+  State<BehaviorPage> createState() => _BehaviorPageState();
+}
+
+class _BehaviorPageState extends State<BehaviorPage> {
+  bool _driving = false;
+  bool _crash = false;
+  bool _classifier = false;
+
+  final List<String> _log = [];
+  String _mode = 'unknown';
+  tl.ImpactEvent? _pendingImpact;
+
+  StreamSubscription<tl.DrivingEvent>? _drivingSub;
+  StreamSubscription<tl.ImpactEvent>? _impactSub;
+  StreamSubscription<tl.ModeChangeEvent>? _modeSub;
+
+  @override
+  void dispose() {
+    _drivingSub?.cancel();
+    _impactSub?.cancel();
+    _modeSub?.cancel();
+    super.dispose();
+  }
+
+  void _logLine(String s) {
+    setState(() {
+      _log.insert(0, '${TimeOfDay.now().format(context)}  $s');
+      if (_log.length > 40) _log.removeLast();
+    });
+  }
+
+  Future<void> _applyConfig() async {
+    await tl.Tracelet.setConfig(
+      tl.Config(
+        telematics: tl.TelematicsConfig(
+          enableDrivingEvents: _driving,
+          // A modest limit so speeding is demoable without a highway.
+          speedLimitKmh: _driving ? 30 : 0,
+        ),
+        classifier: tl.ClassifierConfig(enableFusedClassifier: _classifier),
+        impact: tl.ImpactConfig(enableCrashDetection: _crash),
+      ),
+    );
+  }
+
+  Future<void> _toggleDriving(bool v) async {
+    setState(() => _driving = v);
+    await _applyConfig();
+    if (v) {
+      _drivingSub ??= tl.Tracelet.drivingEventStream.listen((e) {
+        _logLine('🚗 ${e.kind}  sev=${e.severity.toStringAsFixed(2)}  '
+            'val=${e.value.toStringAsFixed(2)}');
+      });
+    } else {
+      _drivingSub?.cancel();
+      _drivingSub = null;
+    }
+  }
+
+  Future<void> _toggleCrash(bool v) async {
+    setState(() => _crash = v);
+    await _applyConfig();
+    if (v) {
+      _impactSub ??= tl.Tracelet.impactStream.listen((e) {
+        if (e.isPotential) {
+          setState(() => _pendingImpact = e);
+          _logLine('⚠️ ${e.kind}  peak=${e.peakG.toStringAsFixed(1)}g  '
+              '(cancel within window)');
+        } else {
+          setState(() => _pendingImpact = null);
+          _logLine('🆘 CONFIRMED ${e.kind}  peak=${e.peakG.toStringAsFixed(1)}g');
+        }
+      });
+    } else {
+      _impactSub?.cancel();
+      _impactSub = null;
+      setState(() => _pendingImpact = null);
+    }
+  }
+
+  Future<void> _toggleClassifier(bool v) async {
+    setState(() => _classifier = v);
+    await _applyConfig();
+    if (v) {
+      _modeSub ??= tl.Tracelet.modeChangeStream.listen((e) {
+        setState(() => _mode = e.mode);
+        _logLine('🚶 mode → ${e.mode}  (${e.confidence.toStringAsFixed(2)})');
+      });
+    } else {
+      _modeSub?.cancel();
+      _modeSub = null;
+    }
+  }
+
+  Future<void> _cancelImpact() async {
+    final e = _pendingImpact;
+    if (e == null) return;
+    await tl.Tracelet.cancelImpact(e.id);
+    setState(() => _pendingImpact = null);
+    _logLine('✋ cancelled impact #${e.id}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Driving & Safety (3.3.0)')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'Opt-in behavior engines. Enable, then start tracking and move or '
+            'drive. All default OFF — they never run unless switched on here.',
+          ),
+          const SizedBox(height: 12),
+          SwitchListTile(
+            title: const Text('Driving events'),
+            subtitle: const Text(
+              'harsh braking / acceleration / cornering / speeding (limit 30 km/h)',
+            ),
+            value: _driving,
+            onChanged: _toggleDriving,
+          ),
+          SwitchListTile(
+            title: const Text('Crash detection'),
+            subtitle: const Text('high-g impact while moving → cancel countdown'),
+            value: _crash,
+            onChanged: _toggleCrash,
+          ),
+          SwitchListTile(
+            title: const Text('Transport-mode classifier'),
+            subtitle: Text('fused accel + GPS — current mode: $_mode'),
+            value: _classifier,
+            onChanged: _toggleClassifier,
+          ),
+          if (_pendingImpact != null)
+            Card(
+              color: Colors.red.shade100,
+              child: ListTile(
+                leading: const Icon(Icons.warning, color: Colors.red),
+                title: Text('Possible ${_pendingImpact!.kind}'),
+                subtitle: Text(
+                  'peak ${_pendingImpact!.peakG.toStringAsFixed(1)}g — '
+                  'auto-confirms unless cancelled',
+                ),
+                trailing: FilledButton(
+                  onPressed: _cancelImpact,
+                  child: const Text("I'm fine"),
+                ),
+              ),
+            ),
+          const Divider(height: 32),
+          const Text('Event log', style: TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          if (_log.isEmpty) const Text('— no events yet —'),
+          ..._log.map(
+            (l) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text(l, style: const TextStyle(fontFamily: 'monospace')),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' as tl;
 import 'package:tracelet_doctor/tracelet_doctor.dart';
+import 'package:tracelet_example/behavior_page.dart';
 import 'package:tracelet_example/map_page.dart';
 import 'package:tracelet_example/issues_page.dart';
 import 'package:tracelet_example/scanner_page.dart';
@@ -3900,6 +3901,33 @@ class _DashboardPageState extends State<DashboardPage>
                     icon: const Icon(Icons.bug_report),
                     label: const Text(
                       'Issues Test',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                // ── Driving & Safety (3.3.0) Button ──
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: FilledButton.icon(
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Colors.deepPurple,
+                      foregroundColor: Colors.white,
+                      minimumSize: const Size.fromHeight(50),
+                    ),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute<void>(
+                          builder: (_) => const BehaviorPage(),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.drive_eta),
+                    label: const Text(
+                      'Driving & Safety',
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,

--- a/help/DRIVING-AND-SAFETY.md
+++ b/help/DRIVING-AND-SAFETY.md
@@ -1,0 +1,126 @@
+# Driving & Safety (Telematics, Transport Mode, Crash/Fall)
+
+> Added in **3.3.0**. All three features are **opt-in and default-off** — they
+> never run, allocate, or affect tracking unless you explicitly enable them.
+
+Tracelet 3.3.0 adds three on-device behavior engines that turn the location +
+accelerometer stream into higher-level signals:
+
+| Feature | Config | Events |
+|---|---|---|
+| Driving-behavior (telematics) | `TelematicsConfig` | `Tracelet.onDrivingEvent` |
+| Transport-mode classifier | `ClassifierConfig` | `Tracelet.onModeChange` |
+| Crash / fall detection | `ImpactConfig` | `Tracelet.onImpact` |
+
+All detection runs **on device** in the Rust core (no cloud, deterministic).
+Thresholds are expressed in **g** (1 g ≈ 9.81 m/s²) and are fully tunable.
+
+---
+
+## 1. Driving-behavior events (telematics)
+
+GPS-derived detection of `harsh_braking`, `harsh_acceleration`,
+`harsh_cornering`, and `speeding` — no extra sensors required.
+
+```dart
+await Tracelet.ready(Config(
+  telematics: TelematicsConfig(
+    enableDrivingEvents: true,
+    harshBrakingG: 0.40,        // deceleration threshold (g)
+    harshAccelerationG: 0.35,
+    harshCorneringG: 0.40,
+    speedLimitKmh: 50,          // 0 disables speeding
+    speedingToleranceKmh: 5,
+    speedingMinDurationMs: 3000,
+  ),
+));
+
+Tracelet.onDrivingEvent((e) {
+  print('${e.kind}  severity=${e.severity}  value=${e.value}');
+  // e.kind: harsh_braking | harsh_acceleration | harsh_cornering | speeding
+  // e.value: g for harsh events, km/h-over-limit for speeding
+});
+```
+
+GPS speed is ~1 Hz and noisy, so the engine favors **specificity over
+sensitivity** (high thresholds, gap rejection, one-event-per-maneuver debounce).
+Each event carries a normalized `severity` (0–1). A rolling driving score is
+maintained internally per tracking session.
+
+## 2. Transport-mode classifier
+
+Fuses accelerometer features (variance, cadence) with GPS speed to classify
+`still` / `walking` / `running` / `cycling` / `vehicle`, with hysteresis so a
+mode must persist before it commits.
+
+```dart
+await Tracelet.ready(Config(
+  classifier: ClassifierConfig(
+    enableFusedClassifier: true,
+    fusedClassifierAuthoritative: false, // annotate, don't override platform
+    modeSwitchDwellMs: 8000,
+    minModeConfidence: 0.6,
+  ),
+));
+
+Tracelet.onModeChange((e) => print('mode: ${e.mode} (${e.confidence})'));
+```
+
+By default the classifier **annotates** — the platform Activity-Recognition
+value stays authoritative. Set `fusedClassifierAuthoritative: true` to let the
+fused mode drive sampling decisions.
+
+## 3. Crash & fall detection
+
+Safety-critical, so detection is **corroborated** (a high-g spike alone is never
+a crash) and uses a **cancel-countdown** confirmation flow.
+
+```dart
+await Tracelet.ready(Config(
+  impact: ImpactConfig(
+    enableCrashDetection: true,
+    enableFallDetection: false,  // best-effort; default off
+    crashGThreshold: 3.0,        // impact magnitude (g)
+    crashMinSpeedKmh: 25,        // must have been moving
+    confirmWindowMs: 15000,      // countdown before auto-confirm
+  ),
+));
+
+Tracelet.onImpact((e) {
+  if (e.isPotential) {
+    // Show a countdown UI; if the user is fine, cancel it:
+    // await Tracelet.cancelImpact(e.id);
+    // To escalate immediately:
+    // await Tracelet.confirmImpact(e.id);
+  } else {
+    // e.kind == 'crash' (or 'fall') — confirmed emergency
+  }
+});
+```
+
+- A **crash** requires an impact above `crashGThreshold` **while moving** above
+  `crashMinSpeedKmh`.
+- A `potential_crash`/`potential_fall` fires first with a `confirmDeadline`;
+  if not cancelled within `confirmWindowMs`, the confirmed `crash`/`fall` fires.
+- Tracelet provides the **trigger + cancel window** — it never places emergency
+  calls. That's the host app's responsibility.
+
+---
+
+## Permissions
+
+- **Driving events** need only the location permission you already grant for
+  tracking — **no new permission**.
+- **Classifier** and **crash/fall** use the accelerometer. On Android the
+  accelerometer is already used by motion detection (no extra permission); on
+  iOS, Motion & Fitness (`NSMotionUsageDescription`) improves fidelity. See
+  [PERMISSIONS.md](PERMISSIONS.md).
+
+## Guarantees
+
+- **Default-off:** with the three config blocks at their defaults, no engine is
+  instantiated and behavior is byte-for-byte identical to 3.2.x.
+- **Side-channel:** these events never alter the location pipeline, odometer, or
+  `onLocation` payload.
+- **Cross-platform:** identical engines (shared Rust core) on Android and iOS;
+  driving events also work on Web (GPS-derived).

--- a/packages/tracelet/CHANGELOG.md
+++ b/packages/tracelet/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet/lib/src/models/config.dart
+++ b/packages/tracelet/lib/src/models/config.dart
@@ -5,6 +5,7 @@ import 'package:tracelet/src/models/_helpers.dart';
 import 'package:tracelet/src/models/android_config.dart';
 import 'package:tracelet/src/models/attestation_config.dart';
 import 'package:tracelet/src/models/audit_config.dart';
+import 'package:tracelet/src/models/driving_config.dart';
 import 'package:tracelet/src/models/ios_config.dart';
 import 'package:tracelet/src/models/privacy_zone_config.dart';
 import 'package:tracelet/src/models/security_config.dart';
@@ -59,6 +60,9 @@ class Config {
     this.privacyZone = const PrivacyZoneConfig(),
     this.security = const SecurityConfig(),
     this.attestation = const AttestationConfig(),
+    this.telematics = const TelematicsConfig(),
+    this.classifier = const ClassifierConfig(),
+    this.impact = const ImpactConfig(),
   });
 
   /// High Accuracy profile tailored for turn-by-turn navigation or precise tracking.
@@ -100,6 +104,13 @@ class Config {
       privacyZone: PrivacyZoneConfig.fromMap(privacyMap ?? map),
       security: SecurityConfig.fromMap(securityMap ?? map),
       attestation: AttestationConfig.fromMap(attestMap ?? map),
+      telematics: TelematicsConfig.fromMap(
+        safeMap(map['telematics']) ?? map,
+      ),
+      classifier: ClassifierConfig.fromMap(
+        safeMap(map['classifier']) ?? map,
+      ),
+      impact: ImpactConfig.fromMap(safeMap(map['impact']) ?? map),
     );
   }
 
@@ -142,6 +153,15 @@ class Config {
   /// **Enterprise** — Device integrity attestation.
   final AttestationConfig attestation;
 
+  /// Driving-behavior (telematics) event detection.
+  final TelematicsConfig telematics;
+
+  /// On-device transport-mode classifier.
+  final ClassifierConfig classifier;
+
+  /// Crash & fall detection.
+  final ImpactConfig impact;
+
   /// Creates a copy of this [Config] with the given fields replaced with the new values.
   Config copyWith({
     GeoConfig? geo,
@@ -157,6 +177,9 @@ class Config {
     PrivacyZoneConfig? privacyZone,
     SecurityConfig? security,
     AttestationConfig? attestation,
+    TelematicsConfig? telematics,
+    ClassifierConfig? classifier,
+    ImpactConfig? impact,
   }) {
     return Config(
       geo: geo ?? this.geo,
@@ -172,6 +195,9 @@ class Config {
       privacyZone: privacyZone ?? this.privacyZone,
       security: security ?? this.security,
       attestation: attestation ?? this.attestation,
+      telematics: telematics ?? this.telematics,
+      classifier: classifier ?? this.classifier,
+      impact: impact ?? this.impact,
     );
   }
 
@@ -206,6 +232,9 @@ class Config {
     privacyZone: privacyZone.toTlConfig(),
     security: security.toTlConfig(),
     attestation: attestation.toTlConfig(),
+    telematics: telematics.toTlConfig(),
+    classifier: classifier.toTlConfig(),
+    impact: impact.toTlConfig(),
   );
 
   /// Serializes to a nested map suitable for platform channel transmission.
@@ -224,6 +253,9 @@ class Config {
       'privacyZone': privacyZone.toMap(),
       'security': security.toMap(),
       'attestation': attestation.toMap(),
+      'telematics': telematics.toMap(),
+      'classifier': classifier.toMap(),
+      'impact': impact.toMap(),
     };
   }
 
@@ -232,7 +264,8 @@ class Config {
       'Config(geo: $geo, app: $app, android: $android, ios: $ios, http: $http, '
       'logger: $logger, motion: $motion, geofence: $geofence, '
       'persistence: $persistence, audit: $audit, privacyZone: $privacyZone, '
-      'security: $security, attestation: $attestation)';
+      'security: $security, attestation: $attestation, '
+      'telematics: $telematics, classifier: $classifier, impact: $impact)';
 
   @override
   bool operator ==(Object other) =>
@@ -251,7 +284,10 @@ class Config {
           audit == other.audit &&
           privacyZone == other.privacyZone &&
           security == other.security &&
-          attestation == other.attestation;
+          attestation == other.attestation &&
+          telematics == other.telematics &&
+          classifier == other.classifier &&
+          impact == other.impact;
 
   @override
   int get hashCode => Object.hashAll([
@@ -268,6 +304,9 @@ class Config {
     privacyZone,
     security,
     attestation,
+    telematics,
+    classifier,
+    impact,
   ]);
 }
 

--- a/packages/tracelet/lib/src/models/driving_config.dart
+++ b/packages/tracelet/lib/src/models/driving_config.dart
@@ -1,0 +1,345 @@
+import 'package:meta/meta.dart';
+import 'package:tracelet/src/models/_helpers.dart';
+import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
+
+// ---------------------------------------------------------------------------
+// TelematicsConfig (driving-behavior events)
+// ---------------------------------------------------------------------------
+
+/// Driving-behavior (telematics) event detection.
+///
+/// When [enableDrivingEvents] is `true`, Tracelet scores the location stream
+/// into `harsh_braking`, `harsh_acceleration`, `harsh_cornering`, and
+/// `speeding` events (delivered via `Tracelet.onDrivingEvent`) plus a per-trip
+/// driving score. Thresholds are in **g** (1 g ≈ 9.81 m/s²) and follow common
+/// usage-based-insurance practice; all are tunable.
+///
+/// Default: **disabled** — zero behavior change when off.
+@immutable
+class TelematicsConfig {
+  /// Creates a new [TelematicsConfig].
+  const TelematicsConfig({
+    this.enableDrivingEvents = false,
+    this.harshBrakingG = 0.40,
+    this.harshAccelerationG = 0.35,
+    this.harshCorneringG = 0.40,
+    this.speedLimitKmh = 0.0,
+    this.speedingToleranceKmh = 5.0,
+    this.speedingMinDurationMs = 3000,
+    this.minSpeedForEventsKmh = 5.0,
+    this.eventDebounceMs = 2000,
+  });
+
+  /// Creates a [TelematicsConfig] from a map.
+  factory TelematicsConfig.fromMap(Map<String, Object?> map) {
+    return TelematicsConfig(
+      enableDrivingEvents: ensureBool(
+        map['enableDrivingEvents'],
+        fallback: false,
+      ),
+      harshBrakingG: ensureDouble(map['harshBrakingG'], fallback: 0.40),
+      harshAccelerationG: ensureDouble(
+        map['harshAccelerationG'],
+        fallback: 0.35,
+      ),
+      harshCorneringG: ensureDouble(map['harshCorneringG'], fallback: 0.40),
+      speedLimitKmh: ensureDouble(map['speedLimitKmh'], fallback: 0),
+      speedingToleranceKmh: ensureDouble(
+        map['speedingToleranceKmh'],
+        fallback: 5,
+      ),
+      speedingMinDurationMs: ensureInt(
+        map['speedingMinDurationMs'],
+        fallback: 3000,
+      ),
+      minSpeedForEventsKmh: ensureDouble(
+        map['minSpeedForEventsKmh'],
+        fallback: 5,
+      ),
+      eventDebounceMs: ensureInt(map['eventDebounceMs'], fallback: 2000),
+    );
+  }
+
+  /// Master switch. When `false` the telematics engine is never created.
+  final bool enableDrivingEvents;
+
+  /// Deceleration (g) above which `harsh_braking` fires. Default `0.40`.
+  final double harshBrakingG;
+
+  /// Acceleration (g) above which `harsh_acceleration` fires. Default `0.35`.
+  final double harshAccelerationG;
+
+  /// Lateral acceleration (g) above which `harsh_cornering` fires. Default `0.40`.
+  final double harshCorneringG;
+
+  /// Global speed limit (km/h); `0` disables threshold-based speeding. Default `0`.
+  final double speedLimitKmh;
+
+  /// Grace over the limit (km/h) before speeding counts. Default `5`.
+  final double speedingToleranceKmh;
+
+  /// Sustained time over the limit (ms) before `speeding` fires. Default `3000`.
+  final int speedingMinDurationMs;
+
+  /// Suppress brake/accel/corner events below this speed (km/h). Default `5`.
+  final double minSpeedForEventsKmh;
+
+  /// Minimum time between same-kind events (ms). Default `2000`.
+  final int eventDebounceMs;
+
+  /// Serializes to a map.
+  Map<String, Object?> toMap() => <String, Object?>{
+    'enableDrivingEvents': enableDrivingEvents,
+    'harshBrakingG': harshBrakingG,
+    'harshAccelerationG': harshAccelerationG,
+    'harshCorneringG': harshCorneringG,
+    'speedLimitKmh': speedLimitKmh,
+    'speedingToleranceKmh': speedingToleranceKmh,
+    'speedingMinDurationMs': speedingMinDurationMs,
+    'minSpeedForEventsKmh': minSpeedForEventsKmh,
+    'eventDebounceMs': eventDebounceMs,
+  };
+
+  /// Converts to Pigeon [TlTelematicsConfig].
+  TlTelematicsConfig toTlConfig() => TlTelematicsConfig(
+    enableDrivingEvents: enableDrivingEvents,
+    harshBrakingG: harshBrakingG,
+    harshAccelerationG: harshAccelerationG,
+    harshCorneringG: harshCorneringG,
+    speedLimitKmh: speedLimitKmh,
+    speedingToleranceKmh: speedingToleranceKmh,
+    speedingMinDurationMs: speedingMinDurationMs,
+    minSpeedForEventsKmh: minSpeedForEventsKmh,
+    eventDebounceMs: eventDebounceMs,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TelematicsConfig &&
+          runtimeType == other.runtimeType &&
+          enableDrivingEvents == other.enableDrivingEvents &&
+          harshBrakingG == other.harshBrakingG &&
+          harshAccelerationG == other.harshAccelerationG &&
+          harshCorneringG == other.harshCorneringG &&
+          speedLimitKmh == other.speedLimitKmh &&
+          speedingToleranceKmh == other.speedingToleranceKmh &&
+          speedingMinDurationMs == other.speedingMinDurationMs &&
+          minSpeedForEventsKmh == other.minSpeedForEventsKmh &&
+          eventDebounceMs == other.eventDebounceMs;
+
+  @override
+  int get hashCode => Object.hash(
+    enableDrivingEvents,
+    harshBrakingG,
+    harshAccelerationG,
+    harshCorneringG,
+    speedLimitKmh,
+    speedingToleranceKmh,
+    speedingMinDurationMs,
+    minSpeedForEventsKmh,
+    eventDebounceMs,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ClassifierConfig (on-device transport-mode classifier)
+// ---------------------------------------------------------------------------
+
+/// On-device transport-mode classifier (fused accelerometer + GPS speed).
+///
+/// When [enableFusedClassifier] is `true`, Tracelet emits a fused travel mode
+/// (`still`/`walking`/`running`/`cycling`/`vehicle`) with confidence via
+/// `Tracelet.onModeChange`. By default it **annotates** (the platform Activity
+/// Recognition value stays authoritative) unless [fusedClassifierAuthoritative].
+///
+/// Default: **disabled**.
+@immutable
+class ClassifierConfig {
+  /// Creates a new [ClassifierConfig].
+  const ClassifierConfig({
+    this.enableFusedClassifier = false,
+    this.fusedClassifierAuthoritative = false,
+    this.modeSwitchDwellMs = 8000,
+    this.minModeConfidence = 0.6,
+  });
+
+  /// Creates a [ClassifierConfig] from a map.
+  factory ClassifierConfig.fromMap(Map<String, Object?> map) {
+    return ClassifierConfig(
+      enableFusedClassifier: ensureBool(
+        map['enableFusedClassifier'],
+        fallback: false,
+      ),
+      fusedClassifierAuthoritative: ensureBool(
+        map['fusedClassifierAuthoritative'],
+        fallback: false,
+      ),
+      modeSwitchDwellMs: ensureInt(map['modeSwitchDwellMs'], fallback: 8000),
+      minModeConfidence: ensureDouble(map['minModeConfidence'], fallback: 0.6),
+    );
+  }
+
+  /// Master switch. When `false` the classifier and accel feed never start.
+  final bool enableFusedClassifier;
+
+  /// If `true`, the fused mode overrides the platform activity for sampling.
+  final bool fusedClassifierAuthoritative;
+
+  /// Dwell (ms) a candidate mode must persist before committing. Default `8000`.
+  final int modeSwitchDwellMs;
+
+  /// Below this confidence the mode is reported as `unknown`. Default `0.6`.
+  final double minModeConfidence;
+
+  /// Serializes to a map.
+  Map<String, Object?> toMap() => <String, Object?>{
+    'enableFusedClassifier': enableFusedClassifier,
+    'fusedClassifierAuthoritative': fusedClassifierAuthoritative,
+    'modeSwitchDwellMs': modeSwitchDwellMs,
+    'minModeConfidence': minModeConfidence,
+  };
+
+  /// Converts to Pigeon [TlClassifierConfig].
+  TlClassifierConfig toTlConfig() => TlClassifierConfig(
+    enableFusedClassifier: enableFusedClassifier,
+    fusedClassifierAuthoritative: fusedClassifierAuthoritative,
+    modeSwitchDwellMs: modeSwitchDwellMs,
+    minModeConfidence: minModeConfidence,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ClassifierConfig &&
+          runtimeType == other.runtimeType &&
+          enableFusedClassifier == other.enableFusedClassifier &&
+          fusedClassifierAuthoritative == other.fusedClassifierAuthoritative &&
+          modeSwitchDwellMs == other.modeSwitchDwellMs &&
+          minModeConfidence == other.minModeConfidence;
+
+  @override
+  int get hashCode => Object.hash(
+    enableFusedClassifier,
+    fusedClassifierAuthoritative,
+    modeSwitchDwellMs,
+    minModeConfidence,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ImpactConfig (crash & fall detection)
+// ---------------------------------------------------------------------------
+
+/// Crash & fall detection.
+///
+/// When [enableCrashDetection] is `true`, a corroborated high-g impact while
+/// moving raises a `potential_crash` (with a [confirmWindowMs] cancel
+/// countdown) that auto-confirms to `crash` unless cancelled — delivered via
+/// `Tracelet.onImpact`. [enableFallDetection] adds best-effort personal-fall
+/// detection (more false positives; default off).
+///
+/// Default: **disabled**. Tracelet provides the trigger + cancel window; it
+/// never places emergency calls.
+@immutable
+class ImpactConfig {
+  /// Creates a new [ImpactConfig].
+  const ImpactConfig({
+    this.enableCrashDetection = false,
+    this.enableFallDetection = false,
+    this.crashGThreshold = 3.0,
+    this.crashMinSpeedKmh = 25.0,
+    this.fallGThreshold = 2.5,
+    this.confirmWindowMs = 15000,
+    this.minImpactConfidence = 0.6,
+  });
+
+  /// Creates an [ImpactConfig] from a map.
+  factory ImpactConfig.fromMap(Map<String, Object?> map) {
+    return ImpactConfig(
+      enableCrashDetection: ensureBool(
+        map['enableCrashDetection'],
+        fallback: false,
+      ),
+      enableFallDetection: ensureBool(
+        map['enableFallDetection'],
+        fallback: false,
+      ),
+      crashGThreshold: ensureDouble(map['crashGThreshold'], fallback: 3),
+      crashMinSpeedKmh: ensureDouble(map['crashMinSpeedKmh'], fallback: 25),
+      fallGThreshold: ensureDouble(map['fallGThreshold'], fallback: 2.5),
+      confirmWindowMs: ensureInt(map['confirmWindowMs'], fallback: 15000),
+      minImpactConfidence: ensureDouble(
+        map['minImpactConfidence'],
+        fallback: 0.6,
+      ),
+    );
+  }
+
+  /// Master switch for vehicle crash detection.
+  final bool enableCrashDetection;
+
+  /// Personal fall detection (best-effort; default `false`).
+  final bool enableFallDetection;
+
+  /// Impact magnitude (g) for a crash candidate. Default `3.0`.
+  final double crashGThreshold;
+
+  /// Pre-impact speed (km/h) required to corroborate a crash. Default `25`.
+  final double crashMinSpeedKmh;
+
+  /// Impact magnitude (g) for a fall candidate. Default `2.5`.
+  final double fallGThreshold;
+
+  /// Countdown (ms) before a candidate auto-confirms. Default `15000`.
+  final int confirmWindowMs;
+
+  /// Suppress candidates below this confidence. Default `0.6`.
+  final double minImpactConfidence;
+
+  /// Serializes to a map.
+  Map<String, Object?> toMap() => <String, Object?>{
+    'enableCrashDetection': enableCrashDetection,
+    'enableFallDetection': enableFallDetection,
+    'crashGThreshold': crashGThreshold,
+    'crashMinSpeedKmh': crashMinSpeedKmh,
+    'fallGThreshold': fallGThreshold,
+    'confirmWindowMs': confirmWindowMs,
+    'minImpactConfidence': minImpactConfidence,
+  };
+
+  /// Converts to Pigeon [TlImpactConfig].
+  TlImpactConfig toTlConfig() => TlImpactConfig(
+    enableCrashDetection: enableCrashDetection,
+    enableFallDetection: enableFallDetection,
+    crashGThreshold: crashGThreshold,
+    crashMinSpeedKmh: crashMinSpeedKmh,
+    fallGThreshold: fallGThreshold,
+    confirmWindowMs: confirmWindowMs,
+    minImpactConfidence: minImpactConfidence,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImpactConfig &&
+          runtimeType == other.runtimeType &&
+          enableCrashDetection == other.enableCrashDetection &&
+          enableFallDetection == other.enableFallDetection &&
+          crashGThreshold == other.crashGThreshold &&
+          crashMinSpeedKmh == other.crashMinSpeedKmh &&
+          fallGThreshold == other.fallGThreshold &&
+          confirmWindowMs == other.confirmWindowMs &&
+          minImpactConfidence == other.minImpactConfidence;
+
+  @override
+  int get hashCode => Object.hash(
+    enableCrashDetection,
+    enableFallDetection,
+    crashGThreshold,
+    crashMinSpeedKmh,
+    fallGThreshold,
+    confirmWindowMs,
+    minImpactConfidence,
+  );
+}

--- a/packages/tracelet/lib/src/models/driving_event.dart
+++ b/packages/tracelet/lib/src/models/driving_event.dart
@@ -1,0 +1,151 @@
+import 'package:meta/meta.dart';
+import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
+
+/// A driving-behavior event emitted by the telematics engine.
+///
+/// One of [kind]: `harsh_braking`, `harsh_acceleration`, `harsh_cornering`,
+/// or `speeding`. Delivered via `Tracelet.onDrivingEvent`.
+@immutable
+class DrivingEvent {
+  /// Creates a new [DrivingEvent].
+  const DrivingEvent({
+    required this.kind,
+    required this.severity,
+    required this.speed,
+    required this.value,
+    required this.latitude,
+    required this.longitude,
+    required this.timestamp,
+  });
+
+  /// Creates a [DrivingEvent] from the Pigeon [TlDrivingEvent].
+  factory DrivingEvent.fromTl(TlDrivingEvent e) => DrivingEvent(
+    kind: e.kind,
+    severity: e.severity,
+    speed: e.speed,
+    value: e.value,
+    latitude: e.latitude,
+    longitude: e.longitude,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(e.timestampMs),
+  );
+
+  /// Event kind: `harsh_braking` | `harsh_acceleration` | `harsh_cornering` | `speeding`.
+  final String kind;
+
+  /// Normalized 0–1 severity (how far past the threshold).
+  final double severity;
+
+  /// Speed at the event (m/s).
+  final double speed;
+
+  /// Measured magnitude: g for harsh events, km/h over the limit for speeding.
+  final double value;
+
+  /// Latitude at the event.
+  final double latitude;
+
+  /// Longitude at the event.
+  final double longitude;
+
+  /// When the event occurred.
+  final DateTime timestamp;
+
+  @override
+  String toString() =>
+      'DrivingEvent($kind, severity: ${severity.toStringAsFixed(2)}, '
+      'value: ${value.toStringAsFixed(2)})';
+}
+
+/// A crash/fall impact event emitted by the impact detector.
+///
+/// [kind] is one of `potential_crash`, `crash`, `potential_fall`, `fall`. A
+/// `potential_*` event carries a [confirmDeadline]; if the host does not call
+/// `Tracelet.cancelImpact([id])` before then, the confirmed `crash`/`fall`
+/// event fires. Delivered via `Tracelet.onImpact`.
+@immutable
+class ImpactEvent {
+  /// Creates a new [ImpactEvent].
+  const ImpactEvent({
+    required this.kind,
+    required this.id,
+    required this.confidence,
+    required this.peakG,
+    required this.speedBefore,
+    required this.latitude,
+    required this.longitude,
+    required this.timestamp,
+    required this.confirmDeadline,
+  });
+
+  /// Creates an [ImpactEvent] from the Pigeon [TlImpactEvent].
+  factory ImpactEvent.fromTl(TlImpactEvent e) => ImpactEvent(
+    kind: e.kind,
+    id: e.id,
+    confidence: e.confidence,
+    peakG: e.peakG,
+    speedBefore: e.speedBefore,
+    latitude: e.latitude,
+    longitude: e.longitude,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(e.timestampMs),
+    confirmDeadline: DateTime.fromMillisecondsSinceEpoch(e.confirmDeadlineMs),
+  );
+
+  /// `potential_crash` | `crash` | `potential_fall` | `fall`.
+  final String kind;
+
+  /// Candidate id — pass to `cancelImpact`/`confirmImpact`.
+  final int id;
+
+  /// 0–1 detection confidence.
+  final double confidence;
+
+  /// Peak impact magnitude (g).
+  final double peakG;
+
+  /// Speed before impact (m/s).
+  final double speedBefore;
+
+  /// Latitude at impact.
+  final double latitude;
+
+  /// Longitude at impact.
+  final double longitude;
+
+  /// When the impact occurred.
+  final DateTime timestamp;
+
+  /// For `potential_*`: when it auto-confirms unless cancelled.
+  final DateTime confirmDeadline;
+
+  /// Whether this is a not-yet-confirmed candidate (`potential_*`).
+  bool get isPotential => kind.startsWith('potential_');
+
+  @override
+  String toString() =>
+      'ImpactEvent($kind, id: $id, peakG: ${peakG.toStringAsFixed(1)}, '
+      'confidence: ${confidence.toStringAsFixed(2)})';
+}
+
+/// A fused transport-mode change emitted by the on-device classifier.
+///
+/// Delivered via `Tracelet.onModeChange`. [mode] is one of `still`, `walking`,
+/// `running`, `cycling`, `vehicle`, or `unknown`.
+@immutable
+class ModeChangeEvent {
+  /// Creates a new [ModeChangeEvent].
+  const ModeChangeEvent({required this.mode, required this.confidence});
+
+  /// Creates a [ModeChangeEvent] from the Pigeon [TlModeChangeEvent].
+  factory ModeChangeEvent.fromTl(TlModeChangeEvent e) =>
+      ModeChangeEvent(mode: e.mode, confidence: e.confidence);
+
+  /// `still` | `walking` | `running` | `cycling` | `vehicle` | `unknown`.
+  final String mode;
+
+  /// 0–1 confidence of the classification.
+  final double confidence;
+
+  @override
+  String toString() =>
+      'ModeChangeEvent($mode, confidence: ${confidence.toStringAsFixed(2)})';
+}

--- a/packages/tracelet/lib/src/tracelet.dart
+++ b/packages/tracelet/lib/src/tracelet.dart
@@ -10,6 +10,7 @@ import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet/src/models/activity_change_event.dart';
 import 'package:tracelet/src/models/attestation_config.dart';
 import 'package:tracelet/src/models/audit_config.dart';
+import 'package:tracelet/src/models/driving_event.dart';
 import 'package:tracelet/src/models/audit_proof.dart';
 import 'package:tracelet/src/models/authorization_event.dart';
 import 'package:tracelet/src/models/compliance_report.dart';
@@ -121,6 +122,9 @@ class Tracelet {
   static Stream<HttpEvent>? _httpStream;
   static Stream<State>? _scheduleStream;
   static Stream<ConnectivityChangeEvent>? _connectivityChangeStream;
+  static Stream<DrivingEvent>? _drivingEventStream;
+  static Stream<ImpactEvent>? _impactStream;
+  static Stream<ModeChangeEvent>? _modeChangeStream;
 
   /// Whether the Kalman filter is currently enabled for GPS smoothing.
   ///
@@ -556,6 +560,19 @@ class Tracelet {
   /// updates). `isMoving: false` forces stationary mode.
   static Future<bool> changePace(bool isMoving) {
     return _platform.changePace(isMoving);
+  }
+
+  /// Confirms a pending impact candidate ([ImpactEvent.id]) as a real
+  /// emergency, firing its confirmed `crash`/`fall` event immediately.
+  static Future<bool> confirmImpact(int id) {
+    return _platform.confirmImpact(id);
+  }
+
+  /// Cancels a pending impact candidate ([ImpactEvent.id]) within its
+  /// confirmation window — no confirmed event will fire. Call this when the
+  /// user dismisses the crash/fall countdown ("I'm fine").
+  static Future<bool> cancelImpact(int id) {
+    return _platform.cancelImpact(id);
   }
 
   /// Get the current odometer value in meters.
@@ -1906,6 +1923,33 @@ class Tracelet {
     );
   }
 
+  /// A broadcast stream of driving-behavior (telematics) events.
+  ///
+  /// Fires for `harsh_braking`, `harsh_acceleration`, `harsh_cornering`, and
+  /// `speeding` when `TelematicsConfig.enableDrivingEvents` is set.
+  static Stream<DrivingEvent> get drivingEventStream {
+    return _drivingEventStream ??= _platform.drivingEvents.map(
+      DrivingEvent.fromTl,
+    );
+  }
+
+  /// A broadcast stream of crash/fall impact events.
+  ///
+  /// Fires `potential_crash`/`crash` (and `potential_fall`/`fall` when enabled)
+  /// when `ImpactConfig.enableCrashDetection` is set.
+  static Stream<ImpactEvent> get impactStream {
+    return _impactStream ??= _platform.impactEvents.map(ImpactEvent.fromTl);
+  }
+
+  /// A broadcast stream of fused transport-mode changes.
+  ///
+  /// Fires when `ClassifierConfig.enableFusedClassifier` is set.
+  static Stream<ModeChangeEvent> get modeChangeStream {
+    return _modeChangeStream ??= _platform.modeChangeEvents.map(
+      ModeChangeEvent.fromTl,
+    );
+  }
+
   /// A broadcast stream of schedule events.
   ///
   /// Fires when the scheduler starts or stops a tracking period.
@@ -2088,6 +2132,36 @@ class Tracelet {
           )
           .listen(callback),
     );
+  }
+
+  /// Subscribe to driving-behavior (telematics) events.
+  ///
+  /// Requires `TelematicsConfig.enableDrivingEvents`. Fires `harsh_braking`,
+  /// `harsh_acceleration`, `harsh_cornering`, and `speeding`.
+  static StreamSubscription<DrivingEvent> onDrivingEvent(
+    void Function(DrivingEvent) callback,
+  ) {
+    return _tracked(drivingEventStream.listen(callback));
+  }
+
+  /// Subscribe to crash/fall impact events.
+  ///
+  /// Requires `ImpactConfig.enableCrashDetection` (and/or `enableFallDetection`).
+  /// A `potential_*` event can be cancelled within its window via
+  /// [cancelImpact], or confirmed early via [confirmImpact].
+  static StreamSubscription<ImpactEvent> onImpact(
+    void Function(ImpactEvent) callback,
+  ) {
+    return _tracked(impactStream.listen(callback));
+  }
+
+  /// Subscribe to fused transport-mode changes.
+  ///
+  /// Requires `ClassifierConfig.enableFusedClassifier`.
+  static StreamSubscription<ModeChangeEvent> onModeChange(
+    void Function(ModeChangeEvent) callback,
+  ) {
+    return _tracked(modeChangeStream.listen(callback));
   }
 
   /// Subscribe to heartbeat events.

--- a/packages/tracelet/lib/tracelet.dart
+++ b/packages/tracelet/lib/tracelet.dart
@@ -63,6 +63,7 @@ export 'src/models/authorization_event.dart';
 export 'src/models/compliance_report.dart';
 export 'src/models/config.dart';
 export 'src/models/connectivity_change_event.dart';
+export 'src/models/driving_config.dart';
 export 'src/models/device_info.dart';
 export 'src/models/geofence.dart';
 export 'src/models/geofence_event.dart';

--- a/packages/tracelet/lib/tracelet.dart
+++ b/packages/tracelet/lib/tracelet.dart
@@ -64,6 +64,7 @@ export 'src/models/compliance_report.dart';
 export 'src/models/config.dart';
 export 'src/models/connectivity_change_event.dart';
 export 'src/models/driving_config.dart';
+export 'src/models/driving_event.dart';
 export 'src/models/device_info.dart';
 export 'src/models/geofence.dart';
 export 'src/models/geofence_event.dart';

--- a/packages/tracelet/pubspec.yaml
+++ b/packages/tracelet/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Production-grade background geolocation for Flutter. Battery-conscious
   tracking, geofencing, SQLite persistence, HTTP sync, and headless
   execution for iOS & Android.
-version: 3.2.19
+version: 3.3.0
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -30,10 +30,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.2.19
-  tracelet_android: ^3.2.19
-  tracelet_ios: ^3.2.19
-  tracelet_web: ^3.2.19
+  tracelet_platform_interface: ^3.3.0
+  tracelet_android: ^3.3.0
+  tracelet_ios: ^3.3.0
+  tracelet_web: ^3.3.0
   collection: ^1.19.1
   meta: ^1.18.0
 

--- a/packages/tracelet/test/driving_config_test.dart
+++ b/packages/tracelet/test/driving_config_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet/tracelet.dart';
+
+void main() {
+  group('TelematicsConfig', () {
+    test('defaults are off and match engine defaults', () {
+      const c = TelematicsConfig();
+      expect(c.enableDrivingEvents, isFalse);
+      expect(c.harshBrakingG, 0.40);
+      expect(c.harshAccelerationG, 0.35);
+      expect(c.harshCorneringG, 0.40);
+      expect(c.speedLimitKmh, 0.0);
+      expect(c.speedingMinDurationMs, 3000);
+      expect(c.eventDebounceMs, 2000);
+    });
+
+    test('round-trips through map', () {
+      const c = TelematicsConfig(
+        enableDrivingEvents: true,
+        harshBrakingG: 0.5,
+        speedLimitKmh: 50,
+      );
+      final back = TelematicsConfig.fromMap(c.toMap());
+      expect(back, c);
+      expect(back.enableDrivingEvents, isTrue);
+      expect(back.speedLimitKmh, 50);
+    });
+
+    test('toTlConfig carries values', () {
+      const c = TelematicsConfig(enableDrivingEvents: true, harshBrakingG: 0.6);
+      final tl = c.toTlConfig();
+      expect(tl.enableDrivingEvents, isTrue);
+      expect(tl.harshBrakingG, 0.6);
+    });
+  });
+
+  group('ClassifierConfig', () {
+    test('defaults off + annotate', () {
+      const c = ClassifierConfig();
+      expect(c.enableFusedClassifier, isFalse);
+      expect(c.fusedClassifierAuthoritative, isFalse);
+      expect(c.modeSwitchDwellMs, 8000);
+      expect(c.minModeConfidence, 0.6);
+    });
+
+    test('round-trips through map', () {
+      const c = ClassifierConfig(
+        enableFusedClassifier: true,
+        fusedClassifierAuthoritative: true,
+        modeSwitchDwellMs: 5000,
+      );
+      expect(ClassifierConfig.fromMap(c.toMap()), c);
+    });
+  });
+
+  group('ImpactConfig', () {
+    test('defaults off', () {
+      const c = ImpactConfig();
+      expect(c.enableCrashDetection, isFalse);
+      expect(c.enableFallDetection, isFalse);
+      expect(c.crashGThreshold, 3.0);
+      expect(c.crashMinSpeedKmh, 25.0);
+      expect(c.confirmWindowMs, 15000);
+    });
+
+    test('round-trips through map', () {
+      const c = ImpactConfig(
+        enableCrashDetection: true,
+        crashGThreshold: 4,
+        confirmWindowMs: 10000,
+      );
+      final back = ImpactConfig.fromMap(c.toMap());
+      expect(back, c);
+      expect(back.enableCrashDetection, isTrue);
+      expect(back.crashGThreshold, 4);
+    });
+  });
+
+  group('Config integration', () {
+    test('defaults include the three new blocks, all off', () {
+      const cfg = Config();
+      expect(cfg.telematics.enableDrivingEvents, isFalse);
+      expect(cfg.classifier.enableFusedClassifier, isFalse);
+      expect(cfg.impact.enableCrashDetection, isFalse);
+    });
+
+    test('round-trips telematics/classifier/impact through Config map', () {
+      const cfg = Config(
+        telematics: TelematicsConfig(enableDrivingEvents: true),
+        classifier: ClassifierConfig(enableFusedClassifier: true),
+        impact: ImpactConfig(enableCrashDetection: true),
+      );
+      final back = Config.fromMap(cfg.toMap());
+      expect(back.telematics.enableDrivingEvents, isTrue);
+      expect(back.classifier.enableFusedClassifier, isTrue);
+      expect(back.impact.enableCrashDetection, isTrue);
+    });
+
+    test('copyWith replaces only the targeted block', () {
+      const cfg = Config();
+      final updated = cfg.copyWith(
+        telematics: const TelematicsConfig(enableDrivingEvents: true),
+      );
+      expect(updated.telematics.enableDrivingEvents, isTrue);
+      expect(updated.classifier.enableFusedClassifier, isFalse);
+      expect(updated.impact, cfg.impact);
+    });
+
+    test('toTlConfig builds the new Pigeon blocks', () {
+      const cfg = Config(impact: ImpactConfig(enableFallDetection: true));
+      final tl = cfg.toTlConfig();
+      expect(tl.impact.enableFallDetection, isTrue);
+      expect(tl.telematics.enableDrivingEvents, isFalse);
+    });
+  });
+}

--- a/packages/tracelet/test/driving_event_test.dart
+++ b/packages/tracelet/test/driving_event_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet/tracelet.dart';
+import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
+
+void main() {
+  test('DrivingEvent.fromTl maps all fields', () {
+    final e = DrivingEvent.fromTl(
+      TlDrivingEvent(
+        kind: 'harsh_braking',
+        severity: 0.7,
+        speed: 12,
+        value: 0.9,
+        latitude: 1,
+        longitude: 2,
+        timestampMs: 1000,
+      ),
+    );
+    expect(e.kind, 'harsh_braking');
+    expect(e.severity, 0.7);
+    expect(e.value, 0.9);
+    expect(e.timestamp.millisecondsSinceEpoch, 1000);
+  });
+
+  test('ImpactEvent.fromTl maps fields and isPotential', () {
+    final pot = ImpactEvent.fromTl(
+      TlImpactEvent(
+        kind: 'potential_crash',
+        id: 5,
+        confidence: 0.8,
+        peakG: 4,
+        speedBefore: 16,
+        latitude: 1,
+        longitude: 2,
+        timestampMs: 1000,
+        confirmDeadlineMs: 16000,
+      ),
+    );
+    expect(pot.isPotential, isTrue);
+    expect(pot.id, 5);
+    expect(pot.confirmDeadline.millisecondsSinceEpoch, 16000);
+
+    final confirmed = ImpactEvent.fromTl(
+      TlImpactEvent(
+        kind: 'crash',
+        id: 5,
+        confidence: 0.8,
+        peakG: 4,
+        speedBefore: 16,
+        latitude: 1,
+        longitude: 2,
+        timestampMs: 1000,
+        confirmDeadlineMs: 1000,
+      ),
+    );
+    expect(confirmed.isPotential, isFalse);
+  });
+
+  test('ModeChangeEvent.fromTl maps fields', () {
+    final e = ModeChangeEvent.fromTl(
+      TlModeChangeEvent(mode: 'vehicle', confidence: 0.95),
+    );
+    expect(e.mode, 'vehicle');
+    expect(e.confidence, 0.95);
+  });
+}

--- a/packages/tracelet_android/CHANGELOG.md
+++ b/packages/tracelet_android/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
@@ -2484,6 +2484,180 @@ data class TlConnectivityChangeEvent (
     return result
   }
 }
+
+/**
+ * A driving-behavior event (harsh brake/accel/cornering/speeding).
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class TlDrivingEvent (
+  val kind: String,
+  val severity: Double,
+  val speed: Double,
+  val value: Double,
+  val latitude: Double,
+  val longitude: Double,
+  val timestampMs: Long
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): TlDrivingEvent {
+      val kind = pigeonVar_list[0] as String
+      val severity = pigeonVar_list[1] as Double
+      val speed = pigeonVar_list[2] as Double
+      val value = pigeonVar_list[3] as Double
+      val latitude = pigeonVar_list[4] as Double
+      val longitude = pigeonVar_list[5] as Double
+      val timestampMs = pigeonVar_list[6] as Long
+      return TlDrivingEvent(kind, severity, speed, value, latitude, longitude, timestampMs)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      kind,
+      severity,
+      speed,
+      value,
+      latitude,
+      longitude,
+      timestampMs,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as TlDrivingEvent
+    return TraceletApiPigeonUtils.deepEquals(this.kind, other.kind) && TraceletApiPigeonUtils.deepEquals(this.severity, other.severity) && TraceletApiPigeonUtils.deepEquals(this.speed, other.speed) && TraceletApiPigeonUtils.deepEquals(this.value, other.value) && TraceletApiPigeonUtils.deepEquals(this.latitude, other.latitude) && TraceletApiPigeonUtils.deepEquals(this.longitude, other.longitude) && TraceletApiPigeonUtils.deepEquals(this.timestampMs, other.timestampMs)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.kind)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.severity)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.speed)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.value)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.latitude)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.longitude)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.timestampMs)
+    return result
+  }
+}
+
+/**
+ * A crash/fall impact event (`potential_crash`/`crash`/`potential_fall`/`fall`).
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class TlImpactEvent (
+  val kind: String,
+  val id: Long,
+  val confidence: Double,
+  val peakG: Double,
+  val speedBefore: Double,
+  val latitude: Double,
+  val longitude: Double,
+  val timestampMs: Long,
+  val confirmDeadlineMs: Long
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): TlImpactEvent {
+      val kind = pigeonVar_list[0] as String
+      val id = pigeonVar_list[1] as Long
+      val confidence = pigeonVar_list[2] as Double
+      val peakG = pigeonVar_list[3] as Double
+      val speedBefore = pigeonVar_list[4] as Double
+      val latitude = pigeonVar_list[5] as Double
+      val longitude = pigeonVar_list[6] as Double
+      val timestampMs = pigeonVar_list[7] as Long
+      val confirmDeadlineMs = pigeonVar_list[8] as Long
+      return TlImpactEvent(kind, id, confidence, peakG, speedBefore, latitude, longitude, timestampMs, confirmDeadlineMs)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      kind,
+      id,
+      confidence,
+      peakG,
+      speedBefore,
+      latitude,
+      longitude,
+      timestampMs,
+      confirmDeadlineMs,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as TlImpactEvent
+    return TraceletApiPigeonUtils.deepEquals(this.kind, other.kind) && TraceletApiPigeonUtils.deepEquals(this.id, other.id) && TraceletApiPigeonUtils.deepEquals(this.confidence, other.confidence) && TraceletApiPigeonUtils.deepEquals(this.peakG, other.peakG) && TraceletApiPigeonUtils.deepEquals(this.speedBefore, other.speedBefore) && TraceletApiPigeonUtils.deepEquals(this.latitude, other.latitude) && TraceletApiPigeonUtils.deepEquals(this.longitude, other.longitude) && TraceletApiPigeonUtils.deepEquals(this.timestampMs, other.timestampMs) && TraceletApiPigeonUtils.deepEquals(this.confirmDeadlineMs, other.confirmDeadlineMs)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.kind)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.id)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.confidence)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.peakG)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.speedBefore)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.latitude)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.longitude)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.timestampMs)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.confirmDeadlineMs)
+    return result
+  }
+}
+
+/**
+ * A fused transport-mode change.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class TlModeChangeEvent (
+  val mode: String,
+  val confidence: Double
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): TlModeChangeEvent {
+      val mode = pigeonVar_list[0] as String
+      val confidence = pigeonVar_list[1] as Double
+      return TlModeChangeEvent(mode, confidence)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      mode,
+      confidence,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as TlModeChangeEvent
+    return TraceletApiPigeonUtils.deepEquals(this.mode, other.mode) && TraceletApiPigeonUtils.deepEquals(this.confidence, other.confidence)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.mode)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.confidence)
+    return result
+  }
+}
 private open class TraceletApiPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -2762,6 +2936,21 @@ private open class TraceletApiPigeonCodec : StandardMessageCodec() {
           TlConnectivityChangeEvent.fromList(it)
         }
       }
+      184.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          TlDrivingEvent.fromList(it)
+        }
+      }
+      185.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          TlImpactEvent.fromList(it)
+        }
+      }
+      186.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          TlModeChangeEvent.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -2987,6 +3176,18 @@ private open class TraceletApiPigeonCodec : StandardMessageCodec() {
         stream.write(183)
         writeValue(stream, value.toList())
       }
+      is TlDrivingEvent -> {
+        stream.write(184)
+        writeValue(stream, value.toList())
+      }
+      is TlImpactEvent -> {
+        stream.write(185)
+        writeValue(stream, value.toList())
+      }
+      is TlModeChangeEvent -> {
+        stream.write(186)
+        writeValue(stream, value.toList())
+      }
       else -> super.writeValue(stream, value)
     }
   }
@@ -3009,6 +3210,10 @@ interface TraceletHostApi {
   fun watchPosition(options: TlCurrentPositionOptions, callback: (Result<Long>) -> Unit)
   fun stopWatchPosition(watchId: Long, callback: (Result<Boolean>) -> Unit)
   fun changePace(isMoving: Boolean, callback: (Result<Boolean>) -> Unit)
+  /** Confirms a pending impact candidate (by [id]) as a real emergency now. */
+  fun confirmImpact(id: Long): Boolean
+  /** Cancels a pending impact candidate (by [id]) — no confirmed event fires. */
+  fun cancelImpact(id: Long): Boolean
   fun getOdometer(callback: (Result<Double>) -> Unit)
   fun setOdometer(value: Double, callback: (Result<TlLocation>) -> Unit)
   fun addGeofence(geofence: TlGeofence, callback: (Result<Boolean>) -> Unit)
@@ -3342,6 +3547,40 @@ interface TraceletHostApi {
                 reply.reply(TraceletApiPigeonUtils.wrapResult(data))
               }
             }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.confirmImpact$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val idArg = args[0] as Long
+            val wrapped: List<Any?> = try {
+              listOf(api.confirmImpact(idArg))
+            } catch (exception: Throwable) {
+              TraceletApiPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.cancelImpact$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val idArg = args[0] as Long
+            val wrapped: List<Any?> = try {
+              listOf(api.cancelImpact(idArg))
+            } catch (exception: Throwable) {
+              TraceletApiPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
           }
         } else {
           channel.setMessageHandler(null)
@@ -4840,6 +5079,57 @@ class TraceletEventApi(private val binaryMessenger: BinaryMessenger, private val
     val channelName = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onWatchPosition$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(locationArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(TraceletApiPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  fun onDrivingEvent(eventArg: TlDrivingEvent, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onDrivingEvent$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(eventArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(TraceletApiPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  fun onImpact(eventArg: TlImpactEvent, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onImpact$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(eventArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(TraceletApiPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  fun onModeChange(eventArg: TlModeChangeEvent, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onModeChange$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(eventArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
@@ -1007,7 +1007,10 @@ data class TlConfig (
   val audit: TlAuditConfig,
   val privacyZone: TlPrivacyZoneConfig,
   val security: TlSecurityConfig,
-  val attestation: TlAttestationConfig
+  val attestation: TlAttestationConfig,
+  val telematics: TlTelematicsConfig,
+  val classifier: TlClassifierConfig,
+  val impact: TlImpactConfig
 )
  {
   companion object {
@@ -1025,7 +1028,10 @@ data class TlConfig (
       val privacyZone = pigeonVar_list[10] as TlPrivacyZoneConfig
       val security = pigeonVar_list[11] as TlSecurityConfig
       val attestation = pigeonVar_list[12] as TlAttestationConfig
-      return TlConfig(geo, app, android, ios, http, logger, motion, geofence, persistence, audit, privacyZone, security, attestation)
+      val telematics = pigeonVar_list[13] as TlTelematicsConfig
+      val classifier = pigeonVar_list[14] as TlClassifierConfig
+      val impact = pigeonVar_list[15] as TlImpactConfig
+      return TlConfig(geo, app, android, ios, http, logger, motion, geofence, persistence, audit, privacyZone, security, attestation, telematics, classifier, impact)
     }
   }
   fun toList(): List<Any?> {
@@ -1043,6 +1049,9 @@ data class TlConfig (
       privacyZone,
       security,
       attestation,
+      telematics,
+      classifier,
+      impact,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -1053,7 +1062,7 @@ data class TlConfig (
       return true
     }
     val other = other as TlConfig
-    return TraceletApiPigeonUtils.deepEquals(this.geo, other.geo) && TraceletApiPigeonUtils.deepEquals(this.app, other.app) && TraceletApiPigeonUtils.deepEquals(this.android, other.android) && TraceletApiPigeonUtils.deepEquals(this.ios, other.ios) && TraceletApiPigeonUtils.deepEquals(this.http, other.http) && TraceletApiPigeonUtils.deepEquals(this.logger, other.logger) && TraceletApiPigeonUtils.deepEquals(this.motion, other.motion) && TraceletApiPigeonUtils.deepEquals(this.geofence, other.geofence) && TraceletApiPigeonUtils.deepEquals(this.persistence, other.persistence) && TraceletApiPigeonUtils.deepEquals(this.audit, other.audit) && TraceletApiPigeonUtils.deepEquals(this.privacyZone, other.privacyZone) && TraceletApiPigeonUtils.deepEquals(this.security, other.security) && TraceletApiPigeonUtils.deepEquals(this.attestation, other.attestation)
+    return TraceletApiPigeonUtils.deepEquals(this.geo, other.geo) && TraceletApiPigeonUtils.deepEquals(this.app, other.app) && TraceletApiPigeonUtils.deepEquals(this.android, other.android) && TraceletApiPigeonUtils.deepEquals(this.ios, other.ios) && TraceletApiPigeonUtils.deepEquals(this.http, other.http) && TraceletApiPigeonUtils.deepEquals(this.logger, other.logger) && TraceletApiPigeonUtils.deepEquals(this.motion, other.motion) && TraceletApiPigeonUtils.deepEquals(this.geofence, other.geofence) && TraceletApiPigeonUtils.deepEquals(this.persistence, other.persistence) && TraceletApiPigeonUtils.deepEquals(this.audit, other.audit) && TraceletApiPigeonUtils.deepEquals(this.privacyZone, other.privacyZone) && TraceletApiPigeonUtils.deepEquals(this.security, other.security) && TraceletApiPigeonUtils.deepEquals(this.attestation, other.attestation) && TraceletApiPigeonUtils.deepEquals(this.telematics, other.telematics) && TraceletApiPigeonUtils.deepEquals(this.classifier, other.classifier) && TraceletApiPigeonUtils.deepEquals(this.impact, other.impact)
   }
 
   override fun hashCode(): Int {
@@ -1071,6 +1080,9 @@ data class TlConfig (
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.privacyZone)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.security)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.attestation)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.telematics)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.classifier)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.impact)
     return result
   }
 }
@@ -1467,6 +1479,188 @@ data class TlAttestationConfig (
     var result = javaClass.hashCode()
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.enabled)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.refreshInterval)
+    return result
+  }
+}
+
+/**
+ * Driving-behavior (telematics) event detection config. See `TelematicsEngine`.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class TlTelematicsConfig (
+  val enableDrivingEvents: Boolean,
+  val harshBrakingG: Double,
+  val harshAccelerationG: Double,
+  val harshCorneringG: Double,
+  val speedLimitKmh: Double,
+  val speedingToleranceKmh: Double,
+  val speedingMinDurationMs: Long,
+  val minSpeedForEventsKmh: Double,
+  val eventDebounceMs: Long
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): TlTelematicsConfig {
+      val enableDrivingEvents = pigeonVar_list[0] as Boolean
+      val harshBrakingG = pigeonVar_list[1] as Double
+      val harshAccelerationG = pigeonVar_list[2] as Double
+      val harshCorneringG = pigeonVar_list[3] as Double
+      val speedLimitKmh = pigeonVar_list[4] as Double
+      val speedingToleranceKmh = pigeonVar_list[5] as Double
+      val speedingMinDurationMs = pigeonVar_list[6] as Long
+      val minSpeedForEventsKmh = pigeonVar_list[7] as Double
+      val eventDebounceMs = pigeonVar_list[8] as Long
+      return TlTelematicsConfig(enableDrivingEvents, harshBrakingG, harshAccelerationG, harshCorneringG, speedLimitKmh, speedingToleranceKmh, speedingMinDurationMs, minSpeedForEventsKmh, eventDebounceMs)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      enableDrivingEvents,
+      harshBrakingG,
+      harshAccelerationG,
+      harshCorneringG,
+      speedLimitKmh,
+      speedingToleranceKmh,
+      speedingMinDurationMs,
+      minSpeedForEventsKmh,
+      eventDebounceMs,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as TlTelematicsConfig
+    return TraceletApiPigeonUtils.deepEquals(this.enableDrivingEvents, other.enableDrivingEvents) && TraceletApiPigeonUtils.deepEquals(this.harshBrakingG, other.harshBrakingG) && TraceletApiPigeonUtils.deepEquals(this.harshAccelerationG, other.harshAccelerationG) && TraceletApiPigeonUtils.deepEquals(this.harshCorneringG, other.harshCorneringG) && TraceletApiPigeonUtils.deepEquals(this.speedLimitKmh, other.speedLimitKmh) && TraceletApiPigeonUtils.deepEquals(this.speedingToleranceKmh, other.speedingToleranceKmh) && TraceletApiPigeonUtils.deepEquals(this.speedingMinDurationMs, other.speedingMinDurationMs) && TraceletApiPigeonUtils.deepEquals(this.minSpeedForEventsKmh, other.minSpeedForEventsKmh) && TraceletApiPigeonUtils.deepEquals(this.eventDebounceMs, other.eventDebounceMs)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.enableDrivingEvents)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.harshBrakingG)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.harshAccelerationG)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.harshCorneringG)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.speedLimitKmh)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.speedingToleranceKmh)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.speedingMinDurationMs)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.minSpeedForEventsKmh)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.eventDebounceMs)
+    return result
+  }
+}
+
+/**
+ * On-device transport-mode classifier config. See `TransportModeClassifier`.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class TlClassifierConfig (
+  val enableFusedClassifier: Boolean,
+  val fusedClassifierAuthoritative: Boolean,
+  val modeSwitchDwellMs: Long,
+  val minModeConfidence: Double
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): TlClassifierConfig {
+      val enableFusedClassifier = pigeonVar_list[0] as Boolean
+      val fusedClassifierAuthoritative = pigeonVar_list[1] as Boolean
+      val modeSwitchDwellMs = pigeonVar_list[2] as Long
+      val minModeConfidence = pigeonVar_list[3] as Double
+      return TlClassifierConfig(enableFusedClassifier, fusedClassifierAuthoritative, modeSwitchDwellMs, minModeConfidence)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      enableFusedClassifier,
+      fusedClassifierAuthoritative,
+      modeSwitchDwellMs,
+      minModeConfidence,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as TlClassifierConfig
+    return TraceletApiPigeonUtils.deepEquals(this.enableFusedClassifier, other.enableFusedClassifier) && TraceletApiPigeonUtils.deepEquals(this.fusedClassifierAuthoritative, other.fusedClassifierAuthoritative) && TraceletApiPigeonUtils.deepEquals(this.modeSwitchDwellMs, other.modeSwitchDwellMs) && TraceletApiPigeonUtils.deepEquals(this.minModeConfidence, other.minModeConfidence)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.enableFusedClassifier)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.fusedClassifierAuthoritative)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.modeSwitchDwellMs)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.minModeConfidence)
+    return result
+  }
+}
+
+/**
+ * Crash & fall detection config. See `ImpactDetector`.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class TlImpactConfig (
+  val enableCrashDetection: Boolean,
+  val enableFallDetection: Boolean,
+  val crashGThreshold: Double,
+  val crashMinSpeedKmh: Double,
+  val fallGThreshold: Double,
+  val confirmWindowMs: Long,
+  val minImpactConfidence: Double
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): TlImpactConfig {
+      val enableCrashDetection = pigeonVar_list[0] as Boolean
+      val enableFallDetection = pigeonVar_list[1] as Boolean
+      val crashGThreshold = pigeonVar_list[2] as Double
+      val crashMinSpeedKmh = pigeonVar_list[3] as Double
+      val fallGThreshold = pigeonVar_list[4] as Double
+      val confirmWindowMs = pigeonVar_list[5] as Long
+      val minImpactConfidence = pigeonVar_list[6] as Double
+      return TlImpactConfig(enableCrashDetection, enableFallDetection, crashGThreshold, crashMinSpeedKmh, fallGThreshold, confirmWindowMs, minImpactConfidence)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      enableCrashDetection,
+      enableFallDetection,
+      crashGThreshold,
+      crashMinSpeedKmh,
+      fallGThreshold,
+      confirmWindowMs,
+      minImpactConfidence,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as TlImpactConfig
+    return TraceletApiPigeonUtils.deepEquals(this.enableCrashDetection, other.enableCrashDetection) && TraceletApiPigeonUtils.deepEquals(this.enableFallDetection, other.enableFallDetection) && TraceletApiPigeonUtils.deepEquals(this.crashGThreshold, other.crashGThreshold) && TraceletApiPigeonUtils.deepEquals(this.crashMinSpeedKmh, other.crashMinSpeedKmh) && TraceletApiPigeonUtils.deepEquals(this.fallGThreshold, other.fallGThreshold) && TraceletApiPigeonUtils.deepEquals(this.confirmWindowMs, other.confirmWindowMs) && TraceletApiPigeonUtils.deepEquals(this.minImpactConfidence, other.minImpactConfidence)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.enableCrashDetection)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.enableFallDetection)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.crashGThreshold)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.crashMinSpeedKmh)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.fallGThreshold)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.confirmWindowMs)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.minImpactConfidence)
     return result
   }
 }
@@ -2470,85 +2664,100 @@ private open class TraceletApiPigeonCodec : StandardMessageCodec() {
       }
       164.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlCoords.fromList(it)
+          TlTelematicsConfig.fromList(it)
         }
       }
       165.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlBattery.fromList(it)
+          TlClassifierConfig.fromList(it)
         }
       }
       166.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlAddress.fromList(it)
+          TlImpactConfig.fromList(it)
         }
       }
       167.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlLocation.fromList(it)
+          TlCoords.fromList(it)
         }
       }
       168.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlActivity.fromList(it)
+          TlBattery.fromList(it)
         }
       }
       169.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlState.fromList(it)
+          TlAddress.fromList(it)
         }
       }
       170.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlGeofence.fromList(it)
+          TlLocation.fromList(it)
         }
       }
       171.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlGeofenceEvent.fromList(it)
+          TlActivity.fromList(it)
         }
       }
       172.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlHttpEvent.fromList(it)
+          TlState.fromList(it)
         }
       }
       173.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlProviderChangeEvent.fromList(it)
+          TlGeofence.fromList(it)
         }
       }
       174.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlCurrentPositionOptions.fromList(it)
+          TlGeofenceEvent.fromList(it)
         }
       }
       175.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlActivityChangeEvent.fromList(it)
+          TlHttpEvent.fromList(it)
         }
       }
       176.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlGeofencesChangeEvent.fromList(it)
+          TlProviderChangeEvent.fromList(it)
         }
       }
       177.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlHeartbeatEvent.fromList(it)
+          TlCurrentPositionOptions.fromList(it)
         }
       }
       178.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlSpeedMotionEvent.fromList(it)
+          TlActivityChangeEvent.fromList(it)
         }
       }
       179.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TlAuthorizationEvent.fromList(it)
+          TlGeofencesChangeEvent.fromList(it)
         }
       }
       180.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          TlHeartbeatEvent.fromList(it)
+        }
+      }
+      181.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          TlSpeedMotionEvent.fromList(it)
+        }
+      }
+      182.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          TlAuthorizationEvent.fromList(it)
+        }
+      }
+      183.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           TlConnectivityChangeEvent.fromList(it)
         }
@@ -2698,72 +2907,84 @@ private open class TraceletApiPigeonCodec : StandardMessageCodec() {
         stream.write(163)
         writeValue(stream, value.toList())
       }
-      is TlCoords -> {
+      is TlTelematicsConfig -> {
         stream.write(164)
         writeValue(stream, value.toList())
       }
-      is TlBattery -> {
+      is TlClassifierConfig -> {
         stream.write(165)
         writeValue(stream, value.toList())
       }
-      is TlAddress -> {
+      is TlImpactConfig -> {
         stream.write(166)
         writeValue(stream, value.toList())
       }
-      is TlLocation -> {
+      is TlCoords -> {
         stream.write(167)
         writeValue(stream, value.toList())
       }
-      is TlActivity -> {
+      is TlBattery -> {
         stream.write(168)
         writeValue(stream, value.toList())
       }
-      is TlState -> {
+      is TlAddress -> {
         stream.write(169)
         writeValue(stream, value.toList())
       }
-      is TlGeofence -> {
+      is TlLocation -> {
         stream.write(170)
         writeValue(stream, value.toList())
       }
-      is TlGeofenceEvent -> {
+      is TlActivity -> {
         stream.write(171)
         writeValue(stream, value.toList())
       }
-      is TlHttpEvent -> {
+      is TlState -> {
         stream.write(172)
         writeValue(stream, value.toList())
       }
-      is TlProviderChangeEvent -> {
+      is TlGeofence -> {
         stream.write(173)
         writeValue(stream, value.toList())
       }
-      is TlCurrentPositionOptions -> {
+      is TlGeofenceEvent -> {
         stream.write(174)
         writeValue(stream, value.toList())
       }
-      is TlActivityChangeEvent -> {
+      is TlHttpEvent -> {
         stream.write(175)
         writeValue(stream, value.toList())
       }
-      is TlGeofencesChangeEvent -> {
+      is TlProviderChangeEvent -> {
         stream.write(176)
         writeValue(stream, value.toList())
       }
-      is TlHeartbeatEvent -> {
+      is TlCurrentPositionOptions -> {
         stream.write(177)
         writeValue(stream, value.toList())
       }
-      is TlSpeedMotionEvent -> {
+      is TlActivityChangeEvent -> {
         stream.write(178)
         writeValue(stream, value.toList())
       }
-      is TlAuthorizationEvent -> {
+      is TlGeofencesChangeEvent -> {
         stream.write(179)
         writeValue(stream, value.toList())
       }
-      is TlConnectivityChangeEvent -> {
+      is TlHeartbeatEvent -> {
         stream.write(180)
+        writeValue(stream, value.toList())
+      }
+      is TlSpeedMotionEvent -> {
+        stream.write(181)
+        writeValue(stream, value.toList())
+      }
+      is TlAuthorizationEvent -> {
+        stream.write(182)
+        writeValue(stream, value.toList())
+      }
+      is TlConnectivityChangeEvent -> {
+        stream.write(183)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/EventDispatcher.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/EventDispatcher.kt
@@ -288,6 +288,60 @@ class EventDispatcher : TraceletEventSender {
     override fun sendTrip(data: Map<String, Any?>) = fallback("trip", data)
     override fun sendBudgetAdjustment(data: Map<String, Any?>) = fallback("budgetadjustment", data)
 
+    override fun sendDrivingEvent(data: Map<String, Any?>) {
+        val api = eventApi
+        if (api != null) {
+            val event = com.ikolvi.tracelet.TlDrivingEvent(
+                kind = data["kind"] as? String ?: "",
+                severity = num(data["severity"]),
+                speed = num(data["speed"]),
+                value = num(data["value"]),
+                latitude = num(data["latitude"]),
+                longitude = num(data["longitude"]),
+                timestampMs = lng(data["timestampMs"]),
+            )
+            postToMain { api.onDrivingEvent(event) {} }
+        } else {
+            fallback("drivingevent", data)
+        }
+    }
+
+    override fun sendImpact(data: Map<String, Any?>) {
+        val api = eventApi
+        if (api != null) {
+            val event = com.ikolvi.tracelet.TlImpactEvent(
+                kind = data["kind"] as? String ?: "",
+                id = lng(data["id"]),
+                confidence = num(data["confidence"]),
+                peakG = num(data["peakG"]),
+                speedBefore = num(data["speedBefore"]),
+                latitude = num(data["latitude"]),
+                longitude = num(data["longitude"]),
+                timestampMs = lng(data["timestampMs"]),
+                confirmDeadlineMs = lng(data["confirmDeadlineMs"]),
+            )
+            postToMain { api.onImpact(event) {} }
+        } else {
+            fallback("impact", data)
+        }
+    }
+
+    override fun sendModeChange(data: Map<String, Any?>) {
+        val api = eventApi
+        if (api != null) {
+            val event = com.ikolvi.tracelet.TlModeChangeEvent(
+                mode = data["mode"] as? String ?: "unknown",
+                confidence = num(data["confidence"]),
+            )
+            postToMain { api.onModeChange(event) {} }
+        } else {
+            fallback("modechange", data)
+        }
+    }
+
+    private fun num(v: Any?): Double = (v as? Number)?.toDouble() ?: 0.0
+    private fun lng(v: Any?): Long = (v as? Number)?.toLong() ?: 0L
+
     override fun hasListener(eventName: String): Boolean = eventApi != null
 
     // ---------------------------------------------------------------------------

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
@@ -51,6 +51,9 @@ class MultiEventSender : com.ikolvi.tracelet.sdk.TraceletEventSender {
     override fun sendRemoteConfigEvent(data: Map<String, Any?>) { dispatchers.forEach { it.sendRemoteConfigEvent(data) } }
     override fun sendTrip(data: Map<String, Any?>) { dispatchers.forEach { it.sendTrip(data) } }
     override fun sendBudgetAdjustment(data: Map<String, Any?>) { dispatchers.forEach { it.sendBudgetAdjustment(data) } }
+    override fun sendDrivingEvent(data: Map<String, Any?>) { dispatchers.forEach { it.sendDrivingEvent(data) } }
+    override fun sendImpact(data: Map<String, Any?>) { dispatchers.forEach { it.sendImpact(data) } }
+    override fun sendModeChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendModeChange(data) } }
 
     override fun hasListener(eventName: String): Boolean = dispatchers.any { it.hasListener(eventName) }
 }

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -302,6 +302,32 @@ class TraceletHostApiImpl(
             put("enabled", c.attestation.enabled)
             put("refreshInterval", c.attestation.refreshInterval)
         })
+        put("telematics", buildMap {
+            put("enableDrivingEvents", c.telematics.enableDrivingEvents)
+            put("harshBrakingG", c.telematics.harshBrakingG)
+            put("harshAccelerationG", c.telematics.harshAccelerationG)
+            put("harshCorneringG", c.telematics.harshCorneringG)
+            put("speedLimitKmh", c.telematics.speedLimitKmh)
+            put("speedingToleranceKmh", c.telematics.speedingToleranceKmh)
+            put("speedingMinDurationMs", c.telematics.speedingMinDurationMs)
+            put("minSpeedForEventsKmh", c.telematics.minSpeedForEventsKmh)
+            put("eventDebounceMs", c.telematics.eventDebounceMs)
+        })
+        put("classifier", buildMap {
+            put("enableFusedClassifier", c.classifier.enableFusedClassifier)
+            put("fusedClassifierAuthoritative", c.classifier.fusedClassifierAuthoritative)
+            put("modeSwitchDwellMs", c.classifier.modeSwitchDwellMs)
+            put("minModeConfidence", c.classifier.minModeConfidence)
+        })
+        put("impact", buildMap {
+            put("enableCrashDetection", c.impact.enableCrashDetection)
+            put("enableFallDetection", c.impact.enableFallDetection)
+            put("crashGThreshold", c.impact.crashGThreshold)
+            put("crashMinSpeedKmh", c.impact.crashMinSpeedKmh)
+            put("fallGThreshold", c.impact.fallGThreshold)
+            put("confirmWindowMs", c.impact.confirmWindowMs)
+            put("minImpactConfidence", c.impact.minImpactConfidence)
+        })
     }
 
     private fun wrapException(err: String): FlutterError {

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -480,6 +480,12 @@ class TraceletHostApiImpl(
         } catch (e: Exception) { callback(Result.failure(e)) }
     }
 
+    override fun confirmImpact(id: Long): Boolean =
+        if (sdk.isReady) sdk.confirmImpact(id) else false
+
+    override fun cancelImpact(id: Long): Boolean =
+        if (sdk.isReady) sdk.cancelImpact(id) else false
+
     override fun getOdometer(callback: (Result<Double>) -> Unit) {
         try {
             callback(Result.success(sdk.getOdometer()))

--- a/packages/tracelet_android/pubspec.yaml
+++ b/packages/tracelet_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_android
 description: Android implementation of the Tracelet background geolocation plugin.
-version: 3.2.19
+version: 3.3.0
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.2.19
+  tracelet_platform_interface: ^3.3.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_doctor/CHANGELOG.md
+++ b/packages/tracelet_doctor/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_doctor/pubspec.yaml
+++ b/packages/tracelet_doctor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Drop-in diagnostic overlay widget for Tracelet. Visualizes permissions,
   battery health, OEM compatibility, sensor availability, and tracking
   state with actionable fix suggestions.
-version: 3.2.19
+version: 3.3.0
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -29,7 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.2.19
+  tracelet: ^3.3.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_firebase/CHANGELOG.md
+++ b/packages/tracelet_firebase/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_firebase/pubspec.yaml
+++ b/packages/tracelet_firebase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_firebase
 description: >-
   Firebase adapter for Tracelet. Automatically configures native HTTP sync to push locations directly to the Firebase RTDB and manages background auth token refresh.
-version: 3.2.19
+version: 3.3.0
 topics:
   - firebase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.2.19
-  tracelet_sync: ^3.2.19
+  tracelet: ^3.3.0
+  tracelet_sync: ^3.3.0
   firebase_auth: ^6.5.2
   firebase_core: ^4.10.0
 
@@ -43,4 +43,4 @@ dev_dependencies:
   flutter_lints: '6.0.0'
   mocktail: ^1.0.5
   plugin_platform_interface: any
-  tracelet_platform_interface: ^3.2.19
+  tracelet_platform_interface: ^3.3.0

--- a/packages/tracelet_ios/CHANGELOG.md
+++ b/packages/tracelet_ios/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/EventDispatcher.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/EventDispatcher.swift
@@ -190,6 +190,57 @@ public final class PluginEventDispatcher: NSObject, TraceletEventSending {
         fallback("budgetadjustment", data)
     }
 
+    public func sendDrivingEvent(_ data: [String: Any]) {
+        guard let api = eventApi else { return fallback("drivingevent", data) }
+        let event = TlDrivingEvent(
+            kind: data["kind"] as? String ?? "",
+            severity: num(data["severity"]),
+            speed: num(data["speed"]),
+            value: num(data["value"]),
+            latitude: num(data["latitude"]),
+            longitude: num(data["longitude"]),
+            timestampMs: lng(data["timestampMs"])
+        )
+        DispatchQueue.main.async { api.onDrivingEvent(event: event) { _ in } }
+    }
+
+    public func sendImpact(_ data: [String: Any]) {
+        guard let api = eventApi else { return fallback("impact", data) }
+        let event = TlImpactEvent(
+            kind: data["kind"] as? String ?? "",
+            id: lng(data["id"]),
+            confidence: num(data["confidence"]),
+            peakG: num(data["peakG"]),
+            speedBefore: num(data["speedBefore"]),
+            latitude: num(data["latitude"]),
+            longitude: num(data["longitude"]),
+            timestampMs: lng(data["timestampMs"]),
+            confirmDeadlineMs: lng(data["confirmDeadlineMs"])
+        )
+        DispatchQueue.main.async { api.onImpact(event: event) { _ in } }
+    }
+
+    public func sendModeChange(_ data: [String: Any]) {
+        guard let api = eventApi else { return fallback("modechange", data) }
+        let event = TlModeChangeEvent(
+            mode: data["mode"] as? String ?? "unknown",
+            confidence: num(data["confidence"])
+        )
+        DispatchQueue.main.async { api.onModeChange(event: event) { _ in } }
+    }
+
+    private func num(_ v: Any?) -> Double {
+        if let d = v as? Double { return d }
+        if let n = v as? NSNumber { return n.doubleValue }
+        return 0.0
+    }
+
+    private func lng(_ v: Any?) -> Int64 {
+        if let i = v as? Int64 { return i }
+        if let n = v as? NSNumber { return n.int64Value }
+        return 0
+    }
+
     public func hasListener(eventName: String) -> Bool {
         return eventApi != nil
     }

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
@@ -2439,6 +2439,180 @@ struct TlConnectivityChangeEvent: Hashable {
   }
 }
 
+/// A driving-behavior event (harsh brake/accel/cornering/speeding).
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct TlDrivingEvent: Hashable {
+  var kind: String
+  var severity: Double
+  var speed: Double
+  var value: Double
+  var latitude: Double
+  var longitude: Double
+  var timestampMs: Int64
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> TlDrivingEvent? {
+    let kind = pigeonVar_list[0] as! String
+    let severity = pigeonVar_list[1] as! Double
+    let speed = pigeonVar_list[2] as! Double
+    let value = pigeonVar_list[3] as! Double
+    let latitude = pigeonVar_list[4] as! Double
+    let longitude = pigeonVar_list[5] as! Double
+    let timestampMs = pigeonVar_list[6] as! Int64
+
+    return TlDrivingEvent(
+      kind: kind,
+      severity: severity,
+      speed: speed,
+      value: value,
+      latitude: latitude,
+      longitude: longitude,
+      timestampMs: timestampMs
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      kind,
+      severity,
+      speed,
+      value,
+      latitude,
+      longitude,
+      timestampMs,
+    ]
+  }
+  static func == (lhs: TlDrivingEvent, rhs: TlDrivingEvent) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsTraceletApi(lhs.kind, rhs.kind) && deepEqualsTraceletApi(lhs.severity, rhs.severity) && deepEqualsTraceletApi(lhs.speed, rhs.speed) && deepEqualsTraceletApi(lhs.value, rhs.value) && deepEqualsTraceletApi(lhs.latitude, rhs.latitude) && deepEqualsTraceletApi(lhs.longitude, rhs.longitude) && deepEqualsTraceletApi(lhs.timestampMs, rhs.timestampMs)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("TlDrivingEvent")
+    deepHashTraceletApi(value: kind, hasher: &hasher)
+    deepHashTraceletApi(value: severity, hasher: &hasher)
+    deepHashTraceletApi(value: speed, hasher: &hasher)
+    deepHashTraceletApi(value: value, hasher: &hasher)
+    deepHashTraceletApi(value: latitude, hasher: &hasher)
+    deepHashTraceletApi(value: longitude, hasher: &hasher)
+    deepHashTraceletApi(value: timestampMs, hasher: &hasher)
+  }
+}
+
+/// A crash/fall impact event (`potential_crash`/`crash`/`potential_fall`/`fall`).
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct TlImpactEvent: Hashable {
+  var kind: String
+  var id: Int64
+  var confidence: Double
+  var peakG: Double
+  var speedBefore: Double
+  var latitude: Double
+  var longitude: Double
+  var timestampMs: Int64
+  var confirmDeadlineMs: Int64
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> TlImpactEvent? {
+    let kind = pigeonVar_list[0] as! String
+    let id = pigeonVar_list[1] as! Int64
+    let confidence = pigeonVar_list[2] as! Double
+    let peakG = pigeonVar_list[3] as! Double
+    let speedBefore = pigeonVar_list[4] as! Double
+    let latitude = pigeonVar_list[5] as! Double
+    let longitude = pigeonVar_list[6] as! Double
+    let timestampMs = pigeonVar_list[7] as! Int64
+    let confirmDeadlineMs = pigeonVar_list[8] as! Int64
+
+    return TlImpactEvent(
+      kind: kind,
+      id: id,
+      confidence: confidence,
+      peakG: peakG,
+      speedBefore: speedBefore,
+      latitude: latitude,
+      longitude: longitude,
+      timestampMs: timestampMs,
+      confirmDeadlineMs: confirmDeadlineMs
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      kind,
+      id,
+      confidence,
+      peakG,
+      speedBefore,
+      latitude,
+      longitude,
+      timestampMs,
+      confirmDeadlineMs,
+    ]
+  }
+  static func == (lhs: TlImpactEvent, rhs: TlImpactEvent) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsTraceletApi(lhs.kind, rhs.kind) && deepEqualsTraceletApi(lhs.id, rhs.id) && deepEqualsTraceletApi(lhs.confidence, rhs.confidence) && deepEqualsTraceletApi(lhs.peakG, rhs.peakG) && deepEqualsTraceletApi(lhs.speedBefore, rhs.speedBefore) && deepEqualsTraceletApi(lhs.latitude, rhs.latitude) && deepEqualsTraceletApi(lhs.longitude, rhs.longitude) && deepEqualsTraceletApi(lhs.timestampMs, rhs.timestampMs) && deepEqualsTraceletApi(lhs.confirmDeadlineMs, rhs.confirmDeadlineMs)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("TlImpactEvent")
+    deepHashTraceletApi(value: kind, hasher: &hasher)
+    deepHashTraceletApi(value: id, hasher: &hasher)
+    deepHashTraceletApi(value: confidence, hasher: &hasher)
+    deepHashTraceletApi(value: peakG, hasher: &hasher)
+    deepHashTraceletApi(value: speedBefore, hasher: &hasher)
+    deepHashTraceletApi(value: latitude, hasher: &hasher)
+    deepHashTraceletApi(value: longitude, hasher: &hasher)
+    deepHashTraceletApi(value: timestampMs, hasher: &hasher)
+    deepHashTraceletApi(value: confirmDeadlineMs, hasher: &hasher)
+  }
+}
+
+/// A fused transport-mode change.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct TlModeChangeEvent: Hashable {
+  var mode: String
+  var confidence: Double
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> TlModeChangeEvent? {
+    let mode = pigeonVar_list[0] as! String
+    let confidence = pigeonVar_list[1] as! Double
+
+    return TlModeChangeEvent(
+      mode: mode,
+      confidence: confidence
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      mode,
+      confidence,
+    ]
+  }
+  static func == (lhs: TlModeChangeEvent, rhs: TlModeChangeEvent) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsTraceletApi(lhs.mode, rhs.mode) && deepEqualsTraceletApi(lhs.confidence, rhs.confidence)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("TlModeChangeEvent")
+    deepHashTraceletApi(value: mode, hasher: &hasher)
+    deepHashTraceletApi(value: confidence, hasher: &hasher)
+  }
+}
+
 private class TraceletApiPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -2628,6 +2802,12 @@ private class TraceletApiPigeonCodecReader: FlutterStandardReader {
       return TlAuthorizationEvent.fromList(self.readValue() as! [Any?])
     case 183:
       return TlConnectivityChangeEvent.fromList(self.readValue() as! [Any?])
+    case 184:
+      return TlDrivingEvent.fromList(self.readValue() as! [Any?])
+    case 185:
+      return TlImpactEvent.fromList(self.readValue() as! [Any?])
+    case 186:
+      return TlModeChangeEvent.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -2801,6 +2981,15 @@ private class TraceletApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? TlConnectivityChangeEvent {
       super.writeByte(183)
       super.writeValue(value.toList())
+    } else if let value = value as? TlDrivingEvent {
+      super.writeByte(184)
+      super.writeValue(value.toList())
+    } else if let value = value as? TlImpactEvent {
+      super.writeByte(185)
+      super.writeValue(value.toList())
+    } else if let value = value as? TlModeChangeEvent {
+      super.writeByte(186)
+      super.writeValue(value.toList())
     } else {
       super.writeValue(value)
     }
@@ -2838,6 +3027,10 @@ protocol TraceletHostApi {
   func watchPosition(options: TlCurrentPositionOptions, completion: @escaping (Result<Int64, Error>) -> Void)
   func stopWatchPosition(watchId: Int64, completion: @escaping (Result<Bool, Error>) -> Void)
   func changePace(isMoving: Bool, completion: @escaping (Result<Bool, Error>) -> Void)
+  /// Confirms a pending impact candidate (by [id]) as a real emergency now.
+  func confirmImpact(id: Int64) throws -> Bool
+  /// Cancels a pending impact candidate (by [id]) — no confirmed event fires.
+  func cancelImpact(id: Int64) throws -> Bool
   func getOdometer(completion: @escaping (Result<Double, Error>) -> Void)
   func setOdometer(value: Double, completion: @escaping (Result<TlLocation, Error>) -> Void)
   func addGeofence(geofence: TlGeofence, completion: @escaping (Result<Bool, Error>) -> Void)
@@ -3131,6 +3324,38 @@ class TraceletHostApiSetup {
       }
     } else {
       changePaceChannel.setMessageHandler(nil)
+    }
+    /// Confirms a pending impact candidate (by [id]) as a real emergency now.
+    let confirmImpactChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.confirmImpact\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      confirmImpactChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let idArg = args[0] as! Int64
+        do {
+          let result = try api.confirmImpact(id: idArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      confirmImpactChannel.setMessageHandler(nil)
+    }
+    /// Cancels a pending impact candidate (by [id]) — no confirmed event fires.
+    let cancelImpactChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.cancelImpact\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      cancelImpactChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let idArg = args[0] as! Int64
+        do {
+          let result = try api.cancelImpact(id: idArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      cancelImpactChannel.setMessageHandler(nil)
     }
     let getOdometerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getOdometer\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
@@ -4196,6 +4421,9 @@ protocol TraceletEventApiProtocol {
   func onNotificationAction(action actionArg: String, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onAuthorization(event eventArg: TlAuthorizationEvent, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onWatchPosition(location locationArg: TlLocation, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onDrivingEvent(event eventArg: TlDrivingEvent, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onImpact(event eventArg: TlImpactEvent, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onModeChange(event eventArg: TlModeChangeEvent, completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class TraceletEventApi: TraceletEventApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -4481,6 +4709,60 @@ class TraceletEventApi: TraceletEventApiProtocol {
     let channelName: String = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onWatchPosition\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([locationArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onDrivingEvent(event eventArg: TlDrivingEvent, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onDrivingEvent\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([eventArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onImpact(event eventArg: TlImpactEvent, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onImpact\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([eventArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onModeChange(event eventArg: TlModeChangeEvent, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onModeChange\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([eventArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
@@ -935,6 +935,9 @@ struct TlConfig: Hashable {
   var privacyZone: TlPrivacyZoneConfig
   var security: TlSecurityConfig
   var attestation: TlAttestationConfig
+  var telematics: TlTelematicsConfig
+  var classifier: TlClassifierConfig
+  var impact: TlImpactConfig
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -952,6 +955,9 @@ struct TlConfig: Hashable {
     let privacyZone = pigeonVar_list[10] as! TlPrivacyZoneConfig
     let security = pigeonVar_list[11] as! TlSecurityConfig
     let attestation = pigeonVar_list[12] as! TlAttestationConfig
+    let telematics = pigeonVar_list[13] as! TlTelematicsConfig
+    let classifier = pigeonVar_list[14] as! TlClassifierConfig
+    let impact = pigeonVar_list[15] as! TlImpactConfig
 
     return TlConfig(
       geo: geo,
@@ -966,7 +972,10 @@ struct TlConfig: Hashable {
       audit: audit,
       privacyZone: privacyZone,
       security: security,
-      attestation: attestation
+      attestation: attestation,
+      telematics: telematics,
+      classifier: classifier,
+      impact: impact
     )
   }
   func toList() -> [Any?] {
@@ -984,13 +993,16 @@ struct TlConfig: Hashable {
       privacyZone,
       security,
       attestation,
+      telematics,
+      classifier,
+      impact,
     ]
   }
   static func == (lhs: TlConfig, rhs: TlConfig) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsTraceletApi(lhs.geo, rhs.geo) && deepEqualsTraceletApi(lhs.app, rhs.app) && deepEqualsTraceletApi(lhs.android, rhs.android) && deepEqualsTraceletApi(lhs.ios, rhs.ios) && deepEqualsTraceletApi(lhs.http, rhs.http) && deepEqualsTraceletApi(lhs.logger, rhs.logger) && deepEqualsTraceletApi(lhs.motion, rhs.motion) && deepEqualsTraceletApi(lhs.geofence, rhs.geofence) && deepEqualsTraceletApi(lhs.persistence, rhs.persistence) && deepEqualsTraceletApi(lhs.audit, rhs.audit) && deepEqualsTraceletApi(lhs.privacyZone, rhs.privacyZone) && deepEqualsTraceletApi(lhs.security, rhs.security) && deepEqualsTraceletApi(lhs.attestation, rhs.attestation)
+    return deepEqualsTraceletApi(lhs.geo, rhs.geo) && deepEqualsTraceletApi(lhs.app, rhs.app) && deepEqualsTraceletApi(lhs.android, rhs.android) && deepEqualsTraceletApi(lhs.ios, rhs.ios) && deepEqualsTraceletApi(lhs.http, rhs.http) && deepEqualsTraceletApi(lhs.logger, rhs.logger) && deepEqualsTraceletApi(lhs.motion, rhs.motion) && deepEqualsTraceletApi(lhs.geofence, rhs.geofence) && deepEqualsTraceletApi(lhs.persistence, rhs.persistence) && deepEqualsTraceletApi(lhs.audit, rhs.audit) && deepEqualsTraceletApi(lhs.privacyZone, rhs.privacyZone) && deepEqualsTraceletApi(lhs.security, rhs.security) && deepEqualsTraceletApi(lhs.attestation, rhs.attestation) && deepEqualsTraceletApi(lhs.telematics, rhs.telematics) && deepEqualsTraceletApi(lhs.classifier, rhs.classifier) && deepEqualsTraceletApi(lhs.impact, rhs.impact)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -1008,6 +1020,9 @@ struct TlConfig: Hashable {
     deepHashTraceletApi(value: privacyZone, hasher: &hasher)
     deepHashTraceletApi(value: security, hasher: &hasher)
     deepHashTraceletApi(value: attestation, hasher: &hasher)
+    deepHashTraceletApi(value: telematics, hasher: &hasher)
+    deepHashTraceletApi(value: classifier, hasher: &hasher)
+    deepHashTraceletApi(value: impact, hasher: &hasher)
   }
 }
 
@@ -1411,6 +1426,190 @@ struct TlAttestationConfig: Hashable {
     hasher.combine("TlAttestationConfig")
     deepHashTraceletApi(value: enabled, hasher: &hasher)
     deepHashTraceletApi(value: refreshInterval, hasher: &hasher)
+  }
+}
+
+/// Driving-behavior (telematics) event detection config. See `TelematicsEngine`.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct TlTelematicsConfig: Hashable {
+  var enableDrivingEvents: Bool
+  var harshBrakingG: Double
+  var harshAccelerationG: Double
+  var harshCorneringG: Double
+  var speedLimitKmh: Double
+  var speedingToleranceKmh: Double
+  var speedingMinDurationMs: Int64
+  var minSpeedForEventsKmh: Double
+  var eventDebounceMs: Int64
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> TlTelematicsConfig? {
+    let enableDrivingEvents = pigeonVar_list[0] as! Bool
+    let harshBrakingG = pigeonVar_list[1] as! Double
+    let harshAccelerationG = pigeonVar_list[2] as! Double
+    let harshCorneringG = pigeonVar_list[3] as! Double
+    let speedLimitKmh = pigeonVar_list[4] as! Double
+    let speedingToleranceKmh = pigeonVar_list[5] as! Double
+    let speedingMinDurationMs = pigeonVar_list[6] as! Int64
+    let minSpeedForEventsKmh = pigeonVar_list[7] as! Double
+    let eventDebounceMs = pigeonVar_list[8] as! Int64
+
+    return TlTelematicsConfig(
+      enableDrivingEvents: enableDrivingEvents,
+      harshBrakingG: harshBrakingG,
+      harshAccelerationG: harshAccelerationG,
+      harshCorneringG: harshCorneringG,
+      speedLimitKmh: speedLimitKmh,
+      speedingToleranceKmh: speedingToleranceKmh,
+      speedingMinDurationMs: speedingMinDurationMs,
+      minSpeedForEventsKmh: minSpeedForEventsKmh,
+      eventDebounceMs: eventDebounceMs
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      enableDrivingEvents,
+      harshBrakingG,
+      harshAccelerationG,
+      harshCorneringG,
+      speedLimitKmh,
+      speedingToleranceKmh,
+      speedingMinDurationMs,
+      minSpeedForEventsKmh,
+      eventDebounceMs,
+    ]
+  }
+  static func == (lhs: TlTelematicsConfig, rhs: TlTelematicsConfig) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsTraceletApi(lhs.enableDrivingEvents, rhs.enableDrivingEvents) && deepEqualsTraceletApi(lhs.harshBrakingG, rhs.harshBrakingG) && deepEqualsTraceletApi(lhs.harshAccelerationG, rhs.harshAccelerationG) && deepEqualsTraceletApi(lhs.harshCorneringG, rhs.harshCorneringG) && deepEqualsTraceletApi(lhs.speedLimitKmh, rhs.speedLimitKmh) && deepEqualsTraceletApi(lhs.speedingToleranceKmh, rhs.speedingToleranceKmh) && deepEqualsTraceletApi(lhs.speedingMinDurationMs, rhs.speedingMinDurationMs) && deepEqualsTraceletApi(lhs.minSpeedForEventsKmh, rhs.minSpeedForEventsKmh) && deepEqualsTraceletApi(lhs.eventDebounceMs, rhs.eventDebounceMs)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("TlTelematicsConfig")
+    deepHashTraceletApi(value: enableDrivingEvents, hasher: &hasher)
+    deepHashTraceletApi(value: harshBrakingG, hasher: &hasher)
+    deepHashTraceletApi(value: harshAccelerationG, hasher: &hasher)
+    deepHashTraceletApi(value: harshCorneringG, hasher: &hasher)
+    deepHashTraceletApi(value: speedLimitKmh, hasher: &hasher)
+    deepHashTraceletApi(value: speedingToleranceKmh, hasher: &hasher)
+    deepHashTraceletApi(value: speedingMinDurationMs, hasher: &hasher)
+    deepHashTraceletApi(value: minSpeedForEventsKmh, hasher: &hasher)
+    deepHashTraceletApi(value: eventDebounceMs, hasher: &hasher)
+  }
+}
+
+/// On-device transport-mode classifier config. See `TransportModeClassifier`.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct TlClassifierConfig: Hashable {
+  var enableFusedClassifier: Bool
+  var fusedClassifierAuthoritative: Bool
+  var modeSwitchDwellMs: Int64
+  var minModeConfidence: Double
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> TlClassifierConfig? {
+    let enableFusedClassifier = pigeonVar_list[0] as! Bool
+    let fusedClassifierAuthoritative = pigeonVar_list[1] as! Bool
+    let modeSwitchDwellMs = pigeonVar_list[2] as! Int64
+    let minModeConfidence = pigeonVar_list[3] as! Double
+
+    return TlClassifierConfig(
+      enableFusedClassifier: enableFusedClassifier,
+      fusedClassifierAuthoritative: fusedClassifierAuthoritative,
+      modeSwitchDwellMs: modeSwitchDwellMs,
+      minModeConfidence: minModeConfidence
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      enableFusedClassifier,
+      fusedClassifierAuthoritative,
+      modeSwitchDwellMs,
+      minModeConfidence,
+    ]
+  }
+  static func == (lhs: TlClassifierConfig, rhs: TlClassifierConfig) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsTraceletApi(lhs.enableFusedClassifier, rhs.enableFusedClassifier) && deepEqualsTraceletApi(lhs.fusedClassifierAuthoritative, rhs.fusedClassifierAuthoritative) && deepEqualsTraceletApi(lhs.modeSwitchDwellMs, rhs.modeSwitchDwellMs) && deepEqualsTraceletApi(lhs.minModeConfidence, rhs.minModeConfidence)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("TlClassifierConfig")
+    deepHashTraceletApi(value: enableFusedClassifier, hasher: &hasher)
+    deepHashTraceletApi(value: fusedClassifierAuthoritative, hasher: &hasher)
+    deepHashTraceletApi(value: modeSwitchDwellMs, hasher: &hasher)
+    deepHashTraceletApi(value: minModeConfidence, hasher: &hasher)
+  }
+}
+
+/// Crash & fall detection config. See `ImpactDetector`.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct TlImpactConfig: Hashable {
+  var enableCrashDetection: Bool
+  var enableFallDetection: Bool
+  var crashGThreshold: Double
+  var crashMinSpeedKmh: Double
+  var fallGThreshold: Double
+  var confirmWindowMs: Int64
+  var minImpactConfidence: Double
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> TlImpactConfig? {
+    let enableCrashDetection = pigeonVar_list[0] as! Bool
+    let enableFallDetection = pigeonVar_list[1] as! Bool
+    let crashGThreshold = pigeonVar_list[2] as! Double
+    let crashMinSpeedKmh = pigeonVar_list[3] as! Double
+    let fallGThreshold = pigeonVar_list[4] as! Double
+    let confirmWindowMs = pigeonVar_list[5] as! Int64
+    let minImpactConfidence = pigeonVar_list[6] as! Double
+
+    return TlImpactConfig(
+      enableCrashDetection: enableCrashDetection,
+      enableFallDetection: enableFallDetection,
+      crashGThreshold: crashGThreshold,
+      crashMinSpeedKmh: crashMinSpeedKmh,
+      fallGThreshold: fallGThreshold,
+      confirmWindowMs: confirmWindowMs,
+      minImpactConfidence: minImpactConfidence
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      enableCrashDetection,
+      enableFallDetection,
+      crashGThreshold,
+      crashMinSpeedKmh,
+      fallGThreshold,
+      confirmWindowMs,
+      minImpactConfidence,
+    ]
+  }
+  static func == (lhs: TlImpactConfig, rhs: TlImpactConfig) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsTraceletApi(lhs.enableCrashDetection, rhs.enableCrashDetection) && deepEqualsTraceletApi(lhs.enableFallDetection, rhs.enableFallDetection) && deepEqualsTraceletApi(lhs.crashGThreshold, rhs.crashGThreshold) && deepEqualsTraceletApi(lhs.crashMinSpeedKmh, rhs.crashMinSpeedKmh) && deepEqualsTraceletApi(lhs.fallGThreshold, rhs.fallGThreshold) && deepEqualsTraceletApi(lhs.confirmWindowMs, rhs.confirmWindowMs) && deepEqualsTraceletApi(lhs.minImpactConfidence, rhs.minImpactConfidence)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("TlImpactConfig")
+    deepHashTraceletApi(value: enableCrashDetection, hasher: &hasher)
+    deepHashTraceletApi(value: enableFallDetection, hasher: &hasher)
+    deepHashTraceletApi(value: crashGThreshold, hasher: &hasher)
+    deepHashTraceletApi(value: crashMinSpeedKmh, hasher: &hasher)
+    deepHashTraceletApi(value: fallGThreshold, hasher: &hasher)
+    deepHashTraceletApi(value: confirmWindowMs, hasher: &hasher)
+    deepHashTraceletApi(value: minImpactConfidence, hasher: &hasher)
   }
 }
 
@@ -2390,38 +2589,44 @@ private class TraceletApiPigeonCodecReader: FlutterStandardReader {
     case 163:
       return TlAttestationConfig.fromList(self.readValue() as! [Any?])
     case 164:
-      return TlCoords.fromList(self.readValue() as! [Any?])
+      return TlTelematicsConfig.fromList(self.readValue() as! [Any?])
     case 165:
-      return TlBattery.fromList(self.readValue() as! [Any?])
+      return TlClassifierConfig.fromList(self.readValue() as! [Any?])
     case 166:
-      return TlAddress.fromList(self.readValue() as! [Any?])
+      return TlImpactConfig.fromList(self.readValue() as! [Any?])
     case 167:
-      return TlLocation.fromList(self.readValue() as! [Any?])
+      return TlCoords.fromList(self.readValue() as! [Any?])
     case 168:
-      return TlActivity.fromList(self.readValue() as! [Any?])
+      return TlBattery.fromList(self.readValue() as! [Any?])
     case 169:
-      return TlState.fromList(self.readValue() as! [Any?])
+      return TlAddress.fromList(self.readValue() as! [Any?])
     case 170:
-      return TlGeofence.fromList(self.readValue() as! [Any?])
+      return TlLocation.fromList(self.readValue() as! [Any?])
     case 171:
-      return TlGeofenceEvent.fromList(self.readValue() as! [Any?])
+      return TlActivity.fromList(self.readValue() as! [Any?])
     case 172:
-      return TlHttpEvent.fromList(self.readValue() as! [Any?])
+      return TlState.fromList(self.readValue() as! [Any?])
     case 173:
-      return TlProviderChangeEvent.fromList(self.readValue() as! [Any?])
+      return TlGeofence.fromList(self.readValue() as! [Any?])
     case 174:
-      return TlCurrentPositionOptions.fromList(self.readValue() as! [Any?])
+      return TlGeofenceEvent.fromList(self.readValue() as! [Any?])
     case 175:
-      return TlActivityChangeEvent.fromList(self.readValue() as! [Any?])
+      return TlHttpEvent.fromList(self.readValue() as! [Any?])
     case 176:
-      return TlGeofencesChangeEvent.fromList(self.readValue() as! [Any?])
+      return TlProviderChangeEvent.fromList(self.readValue() as! [Any?])
     case 177:
-      return TlHeartbeatEvent.fromList(self.readValue() as! [Any?])
+      return TlCurrentPositionOptions.fromList(self.readValue() as! [Any?])
     case 178:
-      return TlSpeedMotionEvent.fromList(self.readValue() as! [Any?])
+      return TlActivityChangeEvent.fromList(self.readValue() as! [Any?])
     case 179:
-      return TlAuthorizationEvent.fromList(self.readValue() as! [Any?])
+      return TlGeofencesChangeEvent.fromList(self.readValue() as! [Any?])
     case 180:
+      return TlHeartbeatEvent.fromList(self.readValue() as! [Any?])
+    case 181:
+      return TlSpeedMotionEvent.fromList(self.readValue() as! [Any?])
+    case 182:
+      return TlAuthorizationEvent.fromList(self.readValue() as! [Any?])
+    case 183:
       return TlConnectivityChangeEvent.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -2536,56 +2741,65 @@ private class TraceletApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? TlAttestationConfig {
       super.writeByte(163)
       super.writeValue(value.toList())
-    } else if let value = value as? TlCoords {
+    } else if let value = value as? TlTelematicsConfig {
       super.writeByte(164)
       super.writeValue(value.toList())
-    } else if let value = value as? TlBattery {
+    } else if let value = value as? TlClassifierConfig {
       super.writeByte(165)
       super.writeValue(value.toList())
-    } else if let value = value as? TlAddress {
+    } else if let value = value as? TlImpactConfig {
       super.writeByte(166)
       super.writeValue(value.toList())
-    } else if let value = value as? TlLocation {
+    } else if let value = value as? TlCoords {
       super.writeByte(167)
       super.writeValue(value.toList())
-    } else if let value = value as? TlActivity {
+    } else if let value = value as? TlBattery {
       super.writeByte(168)
       super.writeValue(value.toList())
-    } else if let value = value as? TlState {
+    } else if let value = value as? TlAddress {
       super.writeByte(169)
       super.writeValue(value.toList())
-    } else if let value = value as? TlGeofence {
+    } else if let value = value as? TlLocation {
       super.writeByte(170)
       super.writeValue(value.toList())
-    } else if let value = value as? TlGeofenceEvent {
+    } else if let value = value as? TlActivity {
       super.writeByte(171)
       super.writeValue(value.toList())
-    } else if let value = value as? TlHttpEvent {
+    } else if let value = value as? TlState {
       super.writeByte(172)
       super.writeValue(value.toList())
-    } else if let value = value as? TlProviderChangeEvent {
+    } else if let value = value as? TlGeofence {
       super.writeByte(173)
       super.writeValue(value.toList())
-    } else if let value = value as? TlCurrentPositionOptions {
+    } else if let value = value as? TlGeofenceEvent {
       super.writeByte(174)
       super.writeValue(value.toList())
-    } else if let value = value as? TlActivityChangeEvent {
+    } else if let value = value as? TlHttpEvent {
       super.writeByte(175)
       super.writeValue(value.toList())
-    } else if let value = value as? TlGeofencesChangeEvent {
+    } else if let value = value as? TlProviderChangeEvent {
       super.writeByte(176)
       super.writeValue(value.toList())
-    } else if let value = value as? TlHeartbeatEvent {
+    } else if let value = value as? TlCurrentPositionOptions {
       super.writeByte(177)
       super.writeValue(value.toList())
-    } else if let value = value as? TlSpeedMotionEvent {
+    } else if let value = value as? TlActivityChangeEvent {
       super.writeByte(178)
       super.writeValue(value.toList())
-    } else if let value = value as? TlAuthorizationEvent {
+    } else if let value = value as? TlGeofencesChangeEvent {
       super.writeByte(179)
       super.writeValue(value.toList())
-    } else if let value = value as? TlConnectivityChangeEvent {
+    } else if let value = value as? TlHeartbeatEvent {
       super.writeByte(180)
+      super.writeValue(value.toList())
+    } else if let value = value as? TlSpeedMotionEvent {
+      super.writeByte(181)
+      super.writeValue(value.toList())
+    } else if let value = value as? TlAuthorizationEvent {
+      super.writeByte(182)
+      super.writeValue(value.toList())
+    } else if let value = value as? TlConnectivityChangeEvent {
+      super.writeByte(183)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
@@ -409,6 +409,14 @@ class TraceletHostApiImpl: TraceletHostApi {
         completion(.success(result))
     }
 
+    func confirmImpact(id: Int64) throws -> Bool {
+        return sdk.isReadyState ? sdk.confirmImpact(id) : false
+    }
+
+    func cancelImpact(id: Int64) throws -> Bool {
+        return sdk.isReadyState ? sdk.cancelImpact(id) : false
+    }
+
     func getOdometer(completion: @escaping (Result<Double, Error>) -> Void) {
         completion(.success(sdk.getOdometer()))
     }

--- a/packages/tracelet_ios/pubspec.yaml
+++ b/packages/tracelet_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_ios
 description: iOS implementation of the Tracelet background geolocation plugin.
-version: 3.2.19
+version: 3.3.0
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.2.19
+  tracelet_platform_interface: ^3.3.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_platform_interface/CHANGELOG.md
+++ b/packages/tracelet_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
+++ b/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
@@ -10,9 +10,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-  List<Object?>? replyList,
-  String channelName, {
-  required bool isNullValid,
+    List<Object?>? replyList,
+    String channelName, {
+    required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -34,11 +34,8 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-List<Object?> wrapResponse({
-  Object? result,
-  PlatformException? error,
-  bool empty = false,
-}) {
+
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -47,7 +44,6 @@ List<Object?> wrapResponse({
   }
   return <Object?>[error.code, error.message, error.details];
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (identical(a, b)) {
     return true;
@@ -60,9 +56,8 @@ bool _deepEquals(Object? a, Object? b) {
   }
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed.every(
-          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
-        );
+        a.indexed
+            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
     if (a.length != b.length) {
@@ -111,15 +106,37 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
-enum TlDesiredAccuracy { high, medium, low, veryLow, passive }
 
-enum TlTrackingMode { location, geofences, periodic }
+enum TlDesiredAccuracy {
+  high,
+  medium,
+  low,
+  veryLow,
+  passive,
+}
 
-enum TlMotionDetectionMode { accelerometer, speed, smart }
+enum TlTrackingMode {
+  location,
+  geofences,
+  periodic,
+}
 
-enum TlStationaryTrackingMode { periodic, geofences }
+enum TlMotionDetectionMode {
+  accelerometer,
+  speed,
+  smart,
+}
 
-enum TlGeofenceAction { enter, exit, dwell }
+enum TlStationaryTrackingMode {
+  periodic,
+  geofences,
+}
+
+enum TlGeofenceAction {
+  enter,
+  exit,
+  dwell,
+}
 
 enum TlAuthorizationStatus {
   notDetermined,
@@ -147,15 +164,37 @@ enum TlNotificationAuthorizationStatus {
   ephemeral,
 }
 
-enum TlHttpMethod { post, put }
+enum TlHttpMethod {
+  post,
+  put,
+}
 
-enum TlIosActivityType { other, automotive, fitness, otherNavigation, airborne }
+enum TlIosActivityType {
+  other,
+  automotive,
+  fitness,
+  otherNavigation,
+  airborne,
+}
 
-enum TlNotificationPriority { min, low, defaultPriority, high, max }
+enum TlNotificationPriority {
+  min,
+  low,
+  defaultPriority,
+  high,
+  max,
+}
 
-enum TlLocationFilterPolicy { adjust, ignore, discard }
+enum TlLocationFilterPolicy {
+  adjust,
+  ignore,
+  discard,
+}
 
-enum TlLocationOrderDirection { ascending, descending }
+enum TlLocationOrderDirection {
+  ascending,
+  descending,
+}
 
 enum TlLocationActivityType {
   still,
@@ -167,15 +206,36 @@ enum TlLocationActivityType {
   unknown,
 }
 
-enum TlLogLevel { off, error, warn, info, debug, verbose }
+enum TlLogLevel {
+  off,
+  error,
+  warn,
+  info,
+  debug,
+  verbose,
+}
 
-enum TlPersistMode { all, location, geofence, none }
+enum TlPersistMode {
+  all,
+  location,
+  geofence,
+  none,
+}
 
-enum TlHashAlgorithm { sha256 }
+enum TlHashAlgorithm {
+  sha256,
+}
 
-enum TlAuthorizationRequest { always, whenInUse }
+enum TlAuthorizationRequest {
+  always,
+  whenInUse,
+}
 
-enum TlSpeedMotionState { moving, slowing, stationary }
+enum TlSpeedMotionState {
+  moving,
+  slowing,
+  stationary,
+}
 
 class TlLocationFilter {
   TlLocationFilter({
@@ -215,8 +275,7 @@ class TlLocationFilter {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlLocationFilter decode(Object result) {
     result as List<Object?>;
@@ -240,19 +299,7 @@ class TlLocationFilter {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(
-          trackingAccuracyThreshold,
-          other.trackingAccuracyThreshold,
-        ) &&
-        _deepEquals(maxImpliedSpeed, other.maxImpliedSpeed) &&
-        _deepEquals(
-          odometerAccuracyThreshold,
-          other.odometerAccuracyThreshold,
-        ) &&
-        _deepEquals(policy, other.policy) &&
-        _deepEquals(rejectMockLocations, other.rejectMockLocations) &&
-        _deepEquals(mockDetectionLevel, other.mockDetectionLevel) &&
-        _deepEquals(useKalmanFilter, other.useKalmanFilter);
+    return _deepEquals(trackingAccuracyThreshold, other.trackingAccuracyThreshold) && _deepEquals(maxImpliedSpeed, other.maxImpliedSpeed) && _deepEquals(odometerAccuracyThreshold, other.odometerAccuracyThreshold) && _deepEquals(policy, other.policy) && _deepEquals(rejectMockLocations, other.rejectMockLocations) && _deepEquals(mockDetectionLevel, other.mockDetectionLevel) && _deepEquals(useKalmanFilter, other.useKalmanFilter);
   }
 
   @override
@@ -354,8 +401,7 @@ class TlGeoConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlGeoConfig decode(Object result) {
     result as List<Object?>;
@@ -393,30 +439,7 @@ class TlGeoConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(desiredAccuracy, other.desiredAccuracy) &&
-        _deepEquals(distanceFilter, other.distanceFilter) &&
-        _deepEquals(stationaryRadius, other.stationaryRadius) &&
-        _deepEquals(locationTimeout, other.locationTimeout) &&
-        _deepEquals(disableElasticity, other.disableElasticity) &&
-        _deepEquals(elasticityMultiplier, other.elasticityMultiplier) &&
-        _deepEquals(stopAfterElapsedMinutes, other.stopAfterElapsedMinutes) &&
-        _deepEquals(maxMonitoredGeofences, other.maxMonitoredGeofences) &&
-        _deepEquals(enableTimestampMeta, other.enableTimestampMeta) &&
-        _deepEquals(enableAdaptiveMode, other.enableAdaptiveMode) &&
-        _deepEquals(periodicLocationInterval, other.periodicLocationInterval) &&
-        _deepEquals(periodicDesiredAccuracy, other.periodicDesiredAccuracy) &&
-        _deepEquals(enableSparseUpdates, other.enableSparseUpdates) &&
-        _deepEquals(sparseDistanceThreshold, other.sparseDistanceThreshold) &&
-        _deepEquals(sparseMaxIdleSeconds, other.sparseMaxIdleSeconds) &&
-        _deepEquals(enableDeadReckoning, other.enableDeadReckoning) &&
-        _deepEquals(
-          deadReckoningActivationDelay,
-          other.deadReckoningActivationDelay,
-        ) &&
-        _deepEquals(deadReckoningMaxDuration, other.deadReckoningMaxDuration) &&
-        _deepEquals(batteryBudgetPerHour, other.batteryBudgetPerHour) &&
-        _deepEquals(filter, other.filter) &&
-        _deepEquals(resolveAddress, other.resolveAddress);
+    return _deepEquals(desiredAccuracy, other.desiredAccuracy) && _deepEquals(distanceFilter, other.distanceFilter) && _deepEquals(stationaryRadius, other.stationaryRadius) && _deepEquals(locationTimeout, other.locationTimeout) && _deepEquals(disableElasticity, other.disableElasticity) && _deepEquals(elasticityMultiplier, other.elasticityMultiplier) && _deepEquals(stopAfterElapsedMinutes, other.stopAfterElapsedMinutes) && _deepEquals(maxMonitoredGeofences, other.maxMonitoredGeofences) && _deepEquals(enableTimestampMeta, other.enableTimestampMeta) && _deepEquals(enableAdaptiveMode, other.enableAdaptiveMode) && _deepEquals(periodicLocationInterval, other.periodicLocationInterval) && _deepEquals(periodicDesiredAccuracy, other.periodicDesiredAccuracy) && _deepEquals(enableSparseUpdates, other.enableSparseUpdates) && _deepEquals(sparseDistanceThreshold, other.sparseDistanceThreshold) && _deepEquals(sparseMaxIdleSeconds, other.sparseMaxIdleSeconds) && _deepEquals(enableDeadReckoning, other.enableDeadReckoning) && _deepEquals(deadReckoningActivationDelay, other.deadReckoningActivationDelay) && _deepEquals(deadReckoningMaxDuration, other.deadReckoningMaxDuration) && _deepEquals(batteryBudgetPerHour, other.batteryBudgetPerHour) && _deepEquals(filter, other.filter) && _deepEquals(resolveAddress, other.resolveAddress);
   }
 
   @override
@@ -466,8 +489,7 @@ class TlAppConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlAppConfig decode(Object result) {
     result as List<Object?>;
@@ -477,8 +499,7 @@ class TlAppConfig {
       heartbeatInterval: result[2]! as int,
       schedule: (result[3]! as List<Object?>).cast<String?>(),
       remoteConfigUrl: result[4] as String?,
-      remoteConfigHeaders: (result[5] as Map<Object?, Object?>?)
-          ?.cast<String?, String?>(),
+      remoteConfigHeaders: (result[5] as Map<Object?, Object?>?)?.cast<String?, String?>(),
       remoteConfigTimeout: result[6]! as int,
       remoteConfigRefreshInterval: result[7]! as int,
     );
@@ -493,17 +514,7 @@ class TlAppConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(stopOnTerminate, other.stopOnTerminate) &&
-        _deepEquals(startOnBoot, other.startOnBoot) &&
-        _deepEquals(heartbeatInterval, other.heartbeatInterval) &&
-        _deepEquals(schedule, other.schedule) &&
-        _deepEquals(remoteConfigUrl, other.remoteConfigUrl) &&
-        _deepEquals(remoteConfigHeaders, other.remoteConfigHeaders) &&
-        _deepEquals(remoteConfigTimeout, other.remoteConfigTimeout) &&
-        _deepEquals(
-          remoteConfigRefreshInterval,
-          other.remoteConfigRefreshInterval,
-        );
+    return _deepEquals(stopOnTerminate, other.stopOnTerminate) && _deepEquals(startOnBoot, other.startOnBoot) && _deepEquals(heartbeatInterval, other.heartbeatInterval) && _deepEquals(schedule, other.schedule) && _deepEquals(remoteConfigUrl, other.remoteConfigUrl) && _deepEquals(remoteConfigHeaders, other.remoteConfigHeaders) && _deepEquals(remoteConfigTimeout, other.remoteConfigTimeout) && _deepEquals(remoteConfigRefreshInterval, other.remoteConfigRefreshInterval);
   }
 
   @override
@@ -569,8 +580,7 @@ class TlForegroundServiceConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlForegroundServiceConfig decode(Object result) {
     result as List<Object?>;
@@ -593,28 +603,13 @@ class TlForegroundServiceConfig {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! TlForegroundServiceConfig ||
-        other.runtimeType != runtimeType) {
+    if (other is! TlForegroundServiceConfig || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) &&
-        _deepEquals(channelId, other.channelId) &&
-        _deepEquals(channelName, other.channelName) &&
-        _deepEquals(notificationTitle, other.notificationTitle) &&
-        _deepEquals(notificationText, other.notificationText) &&
-        _deepEquals(notificationColor, other.notificationColor) &&
-        _deepEquals(notificationSmallIcon, other.notificationSmallIcon) &&
-        _deepEquals(notificationLargeIcon, other.notificationLargeIcon) &&
-        _deepEquals(notificationPriority, other.notificationPriority) &&
-        _deepEquals(notificationOngoing, other.notificationOngoing) &&
-        _deepEquals(
-          showNotificationOnPauseOnly,
-          other.showNotificationOnPauseOnly,
-        ) &&
-        _deepEquals(actions, other.actions);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(channelId, other.channelId) && _deepEquals(channelName, other.channelName) && _deepEquals(notificationTitle, other.notificationTitle) && _deepEquals(notificationText, other.notificationText) && _deepEquals(notificationColor, other.notificationColor) && _deepEquals(notificationSmallIcon, other.notificationSmallIcon) && _deepEquals(notificationLargeIcon, other.notificationLargeIcon) && _deepEquals(notificationPriority, other.notificationPriority) && _deepEquals(notificationOngoing, other.notificationOngoing) && _deepEquals(showNotificationOnPauseOnly, other.showNotificationOnPauseOnly) && _deepEquals(actions, other.actions);
   }
 
   @override
@@ -668,8 +663,7 @@ class TlAndroidConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlAndroidConfig decode(Object result) {
     result as List<Object?>;
@@ -695,21 +689,7 @@ class TlAndroidConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(locationUpdateInterval, other.locationUpdateInterval) &&
-        _deepEquals(
-          fastestLocationUpdateInterval,
-          other.fastestLocationUpdateInterval,
-        ) &&
-        _deepEquals(deferTime, other.deferTime) &&
-        _deepEquals(allowIdenticalLocations, other.allowIdenticalLocations) &&
-        _deepEquals(geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) &&
-        _deepEquals(
-          periodicUseForegroundService,
-          other.periodicUseForegroundService,
-        ) &&
-        _deepEquals(periodicUseExactAlarms, other.periodicUseExactAlarms) &&
-        _deepEquals(scheduleUseAlarmManager, other.scheduleUseAlarmManager) &&
-        _deepEquals(foregroundService, other.foregroundService);
+    return _deepEquals(locationUpdateInterval, other.locationUpdateInterval) && _deepEquals(fastestLocationUpdateInterval, other.fastestLocationUpdateInterval) && _deepEquals(deferTime, other.deferTime) && _deepEquals(allowIdenticalLocations, other.allowIdenticalLocations) && _deepEquals(geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) && _deepEquals(periodicUseForegroundService, other.periodicUseForegroundService) && _deepEquals(periodicUseExactAlarms, other.periodicUseExactAlarms) && _deepEquals(scheduleUseAlarmManager, other.scheduleUseAlarmManager) && _deepEquals(foregroundService, other.foregroundService);
   }
 
   @override
@@ -755,8 +735,7 @@ class TlIosConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlIosConfig decode(Object result) {
     result as List<Object?>;
@@ -780,28 +759,7 @@ class TlIosConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(activityType, other.activityType) &&
-        _deepEquals(
-          useSignificantChangesOnly,
-          other.useSignificantChangesOnly,
-        ) &&
-        _deepEquals(
-          showsBackgroundLocationIndicator,
-          other.showsBackgroundLocationIndicator,
-        ) &&
-        _deepEquals(
-          pausesLocationUpdatesAutomatically,
-          other.pausesLocationUpdatesAutomatically,
-        ) &&
-        _deepEquals(
-          locationAuthorizationRequest,
-          other.locationAuthorizationRequest,
-        ) &&
-        _deepEquals(
-          disableLocationAuthorizationAlert,
-          other.disableLocationAuthorizationAlert,
-        ) &&
-        _deepEquals(preventSuspend, other.preventSuspend);
+    return _deepEquals(activityType, other.activityType) && _deepEquals(useSignificantChangesOnly, other.useSignificantChangesOnly) && _deepEquals(showsBackgroundLocationIndicator, other.showsBackgroundLocationIndicator) && _deepEquals(pausesLocationUpdatesAutomatically, other.pausesLocationUpdatesAutomatically) && _deepEquals(locationAuthorizationRequest, other.locationAuthorizationRequest) && _deepEquals(disableLocationAuthorizationAlert, other.disableLocationAuthorizationAlert) && _deepEquals(preventSuspend, other.preventSuspend);
   }
 
   @override
@@ -907,8 +865,7 @@ class TlHttpConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlHttpConfig decode(Object result) {
     result as List<Object?>;
@@ -947,31 +904,7 @@ class TlHttpConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(url, other.url) &&
-        _deepEquals(method, other.method) &&
-        _deepEquals(headers, other.headers) &&
-        _deepEquals(params, other.params) &&
-        _deepEquals(autoSync, other.autoSync) &&
-        _deepEquals(batchSync, other.batchSync) &&
-        _deepEquals(maxBatchSize, other.maxBatchSize) &&
-        _deepEquals(sslPinningFingerprints, other.sslPinningFingerprints) &&
-        _deepEquals(sslPinningCertificates, other.sslPinningCertificates) &&
-        _deepEquals(httpRootProperty, other.httpRootProperty) &&
-        _deepEquals(autoSyncThreshold, other.autoSyncThreshold) &&
-        _deepEquals(autoSyncDelay, other.autoSyncDelay) &&
-        _deepEquals(syncInterval, other.syncInterval) &&
-        _deepEquals(httpTimeout, other.httpTimeout) &&
-        _deepEquals(locationsOrderDirection, other.locationsOrderDirection) &&
-        _deepEquals(extras, other.extras) &&
-        _deepEquals(
-          disableAutoSyncOnCellular,
-          other.disableAutoSyncOnCellular,
-        ) &&
-        _deepEquals(maxRetries, other.maxRetries) &&
-        _deepEquals(retryBackoffBase, other.retryBackoffBase) &&
-        _deepEquals(retryBackoffCap, other.retryBackoffCap) &&
-        _deepEquals(enableDeltaCompression, other.enableDeltaCompression) &&
-        _deepEquals(deltaCoordinatePrecision, other.deltaCoordinatePrecision);
+    return _deepEquals(url, other.url) && _deepEquals(method, other.method) && _deepEquals(headers, other.headers) && _deepEquals(params, other.params) && _deepEquals(autoSync, other.autoSync) && _deepEquals(batchSync, other.batchSync) && _deepEquals(maxBatchSize, other.maxBatchSize) && _deepEquals(sslPinningFingerprints, other.sslPinningFingerprints) && _deepEquals(sslPinningCertificates, other.sslPinningCertificates) && _deepEquals(httpRootProperty, other.httpRootProperty) && _deepEquals(autoSyncThreshold, other.autoSyncThreshold) && _deepEquals(autoSyncDelay, other.autoSyncDelay) && _deepEquals(syncInterval, other.syncInterval) && _deepEquals(httpTimeout, other.httpTimeout) && _deepEquals(locationsOrderDirection, other.locationsOrderDirection) && _deepEquals(extras, other.extras) && _deepEquals(disableAutoSyncOnCellular, other.disableAutoSyncOnCellular) && _deepEquals(maxRetries, other.maxRetries) && _deepEquals(retryBackoffBase, other.retryBackoffBase) && _deepEquals(retryBackoffCap, other.retryBackoffCap) && _deepEquals(enableDeltaCompression, other.enableDeltaCompression) && _deepEquals(deltaCoordinatePrecision, other.deltaCoordinatePrecision);
   }
 
   @override
@@ -994,6 +927,9 @@ class TlConfig {
     required this.privacyZone,
     required this.security,
     required this.attestation,
+    required this.telematics,
+    required this.classifier,
+    required this.impact,
   });
 
   TlGeoConfig geo;
@@ -1022,6 +958,12 @@ class TlConfig {
 
   TlAttestationConfig attestation;
 
+  TlTelematicsConfig telematics;
+
+  TlClassifierConfig classifier;
+
+  TlImpactConfig impact;
+
   List<Object?> _toList() {
     return <Object?>[
       geo,
@@ -1037,12 +979,14 @@ class TlConfig {
       privacyZone,
       security,
       attestation,
+      telematics,
+      classifier,
+      impact,
     ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlConfig decode(Object result) {
     result as List<Object?>;
@@ -1060,6 +1004,9 @@ class TlConfig {
       privacyZone: result[10]! as TlPrivacyZoneConfig,
       security: result[11]! as TlSecurityConfig,
       attestation: result[12]! as TlAttestationConfig,
+      telematics: result[13]! as TlTelematicsConfig,
+      classifier: result[14]! as TlClassifierConfig,
+      impact: result[15]! as TlImpactConfig,
     );
   }
 
@@ -1072,19 +1019,7 @@ class TlConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(geo, other.geo) &&
-        _deepEquals(app, other.app) &&
-        _deepEquals(android, other.android) &&
-        _deepEquals(ios, other.ios) &&
-        _deepEquals(http, other.http) &&
-        _deepEquals(logger, other.logger) &&
-        _deepEquals(motion, other.motion) &&
-        _deepEquals(geofence, other.geofence) &&
-        _deepEquals(persistence, other.persistence) &&
-        _deepEquals(audit, other.audit) &&
-        _deepEquals(privacyZone, other.privacyZone) &&
-        _deepEquals(security, other.security) &&
-        _deepEquals(attestation, other.attestation);
+    return _deepEquals(geo, other.geo) && _deepEquals(app, other.app) && _deepEquals(android, other.android) && _deepEquals(ios, other.ios) && _deepEquals(http, other.http) && _deepEquals(logger, other.logger) && _deepEquals(motion, other.motion) && _deepEquals(geofence, other.geofence) && _deepEquals(persistence, other.persistence) && _deepEquals(audit, other.audit) && _deepEquals(privacyZone, other.privacyZone) && _deepEquals(security, other.security) && _deepEquals(attestation, other.attestation) && _deepEquals(telematics, other.telematics) && _deepEquals(classifier, other.classifier) && _deepEquals(impact, other.impact);
   }
 
   @override
@@ -1106,12 +1041,15 @@ class TlLoggerConfig {
   bool debug;
 
   List<Object?> _toList() {
-    return <Object?>[logLevel, logMaxDays, debug];
+    return <Object?>[
+      logLevel,
+      logMaxDays,
+      debug,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlLoggerConfig decode(Object result) {
     result as List<Object?>;
@@ -1131,9 +1069,7 @@ class TlLoggerConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(logLevel, other.logLevel) &&
-        _deepEquals(logMaxDays, other.logMaxDays) &&
-        _deepEquals(debug, other.debug);
+    return _deepEquals(logLevel, other.logLevel) && _deepEquals(logMaxDays, other.logMaxDays) && _deepEquals(debug, other.debug);
   }
 
   @override
@@ -1239,8 +1175,7 @@ class TlMotionConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlMotionConfig decode(Object result) {
     result as List<Object?>;
@@ -1254,8 +1189,7 @@ class TlMotionConfig {
       disableStopDetection: result[6]! as bool,
       stopDetectionDelay: result[7]! as int,
       stopOnStationary: result[8]! as bool,
-      activityTypes: (result[9] as List<Object?>?)
-          ?.cast<TlLocationActivityType?>(),
+      activityTypes: (result[9] as List<Object?>?)?.cast<TlLocationActivityType?>(),
       stationaryRadius: result[10]! as double,
       useSignificantChangesOnly: result[11]! as bool,
       shakeThreshold: result[12]! as double,
@@ -1280,46 +1214,7 @@ class TlMotionConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(stopTimeout, other.stopTimeout) &&
-        _deepEquals(motionTriggerDelay, other.motionTriggerDelay) &&
-        _deepEquals(
-          disableMotionActivityUpdates,
-          other.disableMotionActivityUpdates,
-        ) &&
-        _deepEquals(isMoving, other.isMoving) &&
-        _deepEquals(
-          activityRecognitionInterval,
-          other.activityRecognitionInterval,
-        ) &&
-        _deepEquals(
-          minimumActivityRecognitionConfidence,
-          other.minimumActivityRecognitionConfidence,
-        ) &&
-        _deepEquals(disableStopDetection, other.disableStopDetection) &&
-        _deepEquals(stopDetectionDelay, other.stopDetectionDelay) &&
-        _deepEquals(stopOnStationary, other.stopOnStationary) &&
-        _deepEquals(activityTypes, other.activityTypes) &&
-        _deepEquals(stationaryRadius, other.stationaryRadius) &&
-        _deepEquals(
-          useSignificantChangesOnly,
-          other.useSignificantChangesOnly,
-        ) &&
-        _deepEquals(shakeThreshold, other.shakeThreshold) &&
-        _deepEquals(stillThreshold, other.stillThreshold) &&
-        _deepEquals(stillSampleCount, other.stillSampleCount) &&
-        _deepEquals(motionDetectionMode, other.motionDetectionMode) &&
-        _deepEquals(speedMovingThreshold, other.speedMovingThreshold) &&
-        _deepEquals(speedStationaryDelay, other.speedStationaryDelay) &&
-        _deepEquals(stationaryTrackingMode, other.stationaryTrackingMode) &&
-        _deepEquals(
-          stationaryPeriodicInterval,
-          other.stationaryPeriodicInterval,
-        ) &&
-        _deepEquals(
-          stationaryPeriodicAccuracy,
-          other.stationaryPeriodicAccuracy,
-        ) &&
-        _deepEquals(speedWakeConfirmCount, other.speedWakeConfirmCount);
+    return _deepEquals(stopTimeout, other.stopTimeout) && _deepEquals(motionTriggerDelay, other.motionTriggerDelay) && _deepEquals(disableMotionActivityUpdates, other.disableMotionActivityUpdates) && _deepEquals(isMoving, other.isMoving) && _deepEquals(activityRecognitionInterval, other.activityRecognitionInterval) && _deepEquals(minimumActivityRecognitionConfidence, other.minimumActivityRecognitionConfidence) && _deepEquals(disableStopDetection, other.disableStopDetection) && _deepEquals(stopDetectionDelay, other.stopDetectionDelay) && _deepEquals(stopOnStationary, other.stopOnStationary) && _deepEquals(activityTypes, other.activityTypes) && _deepEquals(stationaryRadius, other.stationaryRadius) && _deepEquals(useSignificantChangesOnly, other.useSignificantChangesOnly) && _deepEquals(shakeThreshold, other.shakeThreshold) && _deepEquals(stillThreshold, other.stillThreshold) && _deepEquals(stillSampleCount, other.stillSampleCount) && _deepEquals(motionDetectionMode, other.motionDetectionMode) && _deepEquals(speedMovingThreshold, other.speedMovingThreshold) && _deepEquals(speedStationaryDelay, other.speedStationaryDelay) && _deepEquals(stationaryTrackingMode, other.stationaryTrackingMode) && _deepEquals(stationaryPeriodicInterval, other.stationaryPeriodicInterval) && _deepEquals(stationaryPeriodicAccuracy, other.stationaryPeriodicAccuracy) && _deepEquals(speedWakeConfirmCount, other.speedWakeConfirmCount);
   }
 
   @override
@@ -1353,8 +1248,7 @@ class TlGeofenceConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlGeofenceConfig decode(Object result) {
     result as List<Object?>;
@@ -1375,16 +1269,7 @@ class TlGeofenceConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(
-          geofenceModeHighAccuracy,
-          other.geofenceModeHighAccuracy,
-        ) &&
-        _deepEquals(
-          geofenceInitialTriggerEntry,
-          other.geofenceInitialTriggerEntry,
-        ) &&
-        _deepEquals(geofenceProximityRadius, other.geofenceProximityRadius) &&
-        _deepEquals(geofenceInitialTrigger, other.geofenceInitialTrigger);
+    return _deepEquals(geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) && _deepEquals(geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && _deepEquals(geofenceProximityRadius, other.geofenceProximityRadius) && _deepEquals(geofenceInitialTrigger, other.geofenceInitialTrigger);
   }
 
   @override
@@ -1418,8 +1303,7 @@ class TlPersistenceConfig {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlPersistenceConfig decode(Object result) {
     result as List<Object?>;
@@ -1440,13 +1324,7 @@ class TlPersistenceConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(persistMode, other.persistMode) &&
-        _deepEquals(maxDaysToPersist, other.maxDaysToPersist) &&
-        _deepEquals(maxRecordsToPersist, other.maxRecordsToPersist) &&
-        _deepEquals(
-          disableProviderChangeRecord,
-          other.disableProviderChangeRecord,
-        );
+    return _deepEquals(persistMode, other.persistMode) && _deepEquals(maxDaysToPersist, other.maxDaysToPersist) && _deepEquals(maxRecordsToPersist, other.maxRecordsToPersist) && _deepEquals(disableProviderChangeRecord, other.disableProviderChangeRecord);
   }
 
   @override
@@ -1455,19 +1333,24 @@ class TlPersistenceConfig {
 }
 
 class TlAuditConfig {
-  TlAuditConfig({required this.enabled, required this.hashAlgorithm});
+  TlAuditConfig({
+    required this.enabled,
+    required this.hashAlgorithm,
+  });
 
   bool enabled;
 
   TlHashAlgorithm hashAlgorithm;
 
   List<Object?> _toList() {
-    return <Object?>[enabled, hashAlgorithm];
+    return <Object?>[
+      enabled,
+      hashAlgorithm,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlAuditConfig decode(Object result) {
     result as List<Object?>;
@@ -1486,8 +1369,7 @@ class TlAuditConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) &&
-        _deepEquals(hashAlgorithm, other.hashAlgorithm);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(hashAlgorithm, other.hashAlgorithm);
   }
 
   @override
@@ -1496,21 +1378,26 @@ class TlAuditConfig {
 }
 
 class TlPrivacyZoneConfig {
-  TlPrivacyZoneConfig({required this.enabled});
+  TlPrivacyZoneConfig({
+    required this.enabled,
+  });
 
   bool enabled;
 
   List<Object?> _toList() {
-    return <Object?>[enabled];
+    return <Object?>[
+      enabled,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlPrivacyZoneConfig decode(Object result) {
     result as List<Object?>;
-    return TlPrivacyZoneConfig(enabled: result[0]! as bool);
+    return TlPrivacyZoneConfig(
+      enabled: result[0]! as bool,
+    );
   }
 
   @override
@@ -1531,21 +1418,26 @@ class TlPrivacyZoneConfig {
 }
 
 class TlSecurityConfig {
-  TlSecurityConfig({required this.encryptDatabase});
+  TlSecurityConfig({
+    required this.encryptDatabase,
+  });
 
   bool encryptDatabase;
 
   List<Object?> _toList() {
-    return <Object?>[encryptDatabase];
+    return <Object?>[
+      encryptDatabase,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlSecurityConfig decode(Object result) {
     result as List<Object?>;
-    return TlSecurityConfig(encryptDatabase: result[0]! as bool);
+    return TlSecurityConfig(
+      encryptDatabase: result[0]! as bool,
+    );
   }
 
   @override
@@ -1566,19 +1458,24 @@ class TlSecurityConfig {
 }
 
 class TlAttestationConfig {
-  TlAttestationConfig({required this.enabled, required this.refreshInterval});
+  TlAttestationConfig({
+    required this.enabled,
+    required this.refreshInterval,
+  });
 
   bool enabled;
 
   int refreshInterval;
 
   List<Object?> _toList() {
-    return <Object?>[enabled, refreshInterval];
+    return <Object?>[
+      enabled,
+      refreshInterval,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlAttestationConfig decode(Object result) {
     result as List<Object?>;
@@ -1597,8 +1494,215 @@ class TlAttestationConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) &&
-        _deepEquals(refreshInterval, other.refreshInterval);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(refreshInterval, other.refreshInterval);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// Driving-behavior (telematics) event detection config. See `TelematicsEngine`.
+class TlTelematicsConfig {
+  TlTelematicsConfig({
+    required this.enableDrivingEvents,
+    required this.harshBrakingG,
+    required this.harshAccelerationG,
+    required this.harshCorneringG,
+    required this.speedLimitKmh,
+    required this.speedingToleranceKmh,
+    required this.speedingMinDurationMs,
+    required this.minSpeedForEventsKmh,
+    required this.eventDebounceMs,
+  });
+
+  bool enableDrivingEvents;
+
+  double harshBrakingG;
+
+  double harshAccelerationG;
+
+  double harshCorneringG;
+
+  double speedLimitKmh;
+
+  double speedingToleranceKmh;
+
+  int speedingMinDurationMs;
+
+  double minSpeedForEventsKmh;
+
+  int eventDebounceMs;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      enableDrivingEvents,
+      harshBrakingG,
+      harshAccelerationG,
+      harshCorneringG,
+      speedLimitKmh,
+      speedingToleranceKmh,
+      speedingMinDurationMs,
+      minSpeedForEventsKmh,
+      eventDebounceMs,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static TlTelematicsConfig decode(Object result) {
+    result as List<Object?>;
+    return TlTelematicsConfig(
+      enableDrivingEvents: result[0]! as bool,
+      harshBrakingG: result[1]! as double,
+      harshAccelerationG: result[2]! as double,
+      harshCorneringG: result[3]! as double,
+      speedLimitKmh: result[4]! as double,
+      speedingToleranceKmh: result[5]! as double,
+      speedingMinDurationMs: result[6]! as int,
+      minSpeedForEventsKmh: result[7]! as double,
+      eventDebounceMs: result[8]! as int,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! TlTelematicsConfig || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(enableDrivingEvents, other.enableDrivingEvents) && _deepEquals(harshBrakingG, other.harshBrakingG) && _deepEquals(harshAccelerationG, other.harshAccelerationG) && _deepEquals(harshCorneringG, other.harshCorneringG) && _deepEquals(speedLimitKmh, other.speedLimitKmh) && _deepEquals(speedingToleranceKmh, other.speedingToleranceKmh) && _deepEquals(speedingMinDurationMs, other.speedingMinDurationMs) && _deepEquals(minSpeedForEventsKmh, other.minSpeedForEventsKmh) && _deepEquals(eventDebounceMs, other.eventDebounceMs);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// On-device transport-mode classifier config. See `TransportModeClassifier`.
+class TlClassifierConfig {
+  TlClassifierConfig({
+    required this.enableFusedClassifier,
+    required this.fusedClassifierAuthoritative,
+    required this.modeSwitchDwellMs,
+    required this.minModeConfidence,
+  });
+
+  bool enableFusedClassifier;
+
+  bool fusedClassifierAuthoritative;
+
+  int modeSwitchDwellMs;
+
+  double minModeConfidence;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      enableFusedClassifier,
+      fusedClassifierAuthoritative,
+      modeSwitchDwellMs,
+      minModeConfidence,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static TlClassifierConfig decode(Object result) {
+    result as List<Object?>;
+    return TlClassifierConfig(
+      enableFusedClassifier: result[0]! as bool,
+      fusedClassifierAuthoritative: result[1]! as bool,
+      modeSwitchDwellMs: result[2]! as int,
+      minModeConfidence: result[3]! as double,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! TlClassifierConfig || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(enableFusedClassifier, other.enableFusedClassifier) && _deepEquals(fusedClassifierAuthoritative, other.fusedClassifierAuthoritative) && _deepEquals(modeSwitchDwellMs, other.modeSwitchDwellMs) && _deepEquals(minModeConfidence, other.minModeConfidence);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// Crash & fall detection config. See `ImpactDetector`.
+class TlImpactConfig {
+  TlImpactConfig({
+    required this.enableCrashDetection,
+    required this.enableFallDetection,
+    required this.crashGThreshold,
+    required this.crashMinSpeedKmh,
+    required this.fallGThreshold,
+    required this.confirmWindowMs,
+    required this.minImpactConfidence,
+  });
+
+  bool enableCrashDetection;
+
+  bool enableFallDetection;
+
+  double crashGThreshold;
+
+  double crashMinSpeedKmh;
+
+  double fallGThreshold;
+
+  int confirmWindowMs;
+
+  double minImpactConfidence;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      enableCrashDetection,
+      enableFallDetection,
+      crashGThreshold,
+      crashMinSpeedKmh,
+      fallGThreshold,
+      confirmWindowMs,
+      minImpactConfidence,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static TlImpactConfig decode(Object result) {
+    result as List<Object?>;
+    return TlImpactConfig(
+      enableCrashDetection: result[0]! as bool,
+      enableFallDetection: result[1]! as bool,
+      crashGThreshold: result[2]! as double,
+      crashMinSpeedKmh: result[3]! as double,
+      fallGThreshold: result[4]! as double,
+      confirmWindowMs: result[5]! as int,
+      minImpactConfidence: result[6]! as double,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! TlImpactConfig || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(enableCrashDetection, other.enableCrashDetection) && _deepEquals(enableFallDetection, other.enableFallDetection) && _deepEquals(crashGThreshold, other.crashGThreshold) && _deepEquals(crashMinSpeedKmh, other.crashMinSpeedKmh) && _deepEquals(fallGThreshold, other.fallGThreshold) && _deepEquals(confirmWindowMs, other.confirmWindowMs) && _deepEquals(minImpactConfidence, other.minImpactConfidence);
   }
 
   @override
@@ -1660,8 +1764,7 @@ class TlCoords {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlCoords decode(Object result) {
     result as List<Object?>;
@@ -1689,17 +1792,7 @@ class TlCoords {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(latitude, other.latitude) &&
-        _deepEquals(longitude, other.longitude) &&
-        _deepEquals(accuracy, other.accuracy) &&
-        _deepEquals(speed, other.speed) &&
-        _deepEquals(heading, other.heading) &&
-        _deepEquals(altitude, other.altitude) &&
-        _deepEquals(altitudeAccuracy, other.altitudeAccuracy) &&
-        _deepEquals(speedAccuracy, other.speedAccuracy) &&
-        _deepEquals(headingAccuracy, other.headingAccuracy) &&
-        _deepEquals(ellipsoidalAltitude, other.ellipsoidalAltitude) &&
-        _deepEquals(floor, other.floor);
+    return _deepEquals(latitude, other.latitude) && _deepEquals(longitude, other.longitude) && _deepEquals(accuracy, other.accuracy) && _deepEquals(speed, other.speed) && _deepEquals(heading, other.heading) && _deepEquals(altitude, other.altitude) && _deepEquals(altitudeAccuracy, other.altitudeAccuracy) && _deepEquals(speedAccuracy, other.speedAccuracy) && _deepEquals(headingAccuracy, other.headingAccuracy) && _deepEquals(ellipsoidalAltitude, other.ellipsoidalAltitude) && _deepEquals(floor, other.floor);
   }
 
   @override
@@ -1708,19 +1801,24 @@ class TlCoords {
 }
 
 class TlBattery {
-  TlBattery({required this.level, required this.isCharging});
+  TlBattery({
+    required this.level,
+    required this.isCharging,
+  });
 
   double level;
 
   bool isCharging;
 
   List<Object?> _toList() {
-    return <Object?>[level, isCharging];
+    return <Object?>[
+      level,
+      isCharging,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlBattery decode(Object result) {
     result as List<Object?>;
@@ -1739,8 +1837,7 @@ class TlBattery {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(level, other.level) &&
-        _deepEquals(isCharging, other.isCharging);
+    return _deepEquals(level, other.level) && _deepEquals(isCharging, other.isCharging);
   }
 
   @override
@@ -1768,12 +1865,17 @@ class TlAddress {
   String? country;
 
   List<Object?> _toList() {
-    return <Object?>[street, city, state, postalCode, country];
+    return <Object?>[
+      street,
+      city,
+      state,
+      postalCode,
+      country,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlAddress decode(Object result) {
     result as List<Object?>;
@@ -1795,11 +1897,7 @@ class TlAddress {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(street, other.street) &&
-        _deepEquals(city, other.city) &&
-        _deepEquals(state, other.state) &&
-        _deepEquals(postalCode, other.postalCode) &&
-        _deepEquals(country, other.country);
+    return _deepEquals(street, other.street) && _deepEquals(city, other.city) && _deepEquals(state, other.state) && _deepEquals(postalCode, other.postalCode) && _deepEquals(country, other.country);
   }
 
   @override
@@ -1857,8 +1955,7 @@ class TlLocation {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlLocation decode(Object result) {
     result as List<Object?>;
@@ -1885,16 +1982,7 @@ class TlLocation {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(coords, other.coords) &&
-        _deepEquals(battery, other.battery) &&
-        _deepEquals(timestamp, other.timestamp) &&
-        _deepEquals(uuid, other.uuid) &&
-        _deepEquals(isMoving, other.isMoving) &&
-        _deepEquals(odometer, other.odometer) &&
-        _deepEquals(event, other.event) &&
-        _deepEquals(activity, other.activity) &&
-        _deepEquals(extras, other.extras) &&
-        _deepEquals(address, other.address);
+    return _deepEquals(coords, other.coords) && _deepEquals(battery, other.battery) && _deepEquals(timestamp, other.timestamp) && _deepEquals(uuid, other.uuid) && _deepEquals(isMoving, other.isMoving) && _deepEquals(odometer, other.odometer) && _deepEquals(event, other.event) && _deepEquals(activity, other.activity) && _deepEquals(extras, other.extras) && _deepEquals(address, other.address);
   }
 
   @override
@@ -1903,19 +1991,24 @@ class TlLocation {
 }
 
 class TlActivity {
-  TlActivity({required this.type, required this.confidence});
+  TlActivity({
+    required this.type,
+    required this.confidence,
+  });
 
   String type;
 
   int confidence;
 
   List<Object?> _toList() {
-    return <Object?>[type, confidence];
+    return <Object?>[
+      type,
+      confidence,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlActivity decode(Object result) {
     result as List<Object?>;
@@ -1934,8 +2027,7 @@ class TlActivity {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(type, other.type) &&
-        _deepEquals(confidence, other.confidence);
+    return _deepEquals(type, other.type) && _deepEquals(confidence, other.confidence);
   }
 
   @override
@@ -1977,8 +2069,7 @@ class TlState {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlState decode(Object result) {
     result as List<Object?>;
@@ -2001,12 +2092,7 @@ class TlState {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) &&
-        _deepEquals(isMoving, other.isMoving) &&
-        _deepEquals(trackingMode, other.trackingMode) &&
-        _deepEquals(schedulerEnabled, other.schedulerEnabled) &&
-        _deepEquals(odometer, other.odometer) &&
-        _deepEquals(lastLocationTimestamp, other.lastLocationTimestamp);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(isMoving, other.isMoving) && _deepEquals(trackingMode, other.trackingMode) && _deepEquals(schedulerEnabled, other.schedulerEnabled) && _deepEquals(odometer, other.odometer) && _deepEquals(lastLocationTimestamp, other.lastLocationTimestamp);
   }
 
   @override
@@ -2064,8 +2150,7 @@ class TlGeofence {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlGeofence decode(Object result) {
     result as List<Object?>;
@@ -2092,16 +2177,7 @@ class TlGeofence {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(identifier, other.identifier) &&
-        _deepEquals(latitude, other.latitude) &&
-        _deepEquals(longitude, other.longitude) &&
-        _deepEquals(radius, other.radius) &&
-        _deepEquals(notifyOnEntry, other.notifyOnEntry) &&
-        _deepEquals(notifyOnExit, other.notifyOnExit) &&
-        _deepEquals(notifyOnDwell, other.notifyOnDwell) &&
-        _deepEquals(loiteringDelay, other.loiteringDelay) &&
-        _deepEquals(extras, other.extras) &&
-        _deepEquals(vertices, other.vertices);
+    return _deepEquals(identifier, other.identifier) && _deepEquals(latitude, other.latitude) && _deepEquals(longitude, other.longitude) && _deepEquals(radius, other.radius) && _deepEquals(notifyOnEntry, other.notifyOnEntry) && _deepEquals(notifyOnExit, other.notifyOnExit) && _deepEquals(notifyOnDwell, other.notifyOnDwell) && _deepEquals(loiteringDelay, other.loiteringDelay) && _deepEquals(extras, other.extras) && _deepEquals(vertices, other.vertices);
   }
 
   @override
@@ -2126,12 +2202,16 @@ class TlGeofenceEvent {
   Map<String?, Object?>? extras;
 
   List<Object?> _toList() {
-    return <Object?>[identifier, action, location, extras];
+    return <Object?>[
+      identifier,
+      action,
+      location,
+      extras,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlGeofenceEvent decode(Object result) {
     result as List<Object?>;
@@ -2152,10 +2232,7 @@ class TlGeofenceEvent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(identifier, other.identifier) &&
-        _deepEquals(action, other.action) &&
-        _deepEquals(location, other.location) &&
-        _deepEquals(extras, other.extras);
+    return _deepEquals(identifier, other.identifier) && _deepEquals(action, other.action) && _deepEquals(location, other.location) && _deepEquals(extras, other.extras);
   }
 
   @override
@@ -2177,12 +2254,15 @@ class TlHttpEvent {
   String responseText;
 
   List<Object?> _toList() {
-    return <Object?>[isSuccess, status, responseText];
+    return <Object?>[
+      isSuccess,
+      status,
+      responseText,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlHttpEvent decode(Object result) {
     result as List<Object?>;
@@ -2202,9 +2282,7 @@ class TlHttpEvent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(isSuccess, other.isSuccess) &&
-        _deepEquals(status, other.status) &&
-        _deepEquals(responseText, other.responseText);
+    return _deepEquals(isSuccess, other.isSuccess) && _deepEquals(status, other.status) && _deepEquals(responseText, other.responseText);
   }
 
   @override
@@ -2232,12 +2310,17 @@ class TlProviderChangeEvent {
   int? accuracyAuthorization;
 
   List<Object?> _toList() {
-    return <Object?>[enabled, gps, network, status, accuracyAuthorization];
+    return <Object?>[
+      enabled,
+      gps,
+      network,
+      status,
+      accuracyAuthorization,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlProviderChangeEvent decode(Object result) {
     result as List<Object?>;
@@ -2259,11 +2342,7 @@ class TlProviderChangeEvent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(enabled, other.enabled) &&
-        _deepEquals(gps, other.gps) &&
-        _deepEquals(network, other.network) &&
-        _deepEquals(status, other.status) &&
-        _deepEquals(accuracyAuthorization, other.accuracyAuthorization);
+    return _deepEquals(enabled, other.enabled) && _deepEquals(gps, other.gps) && _deepEquals(network, other.network) && _deepEquals(status, other.status) && _deepEquals(accuracyAuthorization, other.accuracyAuthorization);
   }
 
   @override
@@ -2305,8 +2384,7 @@ class TlCurrentPositionOptions {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlCurrentPositionOptions decode(Object result) {
     result as List<Object?>;
@@ -2323,19 +2401,13 @@ class TlCurrentPositionOptions {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! TlCurrentPositionOptions ||
-        other.runtimeType != runtimeType) {
+    if (other is! TlCurrentPositionOptions || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(desiredAccuracy, other.desiredAccuracy) &&
-        _deepEquals(timeout, other.timeout) &&
-        _deepEquals(maximumAge, other.maximumAge) &&
-        _deepEquals(persist, other.persist) &&
-        _deepEquals(samples, other.samples) &&
-        _deepEquals(extras, other.extras);
+    return _deepEquals(desiredAccuracy, other.desiredAccuracy) && _deepEquals(timeout, other.timeout) && _deepEquals(maximumAge, other.maximumAge) && _deepEquals(persist, other.persist) && _deepEquals(samples, other.samples) && _deepEquals(extras, other.extras);
   }
 
   @override
@@ -2344,19 +2416,24 @@ class TlCurrentPositionOptions {
 }
 
 class TlActivityChangeEvent {
-  TlActivityChangeEvent({required this.activity, required this.confidence});
+  TlActivityChangeEvent({
+    required this.activity,
+    required this.confidence,
+  });
 
   String activity;
 
   int confidence;
 
   List<Object?> _toList() {
-    return <Object?>[activity, confidence];
+    return <Object?>[
+      activity,
+      confidence,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlActivityChangeEvent decode(Object result) {
     result as List<Object?>;
@@ -2375,8 +2452,7 @@ class TlActivityChangeEvent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(activity, other.activity) &&
-        _deepEquals(confidence, other.confidence);
+    return _deepEquals(activity, other.activity) && _deepEquals(confidence, other.confidence);
   }
 
   @override
@@ -2385,19 +2461,24 @@ class TlActivityChangeEvent {
 }
 
 class TlGeofencesChangeEvent {
-  TlGeofencesChangeEvent({this.on, this.off});
+  TlGeofencesChangeEvent({
+    this.on,
+    this.off,
+  });
 
   List<TlGeofence?>? on;
 
   List<TlGeofence?>? off;
 
   List<Object?> _toList() {
-    return <Object?>[on, off];
+    return <Object?>[
+      on,
+      off,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlGeofencesChangeEvent decode(Object result) {
     result as List<Object?>;
@@ -2425,21 +2506,26 @@ class TlGeofencesChangeEvent {
 }
 
 class TlHeartbeatEvent {
-  TlHeartbeatEvent({required this.location});
+  TlHeartbeatEvent({
+    required this.location,
+  });
 
   TlLocation location;
 
   List<Object?> _toList() {
-    return <Object?>[location];
+    return <Object?>[
+      location,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlHeartbeatEvent decode(Object result) {
     result as List<Object?>;
-    return TlHeartbeatEvent(location: result[0]! as TlLocation);
+    return TlHeartbeatEvent(
+      location: result[0]! as TlLocation,
+    );
   }
 
   @override
@@ -2477,12 +2563,15 @@ class TlSpeedMotionEvent {
   TlTrackingMode trackingMode;
 
   List<Object?> _toList() {
-    return <Object?>[state, previousState, trackingMode];
+    return <Object?>[
+      state,
+      previousState,
+      trackingMode,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlSpeedMotionEvent decode(Object result) {
     result as List<Object?>;
@@ -2502,9 +2591,7 @@ class TlSpeedMotionEvent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(state, other.state) &&
-        _deepEquals(previousState, other.previousState) &&
-        _deepEquals(trackingMode, other.trackingMode);
+    return _deepEquals(state, other.state) && _deepEquals(previousState, other.previousState) && _deepEquals(trackingMode, other.trackingMode);
   }
 
   @override
@@ -2526,12 +2613,15 @@ class TlAuthorizationEvent {
   String response;
 
   List<Object?> _toList() {
-    return <Object?>[success, status, response];
+    return <Object?>[
+      success,
+      status,
+      response,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlAuthorizationEvent decode(Object result) {
     result as List<Object?>;
@@ -2551,9 +2641,7 @@ class TlAuthorizationEvent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(success, other.success) &&
-        _deepEquals(status, other.status) &&
-        _deepEquals(response, other.response);
+    return _deepEquals(success, other.success) && _deepEquals(status, other.status) && _deepEquals(response, other.response);
   }
 
   @override
@@ -2562,28 +2650,32 @@ class TlAuthorizationEvent {
 }
 
 class TlConnectivityChangeEvent {
-  TlConnectivityChangeEvent({required this.connected});
+  TlConnectivityChangeEvent({
+    required this.connected,
+  });
 
   bool connected;
 
   List<Object?> _toList() {
-    return <Object?>[connected];
+    return <Object?>[
+      connected,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static TlConnectivityChangeEvent decode(Object result) {
     result as List<Object?>;
-    return TlConnectivityChangeEvent(connected: result[0]! as bool);
+    return TlConnectivityChangeEvent(
+      connected: result[0]! as bool,
+    );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! TlConnectivityChangeEvent ||
-        other.runtimeType != runtimeType) {
+    if (other is! TlConnectivityChangeEvent || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -2597,6 +2689,7 @@ class TlConnectivityChangeEvent {
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
 
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -2604,161 +2697,170 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is TlDesiredAccuracy) {
+    }    else if (value is TlDesiredAccuracy) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is TlTrackingMode) {
+    }    else if (value is TlTrackingMode) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    } else if (value is TlMotionDetectionMode) {
+    }    else if (value is TlMotionDetectionMode) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    } else if (value is TlStationaryTrackingMode) {
+    }    else if (value is TlStationaryTrackingMode) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    } else if (value is TlGeofenceAction) {
+    }    else if (value is TlGeofenceAction) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is TlAuthorizationStatus) {
+    }    else if (value is TlAuthorizationStatus) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is TlMotionAuthorizationStatus) {
+    }    else if (value is TlMotionAuthorizationStatus) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    } else if (value is TlNotificationAuthorizationStatus) {
+    }    else if (value is TlNotificationAuthorizationStatus) {
       buffer.putUint8(136);
       writeValue(buffer, value.index);
-    } else if (value is TlHttpMethod) {
+    }    else if (value is TlHttpMethod) {
       buffer.putUint8(137);
       writeValue(buffer, value.index);
-    } else if (value is TlIosActivityType) {
+    }    else if (value is TlIosActivityType) {
       buffer.putUint8(138);
       writeValue(buffer, value.index);
-    } else if (value is TlNotificationPriority) {
+    }    else if (value is TlNotificationPriority) {
       buffer.putUint8(139);
       writeValue(buffer, value.index);
-    } else if (value is TlLocationFilterPolicy) {
+    }    else if (value is TlLocationFilterPolicy) {
       buffer.putUint8(140);
       writeValue(buffer, value.index);
-    } else if (value is TlLocationOrderDirection) {
+    }    else if (value is TlLocationOrderDirection) {
       buffer.putUint8(141);
       writeValue(buffer, value.index);
-    } else if (value is TlLocationActivityType) {
+    }    else if (value is TlLocationActivityType) {
       buffer.putUint8(142);
       writeValue(buffer, value.index);
-    } else if (value is TlLogLevel) {
+    }    else if (value is TlLogLevel) {
       buffer.putUint8(143);
       writeValue(buffer, value.index);
-    } else if (value is TlPersistMode) {
+    }    else if (value is TlPersistMode) {
       buffer.putUint8(144);
       writeValue(buffer, value.index);
-    } else if (value is TlHashAlgorithm) {
+    }    else if (value is TlHashAlgorithm) {
       buffer.putUint8(145);
       writeValue(buffer, value.index);
-    } else if (value is TlAuthorizationRequest) {
+    }    else if (value is TlAuthorizationRequest) {
       buffer.putUint8(146);
       writeValue(buffer, value.index);
-    } else if (value is TlSpeedMotionState) {
+    }    else if (value is TlSpeedMotionState) {
       buffer.putUint8(147);
       writeValue(buffer, value.index);
-    } else if (value is TlLocationFilter) {
+    }    else if (value is TlLocationFilter) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is TlGeoConfig) {
+    }    else if (value is TlGeoConfig) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is TlAppConfig) {
+    }    else if (value is TlAppConfig) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is TlForegroundServiceConfig) {
+    }    else if (value is TlForegroundServiceConfig) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is TlAndroidConfig) {
+    }    else if (value is TlAndroidConfig) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is TlIosConfig) {
+    }    else if (value is TlIosConfig) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is TlHttpConfig) {
+    }    else if (value is TlHttpConfig) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is TlConfig) {
+    }    else if (value is TlConfig) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is TlLoggerConfig) {
+    }    else if (value is TlLoggerConfig) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is TlMotionConfig) {
+    }    else if (value is TlMotionConfig) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is TlGeofenceConfig) {
+    }    else if (value is TlGeofenceConfig) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is TlPersistenceConfig) {
+    }    else if (value is TlPersistenceConfig) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is TlAuditConfig) {
+    }    else if (value is TlAuditConfig) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is TlPrivacyZoneConfig) {
+    }    else if (value is TlPrivacyZoneConfig) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is TlSecurityConfig) {
+    }    else if (value is TlSecurityConfig) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is TlAttestationConfig) {
+    }    else if (value is TlAttestationConfig) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is TlCoords) {
+    }    else if (value is TlTelematicsConfig) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is TlBattery) {
+    }    else if (value is TlClassifierConfig) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is TlAddress) {
+    }    else if (value is TlImpactConfig) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is TlLocation) {
+    }    else if (value is TlCoords) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is TlActivity) {
+    }    else if (value is TlBattery) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is TlState) {
+    }    else if (value is TlAddress) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is TlGeofence) {
+    }    else if (value is TlLocation) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is TlGeofenceEvent) {
+    }    else if (value is TlActivity) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is TlHttpEvent) {
+    }    else if (value is TlState) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is TlProviderChangeEvent) {
+    }    else if (value is TlGeofence) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is TlCurrentPositionOptions) {
+    }    else if (value is TlGeofenceEvent) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is TlActivityChangeEvent) {
+    }    else if (value is TlHttpEvent) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is TlGeofencesChangeEvent) {
+    }    else if (value is TlProviderChangeEvent) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is TlHeartbeatEvent) {
+    }    else if (value is TlCurrentPositionOptions) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is TlSpeedMotionEvent) {
+    }    else if (value is TlActivityChangeEvent) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is TlAuthorizationEvent) {
+    }    else if (value is TlGeofencesChangeEvent) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is TlConnectivityChangeEvent) {
+    }    else if (value is TlHeartbeatEvent) {
       buffer.putUint8(180);
+      writeValue(buffer, value.encode());
+    }    else if (value is TlSpeedMotionEvent) {
+      buffer.putUint8(181);
+      writeValue(buffer, value.encode());
+    }    else if (value is TlAuthorizationEvent) {
+      buffer.putUint8(182);
+      writeValue(buffer, value.encode());
+    }    else if (value is TlConnectivityChangeEvent) {
+      buffer.putUint8(183);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2791,9 +2893,7 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : TlMotionAuthorizationStatus.values[value];
       case 136:
         final value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : TlNotificationAuthorizationStatus.values[value];
+        return value == null ? null : TlNotificationAuthorizationStatus.values[value];
       case 137:
         final value = readValue(buffer) as int?;
         return value == null ? null : TlHttpMethod.values[value];
@@ -2860,38 +2960,44 @@ class _PigeonCodec extends StandardMessageCodec {
       case 163:
         return TlAttestationConfig.decode(readValue(buffer)!);
       case 164:
-        return TlCoords.decode(readValue(buffer)!);
+        return TlTelematicsConfig.decode(readValue(buffer)!);
       case 165:
-        return TlBattery.decode(readValue(buffer)!);
+        return TlClassifierConfig.decode(readValue(buffer)!);
       case 166:
-        return TlAddress.decode(readValue(buffer)!);
+        return TlImpactConfig.decode(readValue(buffer)!);
       case 167:
-        return TlLocation.decode(readValue(buffer)!);
+        return TlCoords.decode(readValue(buffer)!);
       case 168:
-        return TlActivity.decode(readValue(buffer)!);
+        return TlBattery.decode(readValue(buffer)!);
       case 169:
-        return TlState.decode(readValue(buffer)!);
+        return TlAddress.decode(readValue(buffer)!);
       case 170:
-        return TlGeofence.decode(readValue(buffer)!);
+        return TlLocation.decode(readValue(buffer)!);
       case 171:
-        return TlGeofenceEvent.decode(readValue(buffer)!);
+        return TlActivity.decode(readValue(buffer)!);
       case 172:
-        return TlHttpEvent.decode(readValue(buffer)!);
+        return TlState.decode(readValue(buffer)!);
       case 173:
-        return TlProviderChangeEvent.decode(readValue(buffer)!);
+        return TlGeofence.decode(readValue(buffer)!);
       case 174:
-        return TlCurrentPositionOptions.decode(readValue(buffer)!);
+        return TlGeofenceEvent.decode(readValue(buffer)!);
       case 175:
-        return TlActivityChangeEvent.decode(readValue(buffer)!);
+        return TlHttpEvent.decode(readValue(buffer)!);
       case 176:
-        return TlGeofencesChangeEvent.decode(readValue(buffer)!);
+        return TlProviderChangeEvent.decode(readValue(buffer)!);
       case 177:
-        return TlHeartbeatEvent.decode(readValue(buffer)!);
+        return TlCurrentPositionOptions.decode(readValue(buffer)!);
       case 178:
-        return TlSpeedMotionEvent.decode(readValue(buffer)!);
+        return TlActivityChangeEvent.decode(readValue(buffer)!);
       case 179:
-        return TlAuthorizationEvent.decode(readValue(buffer)!);
+        return TlGeofencesChangeEvent.decode(readValue(buffer)!);
       case 180:
+        return TlHeartbeatEvent.decode(readValue(buffer)!);
+      case 181:
+        return TlSpeedMotionEvent.decode(readValue(buffer)!);
+      case 182:
+        return TlAuthorizationEvent.decode(readValue(buffer)!);
+      case 183:
         return TlConnectivityChangeEvent.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -2903,13 +3009,9 @@ class TraceletHostApi {
   /// Constructor for [TraceletHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  TraceletHostApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  TraceletHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -2917,8 +3019,7 @@ class TraceletHostApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> requestStateFlush() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestStateFlush$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestStateFlush$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -2928,36 +3029,34 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
   }
 
   Future<TlState> ready(TlConfig config) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.ready$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.ready$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[config],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[config]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> start() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.start$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.start$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -2967,16 +3066,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> stop() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stop$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stop$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -2986,16 +3085,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> startGeofences() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startGeofences$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startGeofences$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3005,16 +3104,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> startPeriodic() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startPeriodic$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startPeriodic$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3024,16 +3123,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> getState() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getState$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getState$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3043,167 +3142,149 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> setConfig(TlConfig config) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setConfig$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setConfig$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[config],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[config]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> reset(TlConfig? config) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.reset$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.reset$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[config],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[config]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
-  Future<TlLocation> getCurrentPosition(
-    TlCurrentPositionOptions options,
-  ) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getCurrentPosition$pigeonVar_messageChannelSuffix';
+  Future<TlLocation> getCurrentPosition(TlCurrentPositionOptions options) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getCurrentPosition$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[options],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[options]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlLocation;
   }
 
-  Future<TlLocation?> getLastKnownLocation(
-    TlCurrentPositionOptions? options,
-  ) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getLastKnownLocation$pigeonVar_messageChannelSuffix';
+  Future<TlLocation?> getLastKnownLocation(TlCurrentPositionOptions? options) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getLastKnownLocation$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[options],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[options]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
     return pigeonVar_replyValue as TlLocation?;
   }
 
   Future<int> watchPosition(TlCurrentPositionOptions options) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.watchPosition$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.watchPosition$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[options],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[options]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as int;
   }
 
   Future<bool> stopWatchPosition(int watchId) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stopWatchPosition$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stopWatchPosition$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[watchId],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[watchId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> changePace(bool isMoving) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.changePace$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.changePace$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[isMoving],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[isMoving]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<double> getOdometer() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getOdometer$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getOdometer$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3213,100 +3294,92 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as double;
   }
 
   Future<TlLocation> setOdometer(double value) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setOdometer$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setOdometer$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[value],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlLocation;
   }
 
   Future<bool> addGeofence(TlGeofence geofence) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addGeofence$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addGeofence$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[geofence],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[geofence]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> addGeofences(List<TlGeofence> geofences) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addGeofences$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addGeofences$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[geofences],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[geofences]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> removeGeofence(String identifier) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removeGeofence$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removeGeofence$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[identifier],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[identifier]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> removeGeofences() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removeGeofences$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removeGeofences$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3316,16 +3389,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<List<TlGeofence?>> getGeofences() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getGeofences$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getGeofences$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3335,121 +3408,111 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return (pigeonVar_replyValue! as List<Object?>).cast<TlGeofence?>();
   }
 
   Future<TlGeofence?> getGeofence(String identifier) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getGeofence$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getGeofence$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[identifier],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[identifier]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
     return pigeonVar_replyValue as TlGeofence?;
   }
 
   Future<bool> geofenceExists(String identifier) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.geofenceExists$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.geofenceExists$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[identifier],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[identifier]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<List<TlLocation?>> getLocations(Map<String?, Object?>? query) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getLocations$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getLocations$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[query],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[query]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return (pigeonVar_replyValue! as List<Object?>).cast<TlLocation?>();
   }
 
   Future<int> getCount(Map<String?, Object?>? query) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getCount$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getCount$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[query],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[query]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as int;
   }
 
   Future<String> insertLocation(Map<String?, Object?> params) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.insertLocation$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.insertLocation$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[params],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[params]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as String;
   }
 
   Future<bool> destroyLocations() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroyLocations$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroyLocations$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3459,16 +3522,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<int> destroySyncedLocations() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroySyncedLocations$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroySyncedLocations$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3478,37 +3541,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as int;
   }
 
   Future<bool> destroyLocation(String uuid) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroyLocation$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroyLocation$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[uuid],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<List<TlLocation?>> sync() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.sync$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.sync$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3518,58 +3579,54 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return (pigeonVar_replyValue! as List<Object?>).cast<TlLocation?>();
   }
 
   Future<bool> setDynamicHeaders(Map<String?, String?> headers) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setDynamicHeaders$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setDynamicHeaders$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[headers],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[headers]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> setRouteContext(Map<String?, Object?> context) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setRouteContext$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.setRouteContext$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[context],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[context]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> clearRouteContext() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.clearRouteContext$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.clearRouteContext$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3579,58 +3636,54 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> registerHeadlessHeadersCallback(List<int?> callbackIds) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.registerHeadlessHeadersCallback$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.registerHeadlessHeadersCallback$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[callbackIds],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callbackIds]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> registerHeadlessSyncBodyBuilder(List<int?> callbackIds) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.registerHeadlessSyncBodyBuilder$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.registerHeadlessSyncBodyBuilder$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[callbackIds],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callbackIds]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<TlAuthorizationStatus> getPermissionStatus() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getPermissionStatus$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getPermissionStatus$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3640,16 +3693,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlAuthorizationStatus;
   }
 
   Future<TlAuthorizationStatus> requestPermission() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestPermission$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestPermission$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3659,17 +3712,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlAuthorizationStatus;
   }
 
-  Future<TlNotificationAuthorizationStatus>
-  getNotificationPermissionStatus() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getNotificationPermissionStatus$pigeonVar_messageChannelSuffix';
+  Future<TlNotificationAuthorizationStatus> getNotificationPermissionStatus() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getNotificationPermissionStatus$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3679,17 +3731,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlNotificationAuthorizationStatus;
   }
 
-  Future<TlNotificationAuthorizationStatus>
-  requestNotificationPermission() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestNotificationPermission$pigeonVar_messageChannelSuffix';
+  Future<TlNotificationAuthorizationStatus> requestNotificationPermission() async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestNotificationPermission$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3699,16 +3750,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlNotificationAuthorizationStatus;
   }
 
   Future<bool> canScheduleExactAlarms() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.canScheduleExactAlarms$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.canScheduleExactAlarms$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3718,16 +3769,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> openExactAlarmSettings() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.openExactAlarmSettings$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.openExactAlarmSettings$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3737,16 +3788,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<TlMotionAuthorizationStatus> getMotionPermissionStatus() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getMotionPermissionStatus$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getMotionPermissionStatus$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3756,16 +3807,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlMotionAuthorizationStatus;
   }
 
   Future<TlMotionAuthorizationStatus> requestMotionPermission() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestMotionPermission$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestMotionPermission$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3775,37 +3826,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlMotionAuthorizationStatus;
   }
 
   Future<int> requestTemporaryFullAccuracy(String purpose) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestTemporaryFullAccuracy$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestTemporaryFullAccuracy$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[purpose],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[purpose]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as int;
   }
 
   Future<bool> isPowerSaveMode() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.isPowerSaveMode$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.isPowerSaveMode$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3815,16 +3864,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<TlProviderChangeEvent> getProviderState() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getProviderState$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getProviderState$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3834,16 +3883,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlProviderChangeEvent;
   }
 
   Future<Map<String?, Object?>> getDeviceInfo() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getDeviceInfo$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getDeviceInfo$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3853,59 +3902,54 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
-    return (pigeonVar_replyValue! as Map<Object?, Object?>)
-        .cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return (pigeonVar_replyValue! as Map<Object?, Object?>).cast<String?, Object?>();
   }
 
   Future<bool> log(String level, String message) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.log$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.log$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[level, message],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[level, message]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> playSound(String name) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.playSound$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.playSound$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[name],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[name]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> isIgnoringBatteryOptimizations() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.isIgnoringBatteryOptimizations$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.isIgnoringBatteryOptimizations$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3915,58 +3959,54 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> requestSettings(String action) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestSettings$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.requestSettings$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[action],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[action]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> showSettings(String action) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.showSettings$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.showSettings$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[action],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[action]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<TlState> startSchedule() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startSchedule$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startSchedule$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3976,16 +4016,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<TlState> stopSchedule() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stopSchedule$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stopSchedule$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -3995,37 +4035,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as TlState;
   }
 
   Future<bool> registerHeadlessTask(List<int?> callbackIds) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.registerHeadlessTask$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.registerHeadlessTask$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[callbackIds],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callbackIds]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<int> startBackgroundTask() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startBackgroundTask$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.startBackgroundTask$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4035,37 +4073,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as int;
   }
 
   Future<int> stopBackgroundTask(int taskId) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stopBackgroundTask$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.stopBackgroundTask$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[taskId],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[taskId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as int;
   }
 
   Future<Map<String?, Object?>> getSensors() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getSensors$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getSensors$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4075,17 +4111,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
-    return (pigeonVar_replyValue! as Map<Object?, Object?>)
-        .cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return (pigeonVar_replyValue! as Map<Object?, Object?>).cast<String?, Object?>();
   }
 
   Future<Map<String?, Object?>> getSettingsHealth() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getSettingsHealth$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getSettingsHealth$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4095,38 +4130,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
-    return (pigeonVar_replyValue! as Map<Object?, Object?>)
-        .cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return (pigeonVar_replyValue! as Map<Object?, Object?>).cast<String?, Object?>();
   }
 
   Future<bool> openOemSettings(String label) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.openOemSettings$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.openOemSettings$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[label],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[label]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> showPowerManager() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.showPowerManager$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.showPowerManager$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4136,37 +4168,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<String> getLog(Map<String?, Object?>? query) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getLog$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getLog$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[query],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[query]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as String;
   }
 
   Future<bool> destroyLog() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroyLog$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.destroyLog$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4176,37 +4206,35 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> emailLog(String email) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.emailLog$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.emailLog$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[email],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[email]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<Map<String?, Object?>> verifyAuditTrail() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.verifyAuditTrail$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.verifyAuditTrail$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4216,102 +4244,92 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
-    return (pigeonVar_replyValue! as Map<Object?, Object?>)
-        .cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return (pigeonVar_replyValue! as Map<Object?, Object?>).cast<String?, Object?>();
   }
 
   Future<Map<String?, Object?>?> getAuditProof(String uuid) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getAuditProof$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getAuditProof$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[uuid],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uuid]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
-    return (pigeonVar_replyValue as Map<Object?, Object?>?)
-        ?.cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+    return (pigeonVar_replyValue as Map<Object?, Object?>?)?.cast<String?, Object?>();
   }
 
   Future<bool> addPrivacyZone(Map<String?, Object?> zone) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addPrivacyZone$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addPrivacyZone$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[zone],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[zone]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> addPrivacyZones(List<Map<String?, Object?>?> zones) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addPrivacyZones$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.addPrivacyZones$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[zones],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[zones]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> removePrivacyZone(String identifier) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removePrivacyZone$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removePrivacyZone$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[identifier],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[identifier]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> removePrivacyZones() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removePrivacyZones$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.removePrivacyZones$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4321,16 +4339,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<List<Object?>> getPrivacyZones() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getPrivacyZones$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getPrivacyZones$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4340,16 +4358,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as List<Object?>;
   }
 
   Future<bool> isDatabaseEncrypted() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.isDatabaseEncrypted$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.isDatabaseEncrypted$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4359,16 +4377,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<bool> encryptDatabase() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.encryptDatabase$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.encryptDatabase$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4378,16 +4396,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as bool;
   }
 
   Future<Map<String?, Object?>?> getAttestationToken() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getAttestationToken$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getAttestationToken$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4397,17 +4415,16 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
-    return (pigeonVar_replyValue as Map<Object?, Object?>?)
-        ?.cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+    return (pigeonVar_replyValue as Map<Object?, Object?>?)?.cast<String?, Object?>();
   }
 
   Future<Map<String?, Object?>?> getDeadReckoningState() async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getDeadReckoningState$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getDeadReckoningState$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -4417,36 +4434,31 @@ class TraceletHostApi {
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
-    return (pigeonVar_replyValue as Map<Object?, Object?>?)
-        ?.cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+    return (pigeonVar_replyValue as Map<Object?, Object?>?)?.cast<String?, Object?>();
   }
 
-  Future<Map<String?, Object?>> getCarbonReport(
-    Map<String?, Object?>? query,
-  ) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getCarbonReport$pigeonVar_messageChannelSuffix';
+  Future<Map<String?, Object?>> getCarbonReport(Map<String?, Object?>? query) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.getCarbonReport$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[query],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[query]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
-    return (pigeonVar_replyValue! as Map<Object?, Object?>)
-        .cast<String?, Object?>();
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return (pigeonVar_replyValue! as Map<Object?, Object?>).cast<String?, Object?>();
   }
 }
 
@@ -4457,46 +4469,33 @@ abstract class TraceletFlutterApi {
 
   Future<Map<String?, String?>> onHeadlessHeaders();
 
-  static void setUp(
-    TraceletFlutterApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+  static void setUp(TraceletFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletFlutterApi.onHeadlessEvent$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletFlutterApi.onHeadlessEvent$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final Map<String?, Object?> arg_event =
-              (args[0]! as Map<Object?, Object?>).cast<String?, Object?>();
+          final Map<String?, Object?> arg_event = (args[0]! as Map<Object?, Object?>).cast<String?, Object?>();
           try {
             api.onHeadlessEvent(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletFlutterApi.onHeadlessHeaders$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletFlutterApi.onHeadlessHeaders$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4506,10 +4505,8 @@ abstract class TraceletFlutterApi {
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4552,20 +4549,12 @@ abstract class TraceletEventApi {
 
   void onWatchPosition(TlLocation location);
 
-  static void setUp(
-    TraceletEventApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+  static void setUp(TraceletEventApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onLocation$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onLocation$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4577,20 +4566,16 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onMotionChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onMotionChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4602,20 +4587,16 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onMotionModeChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onMotionModeChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4627,72 +4608,58 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onActivityChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onActivityChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final TlActivityChangeEvent arg_event =
-              args[0]! as TlActivityChangeEvent;
+          final TlActivityChangeEvent arg_event = args[0]! as TlActivityChangeEvent;
           try {
             api.onActivityChange(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onProviderChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onProviderChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final TlProviderChangeEvent arg_event =
-              args[0]! as TlProviderChangeEvent;
+          final TlProviderChangeEvent arg_event = args[0]! as TlProviderChangeEvent;
           try {
             api.onProviderChange(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onGeofence$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onGeofence$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4704,46 +4671,37 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onGeofencesChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onGeofencesChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final TlGeofencesChangeEvent arg_event =
-              args[0]! as TlGeofencesChangeEvent;
+          final TlGeofencesChangeEvent arg_event = args[0]! as TlGeofencesChangeEvent;
           try {
             api.onGeofencesChange(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onHeartbeat$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onHeartbeat$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4755,20 +4713,16 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onHttp$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onHttp$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4780,20 +4734,16 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onSchedule$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onSchedule$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4805,20 +4755,16 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onPowerSaveChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onPowerSaveChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4830,46 +4776,37 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onConnectivityChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onConnectivityChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final TlConnectivityChangeEvent arg_event =
-              args[0]! as TlConnectivityChangeEvent;
+          final TlConnectivityChangeEvent arg_event = args[0]! as TlConnectivityChangeEvent;
           try {
             api.onConnectivityChange(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onEnabledChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onEnabledChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4881,20 +4818,16 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onNotificationAction$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onNotificationAction$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4906,46 +4839,37 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onAuthorization$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onAuthorization$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final TlAuthorizationEvent arg_event =
-              args[0]! as TlAuthorizationEvent;
+          final TlAuthorizationEvent arg_event = args[0]! as TlAuthorizationEvent;
           try {
             api.onAuthorization(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onWatchPosition$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onWatchPosition$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4957,10 +4881,8 @@ abstract class TraceletEventApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
+++ b/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
@@ -2689,6 +2689,204 @@ class TlConnectivityChangeEvent {
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
 
+/// A driving-behavior event (harsh brake/accel/cornering/speeding).
+class TlDrivingEvent {
+  TlDrivingEvent({
+    required this.kind,
+    required this.severity,
+    required this.speed,
+    required this.value,
+    required this.latitude,
+    required this.longitude,
+    required this.timestampMs,
+  });
+
+  String kind;
+
+  double severity;
+
+  double speed;
+
+  double value;
+
+  double latitude;
+
+  double longitude;
+
+  int timestampMs;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      kind,
+      severity,
+      speed,
+      value,
+      latitude,
+      longitude,
+      timestampMs,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static TlDrivingEvent decode(Object result) {
+    result as List<Object?>;
+    return TlDrivingEvent(
+      kind: result[0]! as String,
+      severity: result[1]! as double,
+      speed: result[2]! as double,
+      value: result[3]! as double,
+      latitude: result[4]! as double,
+      longitude: result[5]! as double,
+      timestampMs: result[6]! as int,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! TlDrivingEvent || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(kind, other.kind) && _deepEquals(severity, other.severity) && _deepEquals(speed, other.speed) && _deepEquals(value, other.value) && _deepEquals(latitude, other.latitude) && _deepEquals(longitude, other.longitude) && _deepEquals(timestampMs, other.timestampMs);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// A crash/fall impact event (`potential_crash`/`crash`/`potential_fall`/`fall`).
+class TlImpactEvent {
+  TlImpactEvent({
+    required this.kind,
+    required this.id,
+    required this.confidence,
+    required this.peakG,
+    required this.speedBefore,
+    required this.latitude,
+    required this.longitude,
+    required this.timestampMs,
+    required this.confirmDeadlineMs,
+  });
+
+  String kind;
+
+  int id;
+
+  double confidence;
+
+  double peakG;
+
+  double speedBefore;
+
+  double latitude;
+
+  double longitude;
+
+  int timestampMs;
+
+  int confirmDeadlineMs;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      kind,
+      id,
+      confidence,
+      peakG,
+      speedBefore,
+      latitude,
+      longitude,
+      timestampMs,
+      confirmDeadlineMs,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static TlImpactEvent decode(Object result) {
+    result as List<Object?>;
+    return TlImpactEvent(
+      kind: result[0]! as String,
+      id: result[1]! as int,
+      confidence: result[2]! as double,
+      peakG: result[3]! as double,
+      speedBefore: result[4]! as double,
+      latitude: result[5]! as double,
+      longitude: result[6]! as double,
+      timestampMs: result[7]! as int,
+      confirmDeadlineMs: result[8]! as int,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! TlImpactEvent || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(kind, other.kind) && _deepEquals(id, other.id) && _deepEquals(confidence, other.confidence) && _deepEquals(peakG, other.peakG) && _deepEquals(speedBefore, other.speedBefore) && _deepEquals(latitude, other.latitude) && _deepEquals(longitude, other.longitude) && _deepEquals(timestampMs, other.timestampMs) && _deepEquals(confirmDeadlineMs, other.confirmDeadlineMs);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// A fused transport-mode change.
+class TlModeChangeEvent {
+  TlModeChangeEvent({
+    required this.mode,
+    required this.confidence,
+  });
+
+  String mode;
+
+  double confidence;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      mode,
+      confidence,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static TlModeChangeEvent decode(Object result) {
+    result as List<Object?>;
+    return TlModeChangeEvent(
+      mode: result[0]! as String,
+      confidence: result[1]! as double,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! TlModeChangeEvent || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(mode, other.mode) && _deepEquals(confidence, other.confidence);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -2862,6 +3060,15 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is TlConnectivityChangeEvent) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
+    }    else if (value is TlDrivingEvent) {
+      buffer.putUint8(184);
+      writeValue(buffer, value.encode());
+    }    else if (value is TlImpactEvent) {
+      buffer.putUint8(185);
+      writeValue(buffer, value.encode());
+    }    else if (value is TlModeChangeEvent) {
+      buffer.putUint8(186);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -2999,6 +3206,12 @@ class _PigeonCodec extends StandardMessageCodec {
         return TlAuthorizationEvent.decode(readValue(buffer)!);
       case 183:
         return TlConnectivityChangeEvent.decode(readValue(buffer)!);
+      case 184:
+        return TlDrivingEvent.decode(readValue(buffer)!);
+      case 185:
+        return TlImpactEvent.decode(readValue(buffer)!);
+      case 186:
+        return TlModeChangeEvent.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -3272,6 +3485,46 @@ class TraceletHostApi {
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[isMoving]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as bool;
+  }
+
+  /// Confirms a pending impact candidate (by [id]) as a real emergency now.
+  Future<bool> confirmImpact(int id) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.confirmImpact$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[id]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as bool;
+  }
+
+  /// Cancels a pending impact candidate (by [id]) — no confirmed event fires.
+  Future<bool> cancelImpact(int id) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.cancelImpact$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[id]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -4549,6 +4802,12 @@ abstract class TraceletEventApi {
 
   void onWatchPosition(TlLocation location);
 
+  void onDrivingEvent(TlDrivingEvent event);
+
+  void onImpact(TlImpactEvent event);
+
+  void onModeChange(TlModeChangeEvent event);
+
   static void setUp(TraceletEventApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
@@ -4878,6 +5137,69 @@ abstract class TraceletEventApi {
           final TlLocation arg_location = args[0]! as TlLocation;
           try {
             api.onWatchPosition(arg_location);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onDrivingEvent$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final TlDrivingEvent arg_event = args[0]! as TlDrivingEvent;
+          try {
+            api.onDrivingEvent(arg_event);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onImpact$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final TlImpactEvent arg_event = args[0]! as TlImpactEvent;
+          try {
+            api.onImpact(arg_event);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.tracelet_platform_interface.TraceletEventApi.onModeChange$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final TlModeChangeEvent arg_event = args[0]! as TlModeChangeEvent;
+          try {
+            api.onModeChange(arg_event);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/tracelet_platform_interface/lib/src/pigeon_event_receiver.dart
+++ b/packages/tracelet_platform_interface/lib/src/pigeon_event_receiver.dart
@@ -36,6 +36,9 @@ class PigeonEventReceiver implements TraceletEventApi {
   final _notificationActionCtrl = StreamController<String>.broadcast();
   final _authorizationCtrl = StreamController<TlAuthorizationEvent>.broadcast();
   final _watchPositionCtrl = StreamController<TlLocation>.broadcast();
+  final _drivingEventCtrl = StreamController<TlDrivingEvent>.broadcast();
+  final _impactCtrl = StreamController<TlImpactEvent>.broadcast();
+  final _modeChangeCtrl = StreamController<TlModeChangeEvent>.broadcast();
 
   // ---------------------------------------------------------------------------
   // Public streams
@@ -98,6 +101,15 @@ class PigeonEventReceiver implements TraceletEventApi {
   /// Stream of high-frequency locations from `watchPosition`.
   Stream<TlLocation> get watchPositionEvents => _watchPositionCtrl.stream;
 
+  /// Stream of driving-behavior events (harsh brake/accel/cornering/speeding).
+  Stream<TlDrivingEvent> get drivingEvents => _drivingEventCtrl.stream;
+
+  /// Stream of crash/fall impact events.
+  Stream<TlImpactEvent> get impactEvents => _impactCtrl.stream;
+
+  /// Stream of fused transport-mode changes.
+  Stream<TlModeChangeEvent> get modeChangeEvents => _modeChangeCtrl.stream;
+
   // ---------------------------------------------------------------------------
   // TraceletEventApi implementation (called by native via Pigeon)
   // ---------------------------------------------------------------------------
@@ -154,6 +166,15 @@ class PigeonEventReceiver implements TraceletEventApi {
   @override
   void onWatchPosition(TlLocation location) => _watchPositionCtrl.add(location);
 
+  @override
+  void onDrivingEvent(TlDrivingEvent event) => _drivingEventCtrl.add(event);
+
+  @override
+  void onImpact(TlImpactEvent event) => _impactCtrl.add(event);
+
+  @override
+  void onModeChange(TlModeChangeEvent event) => _modeChangeCtrl.add(event);
+
   /// Called by native when the speed-based motion state machine transitions.
   ///
   /// Forwards the typed [TlSpeedMotionEvent] (state, previousState,
@@ -180,5 +201,8 @@ class PigeonEventReceiver implements TraceletEventApi {
     _authorizationCtrl.close();
     _watchPositionCtrl.close();
     _motionModeChangeCtrl.close();
+    _drivingEventCtrl.close();
+    _impactCtrl.close();
+    _modeChangeCtrl.close();
   }
 }

--- a/packages/tracelet_platform_interface/lib/src/pigeon_tracelet.dart
+++ b/packages/tracelet_platform_interface/lib/src/pigeon_tracelet.dart
@@ -216,6 +216,12 @@ class PigeonTracelet extends TraceletPlatform {
   Future<bool> changePace(bool isMoving) => _api.changePace(isMoving);
 
   @override
+  Future<bool> confirmImpact(int id) => _api.confirmImpact(id);
+
+  @override
+  Future<bool> cancelImpact(int id) => _api.cancelImpact(id);
+
+  @override
   Future<double> getOdometer() => _api.getOdometer();
 
   @override
@@ -678,6 +684,24 @@ class PigeonTracelet extends TraceletPlatform {
   Stream<TlLocation> get watchPositionEvents {
     _ensureEventsRegistered();
     return _events.watchPositionEvents;
+  }
+
+  @override
+  Stream<TlDrivingEvent> get drivingEvents {
+    _ensureEventsRegistered();
+    return _events.drivingEvents;
+  }
+
+  @override
+  Stream<TlImpactEvent> get impactEvents {
+    _ensureEventsRegistered();
+    return _events.impactEvents;
+  }
+
+  @override
+  Stream<TlModeChangeEvent> get modeChangeEvents {
+    _ensureEventsRegistered();
+    return _events.modeChangeEvents;
   }
 
   @override

--- a/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
+++ b/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
@@ -141,6 +141,16 @@ abstract class TraceletPlatform extends PlatformInterface {
     throw UnimplementedError('changePace() has not been implemented.');
   }
 
+  /// Confirms a pending impact candidate as a real emergency.
+  Future<bool> confirmImpact(int id) {
+    throw UnimplementedError('confirmImpact() has not been implemented.');
+  }
+
+  /// Cancels a pending impact candidate.
+  Future<bool> cancelImpact(int id) {
+    throw UnimplementedError('cancelImpact() has not been implemented.');
+  }
+
   /// Get the current odometer value in meters.
   Future<double> getOdometer() {
     throw UnimplementedError('getOdometer() has not been implemented.');
@@ -765,6 +775,21 @@ abstract class TraceletPlatform extends PlatformInterface {
   /// Stream of watchPosition events.
   Stream<TlLocation> get watchPositionEvents {
     throw UnimplementedError('watchPositionEvents has not been implemented.');
+  }
+
+  /// Stream of driving-behavior events (harsh brake/accel/cornering/speeding).
+  Stream<TlDrivingEvent> get drivingEvents {
+    throw UnimplementedError('drivingEvents has not been implemented.');
+  }
+
+  /// Stream of crash/fall impact events.
+  Stream<TlImpactEvent> get impactEvents {
+    throw UnimplementedError('impactEvents has not been implemented.');
+  }
+
+  /// Stream of fused transport-mode changes.
+  Stream<TlModeChangeEvent> get modeChangeEvents {
+    throw UnimplementedError('modeChangeEvents has not been implemented.');
   }
 
   /// Stream of speed-based motion mode change events.

--- a/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
+++ b/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
@@ -717,6 +717,60 @@ class TlConnectivityChangeEvent {
   final bool connected;
 }
 
+/// A driving-behavior event (harsh brake/accel/cornering/speeding).
+class TlDrivingEvent {
+  TlDrivingEvent({
+    required this.kind,
+    required this.severity,
+    required this.speed,
+    required this.value,
+    required this.latitude,
+    required this.longitude,
+    required this.timestampMs,
+  });
+  final String kind;
+  final double severity;
+  final double speed;
+  final double value;
+  final double latitude;
+  final double longitude;
+  final int timestampMs;
+}
+
+/// A crash/fall impact event (`potential_crash`/`crash`/`potential_fall`/`fall`).
+class TlImpactEvent {
+  TlImpactEvent({
+    required this.kind,
+    required this.id,
+    required this.confidence,
+    required this.peakG,
+    required this.speedBefore,
+    required this.latitude,
+    required this.longitude,
+    required this.timestampMs,
+    required this.confirmDeadlineMs,
+  });
+  final String kind;
+  final int id;
+  final double confidence;
+  final double peakG;
+  final double speedBefore;
+  final double latitude;
+  final double longitude;
+  final int timestampMs;
+  final int confirmDeadlineMs;
+}
+
+/// A fused transport-mode change.
+class TlModeChangeEvent {
+  TlModeChangeEvent({
+    required this.mode,
+    required this.confidence,
+  });
+  final String mode;
+  final double confidence;
+}
+
 // =============================================================================
 // Host API
 // =============================================================================
@@ -763,6 +817,12 @@ abstract class TraceletHostApi {
 
   @async
   bool changePace(bool isMoving);
+
+  /// Confirms a pending impact candidate (by [id]) as a real emergency now.
+  bool confirmImpact(int id);
+
+  /// Cancels a pending impact candidate (by [id]) — no confirmed event fires.
+  bool cancelImpact(int id);
 
   @async
   double getOdometer();
@@ -981,4 +1041,7 @@ abstract class TraceletEventApi {
   void onNotificationAction(String action);
   void onAuthorization(TlAuthorizationEvent event);
   void onWatchPosition(TlLocation location);
+  void onDrivingEvent(TlDrivingEvent event);
+  void onImpact(TlImpactEvent event);
+  void onModeChange(TlModeChangeEvent event);
 }

--- a/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
+++ b/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
@@ -279,6 +279,9 @@ class TlConfig {
     required this.privacyZone,
     required this.security,
     required this.attestation,
+    required this.telematics,
+    required this.classifier,
+    required this.impact,
   });
 
   final TlGeoConfig geo;
@@ -294,6 +297,9 @@ class TlConfig {
   final TlPrivacyZoneConfig privacyZone;
   final TlSecurityConfig security;
   final TlAttestationConfig attestation;
+  final TlTelematicsConfig telematics;
+  final TlClassifierConfig classifier;
+  final TlImpactConfig impact;
 }
 
 class TlLoggerConfig {
@@ -400,6 +406,64 @@ class TlAttestationConfig {
   TlAttestationConfig({required this.enabled, required this.refreshInterval});
   final bool enabled;
   final int refreshInterval;
+}
+
+/// Driving-behavior (telematics) event detection config. See `TelematicsEngine`.
+class TlTelematicsConfig {
+  TlTelematicsConfig({
+    required this.enableDrivingEvents,
+    required this.harshBrakingG,
+    required this.harshAccelerationG,
+    required this.harshCorneringG,
+    required this.speedLimitKmh,
+    required this.speedingToleranceKmh,
+    required this.speedingMinDurationMs,
+    required this.minSpeedForEventsKmh,
+    required this.eventDebounceMs,
+  });
+  final bool enableDrivingEvents;
+  final double harshBrakingG;
+  final double harshAccelerationG;
+  final double harshCorneringG;
+  final double speedLimitKmh;
+  final double speedingToleranceKmh;
+  final int speedingMinDurationMs;
+  final double minSpeedForEventsKmh;
+  final int eventDebounceMs;
+}
+
+/// On-device transport-mode classifier config. See `TransportModeClassifier`.
+class TlClassifierConfig {
+  TlClassifierConfig({
+    required this.enableFusedClassifier,
+    required this.fusedClassifierAuthoritative,
+    required this.modeSwitchDwellMs,
+    required this.minModeConfidence,
+  });
+  final bool enableFusedClassifier;
+  final bool fusedClassifierAuthoritative;
+  final int modeSwitchDwellMs;
+  final double minModeConfidence;
+}
+
+/// Crash & fall detection config. See `ImpactDetector`.
+class TlImpactConfig {
+  TlImpactConfig({
+    required this.enableCrashDetection,
+    required this.enableFallDetection,
+    required this.crashGThreshold,
+    required this.crashMinSpeedKmh,
+    required this.fallGThreshold,
+    required this.confirmWindowMs,
+    required this.minImpactConfidence,
+  });
+  final bool enableCrashDetection;
+  final bool enableFallDetection;
+  final double crashGThreshold;
+  final double crashMinSpeedKmh;
+  final double fallGThreshold;
+  final int confirmWindowMs;
+  final double minImpactConfidence;
 }
 
 enum TlLogLevel { off, error, warn, info, debug, verbose }

--- a/packages/tracelet_platform_interface/pubspec.yaml
+++ b/packages/tracelet_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracelet_platform_interface
 description: >-
   A common platform interface for the Tracelet background geolocation plugin.
   Used by tracelet_android and tracelet_ios implementations.
-version: 3.2.19
+version: 3.3.0
 topics:
   - location
   - background

--- a/packages/tracelet_supabase/CHANGELOG.md
+++ b/packages/tracelet_supabase/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_supabase/pubspec.yaml
+++ b/packages/tracelet_supabase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_supabase
 description: >-
   Supabase adapter for Tracelet. Automatically configures Tracelet's native HTTP sync to push locations to Supabase and manages background auth token refresh.
-version: 3.2.19
+version: 3.3.0
 topics:
   - supabase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.2.19
-  tracelet_sync: ^3.2.19
+  tracelet: ^3.3.0
+  tracelet_sync: ^3.3.0
   supabase_flutter: '^2.12.4'
 
   meta: ^1.18.0

--- a/packages/tracelet_sync/CHANGELOG.md
+++ b/packages/tracelet_sync/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_sync/pubspec.yaml
+++ b/packages/tracelet_sync/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_sync
 description: Offline SQLite persistence and automatic HTTP synchronization engine for Tracelet.
-version: 3.2.19
+version: 3.3.0
 homepage: https://github.com/ikolvi/tracelet
 documentation: https://tracelet.ikolvi.com
 repository: https://github.com/ikolvi/tracelet/tree/main/packages/tracelet_sync
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.2.19
+  tracelet: ^3.3.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_web/CHANGELOG.md
+++ b/packages/tracelet_web/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+* **FEAT** (Driving & Safety): On-device driving-behavior telematics — `harsh_braking` / `harsh_acceleration` / `harsh_cornering` / `speeding` via `TelematicsConfig` + `Tracelet.onDrivingEvent` (opt-in, default off) ([#163](https://github.com/Ikolvi/Tracelet/issues/163)).
+* **FEAT** (Driving & Safety): On-device transport-mode classifier (still/walking/running/cycling/vehicle) fusing accelerometer + GPS via `ClassifierConfig` + `Tracelet.onModeChange` ([#164](https://github.com/Ikolvi/Tracelet/issues/164)).
+* **FEAT** (Driving & Safety): Crash & fall detection with a cancel-countdown confirmation flow via `ImpactConfig` + `Tracelet.onImpact` and `Tracelet.confirmImpact` / `Tracelet.cancelImpact` (opt-in, default off) ([#165](https://github.com/Ikolvi/Tracelet/issues/165)).
+* All three features are **default-off** and side-channel — no change to existing tracking when disabled. See [Driving & Safety](https://github.com/Ikolvi/Tracelet/blob/main/help/DRIVING-AND-SAFETY.md).
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/packages/tracelet_web/pubspec.yaml
+++ b/packages/tracelet_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_web
 description: Web implementation of the Tracelet background geolocation plugin.
-version: 3.2.19
+version: 3.3.0
 topics:
   - location
   - background
@@ -28,7 +28,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  tracelet_platform_interface: ^3.2.19
+  tracelet_platform_interface: ^3.3.0
   web: ^1.1.1
 
 dev_dependencies:

--- a/sdk/android/CHANGELOG.md
+++ b/sdk/android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+* **FEAT**: Native runtime for the 3.3.0 behavior engines — TelematicsEngine (driving events), TransportModeClassifier (fused transport mode), and ImpactDetector (crash/fall) wired into the location + accelerometer pipeline. All opt-in / default-off. ([#163](https://github.com/Ikolvi/Tracelet/issues/163), [#164](https://github.com/Ikolvi/Tracelet/issues/164), [#165](https://github.com/Ikolvi/Tracelet/issues/165))
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
@@ -178,7 +178,7 @@ class ConfigManager(context: Context) {
 
         // Dart sends a nested structure: {geo: {...}, app: {...}, http: {...}, ...}
         // Flatten known section sub-maps into the top level first.
-        val sectionKeys = setOf("geo", "app", "android", "http", "logger", "motion", "geofence", "persistence", "audit", "privacyZone", "security")
+        val sectionKeys = setOf("geo", "app", "android", "http", "logger", "motion", "geofence", "persistence", "audit", "privacyZone", "security", "telematics", "classifier", "impact")
         val flat = mutableMapOf<String, Any?>()
         for ((key, value) in newConfig) {
             if (key in sectionKeys && value is Map<*, *>) {
@@ -768,6 +768,33 @@ class ConfigManager(context: Context) {
 
     fun getBatteryBudgetPerHour(): Double =
         getDouble("batteryBudgetPerHour", 0.0)
+
+    // ---------------------------------------------------------------------------
+    // Telematics / classifier / impact (3.3.0)
+    // ---------------------------------------------------------------------------
+
+    fun getEnableDrivingEvents(): Boolean = getBool("enableDrivingEvents", false)
+    fun getHarshBrakingG(): Double = getDouble("harshBrakingG", 0.40)
+    fun getHarshAccelerationG(): Double = getDouble("harshAccelerationG", 0.35)
+    fun getHarshCorneringG(): Double = getDouble("harshCorneringG", 0.40)
+    fun getSpeedLimitKmh(): Double = getDouble("speedLimitKmh", 0.0)
+    fun getSpeedingToleranceKmh(): Double = getDouble("speedingToleranceKmh", 5.0)
+    fun getSpeedingMinDurationMs(): Long = getInt("speedingMinDurationMs", 3000).toLong()
+    fun getMinSpeedForEventsKmh(): Double = getDouble("minSpeedForEventsKmh", 5.0)
+    fun getEventDebounceMs(): Long = getInt("eventDebounceMs", 2000).toLong()
+
+    fun getEnableFusedClassifier(): Boolean = getBool("enableFusedClassifier", false)
+    fun getFusedClassifierAuthoritative(): Boolean = getBool("fusedClassifierAuthoritative", false)
+    fun getModeSwitchDwellMs(): Long = getInt("modeSwitchDwellMs", 8000).toLong()
+    fun getMinModeConfidence(): Double = getDouble("minModeConfidence", 0.6)
+
+    fun getEnableCrashDetection(): Boolean = getBool("enableCrashDetection", false)
+    fun getEnableFallDetection(): Boolean = getBool("enableFallDetection", false)
+    fun getCrashGThreshold(): Double = getDouble("crashGThreshold", 3.0)
+    fun getCrashMinSpeedKmh(): Double = getDouble("crashMinSpeedKmh", 25.0)
+    fun getFallGThreshold(): Double = getDouble("fallGThreshold", 2.5)
+    fun getConfirmWindowMs(): Long = getInt("confirmWindowMs", 15000).toLong()
+    fun getMinImpactConfidence(): Double = getDouble("minImpactConfidence", 0.6)
 
     // ---------------------------------------------------------------------------
     // Private helpers

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ListenerEventSender.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ListenerEventSender.kt
@@ -103,6 +103,15 @@ internal class ListenerEventSender : TraceletEventSender {
     override fun sendBudgetAdjustment(data: Map<String, Any?>) =
         dispatch("budgetadjustment", data) { listener?.onBudgetAdjustment(data) }
 
+    override fun sendDrivingEvent(data: Map<String, Any?>) =
+        dispatch("drivingevent", data) { listener?.onDrivingEvent(data) }
+
+    override fun sendImpact(data: Map<String, Any?>) =
+        dispatch("impact", data) { listener?.onImpact(data) }
+
+    override fun sendModeChange(data: Map<String, Any?>) =
+        dispatch("modechange", data) { listener?.onModeChange(data) }
+
     override fun hasListener(eventName: String): Boolean = listener != null
 
     private inline fun dispatch(

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletEventSender.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletEventSender.kt
@@ -47,6 +47,12 @@ interface TraceletEventSender {
 
     fun sendBudgetAdjustment(data: Map<String, Any?>)
 
+    fun sendDrivingEvent(data: Map<String, Any?>)
+
+    fun sendImpact(data: Map<String, Any?>)
+
+    fun sendModeChange(data: Map<String, Any?>)
+
     /** Returns true if a listener is attached for the given event name. */
     fun hasListener(eventName: String): Boolean
 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletListener.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletListener.kt
@@ -63,4 +63,13 @@ interface TraceletListener {
 
     /** Called when the battery budget engine adjusts parameters. */
     fun onBudgetAdjustment(data: Map<String, Any?>) {}
+
+    /** Called for driving-behavior events (harsh brake/accel/cornering/speeding). */
+    fun onDrivingEvent(data: Map<String, Any?>) {}
+
+    /** Called for crash/fall impact events. */
+    fun onImpact(data: Map<String, Any?>) {}
+
+    /** Called when the fused transport mode changes. */
+    fun onModeChange(data: Map<String, Any?>) {}
 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -127,6 +127,19 @@ class TraceletSdk private constructor(private val context: Context) {
     private var batteryBudgetEngine: BatteryBudgetEngine? = null
     private var batteryBudgetRunnable: Runnable? = null
 
+    // 3.3.0 behavior engines (opt-in, default off)
+    private var telematicsEngine: uniffi.tracelet_core.TelematicsEngine? = null
+    private var transportClassifier: uniffi.tracelet_core.TransportModeClassifier? = null
+    private var impactDetector: uniffi.tracelet_core.ImpactDetector? = null
+    private val accelBuffer = java.util.Collections.synchronizedList(mutableListOf<Double>())
+    private var accelWindowRunnable: Runnable? = null
+    private var impactConfirmRunnable: Runnable? = null
+    @Volatile private var lastSpeedMps: Double = 0.0
+    @Volatile private var lastLat: Double = 0.0
+    @Volatile private var lastLng: Double = 0.0
+    private val accelWindowMs = 1000L
+    private val impactConfirmPollMs = 1000L
+
     var activity: Activity? = null
     var isReady: Boolean = false
         private set
@@ -285,6 +298,7 @@ class TraceletSdk private constructor(private val context: Context) {
         locationEngine.registerSink(object : com.ikolvi.tracelet.sdk.location.LocationDataSink {
             override fun insertLocation(location: Map<String, Any?>) {
                 this@TraceletSdk.insertLocation(location)
+                processTelematics(location)
             }
         })
 
@@ -312,6 +326,13 @@ class TraceletSdk private constructor(private val context: Context) {
         // no motion-state transition occurs (#155).
         motionDetector.onActivityChanged = { type, confidence ->
             locationEngine.setCurrentActivity(type, confidence)
+        }
+        // 3.3.0: feed accelerometer samples (g) to the classifier/impact window
+        // keystone — only buffers while a consumer engine is active.
+        motionDetector.onAccelSample = { magnitudeG ->
+            if (transportClassifier != null || impactDetector != null) {
+                accelBuffer.add(magnitudeG)
+            }
         }
         motionDetector.onStopRequested = {
             mainHandler.post {
@@ -566,6 +587,8 @@ class TraceletSdk private constructor(private val context: Context) {
             batteryBudgetEngine = null
         }
 
+        initBehaviorEngines()
+
         isReady = true
         syncConfigToRustFlat()
         checkSyncProvider()
@@ -749,6 +772,7 @@ class TraceletSdk private constructor(private val context: Context) {
         startHeartbeat()
         startStopAfterElapsedTimer()
         startBatteryBudgetSampling()
+        startBehaviorSampling()
 
         eventSender.sendEnabledChange(true)
         logger.info("start() — tracking started")
@@ -775,6 +799,8 @@ class TraceletSdk private constructor(private val context: Context) {
         if (::tripManager.isInitialized) tripManager.reset()
         stopBatteryBudgetSampling()
         batteryBudgetEngine?.reset()
+        stopBehaviorSampling()
+        telematicsEngine?.reset()
 
         PeriodicLocationWorker.cancel(context)
         PeriodicLocationWorker.eventSender = null
@@ -2011,6 +2037,195 @@ class TraceletSdk private constructor(private val context: Context) {
         syncIntervalRunnable?.let { mainHandler.removeCallbacks(it) }
         syncIntervalRunnable = null
     }
+
+    // =========================================================================
+    // 3.3.0 behavior engines: telematics, transport-mode classifier, impact
+    // =========================================================================
+
+    /** Instantiates the opt-in behavior engines from config. */
+    private fun initBehaviorEngines() {
+        telematicsEngine = if (configManager.getEnableDrivingEvents()) {
+            uniffi.tracelet_core.TelematicsEngine(
+                uniffi.tracelet_core.TelematicsConfig(
+                    harshBrakingG = configManager.getHarshBrakingG(),
+                    harshAccelerationG = configManager.getHarshAccelerationG(),
+                    harshCorneringG = configManager.getHarshCorneringG(),
+                    speedLimitKmh = configManager.getSpeedLimitKmh(),
+                    speedingToleranceKmh = configManager.getSpeedingToleranceKmh(),
+                    speedingMinDurationMs = configManager.getSpeedingMinDurationMs(),
+                    minSpeedForEventsKmh = configManager.getMinSpeedForEventsKmh(),
+                    eventDebounceMs = configManager.getEventDebounceMs(),
+                ),
+            )
+        } else {
+            null
+        }
+
+        transportClassifier = if (configManager.getEnableFusedClassifier()) {
+            uniffi.tracelet_core.TransportModeClassifier(
+                uniffi.tracelet_core.ClassifierConfig(
+                    modeSwitchDwellMs = configManager.getModeSwitchDwellMs(),
+                    minConfidence = configManager.getMinModeConfidence(),
+                ),
+            )
+        } else {
+            null
+        }
+
+        impactDetector = if (configManager.getEnableCrashDetection() ||
+            configManager.getEnableFallDetection()
+        ) {
+            uniffi.tracelet_core.ImpactDetector(
+                uniffi.tracelet_core.ImpactConfig(
+                    enableCrash = configManager.getEnableCrashDetection(),
+                    enableFall = configManager.getEnableFallDetection(),
+                    crashGThreshold = configManager.getCrashGThreshold(),
+                    crashMinSpeedKmh = configManager.getCrashMinSpeedKmh(),
+                    fallGThreshold = configManager.getFallGThreshold(),
+                    confirmWindowMs = configManager.getConfirmWindowMs(),
+                    minConfidence = configManager.getMinImpactConfidence(),
+                ),
+            )
+        } else {
+            null
+        }
+    }
+
+    /** Feeds an accepted location fix to the telematics engine and emits events. */
+    private fun processTelematics(location: Map<String, Any?>) {
+        val engine = telematicsEngine ?: return
+        @Suppress("UNCHECKED_CAST")
+        val coords = location["coords"] as? Map<String, Any?> ?: return
+        val speed = (coords["speed"] as? Number)?.toDouble() ?: 0.0
+        val heading = (coords["heading"] as? Number)?.toDouble() ?: -1.0
+        val lat = (coords["latitude"] as? Number)?.toDouble() ?: 0.0
+        val lng = (coords["longitude"] as? Number)?.toDouble() ?: 0.0
+        lastSpeedMps = speed
+        lastLat = lat
+        lastLng = lng
+        val events = try {
+            engine.processFix(speed, heading, lat, lng, System.currentTimeMillis())
+        } catch (e: Exception) {
+            logger.error("telematics processFix failed: ${e.message}")
+            return
+        }
+        for (e in events) {
+            eventSender.sendDrivingEvent(
+                mapOf(
+                    "kind" to e.kind,
+                    "severity" to e.severity,
+                    "speed" to e.speed,
+                    "value" to e.value,
+                    "latitude" to e.latitude,
+                    "longitude" to e.longitude,
+                    "timestampMs" to e.timestampMs,
+                ),
+            )
+        }
+    }
+
+    /** Starts the ~1 Hz accel-window loop (classifier + impact) if a consumer is active. */
+    private fun startBehaviorSampling() {
+        stopBehaviorSampling()
+        if (transportClassifier == null && impactDetector == null) return
+
+        accelBuffer.clear()
+        accelWindowRunnable = object : Runnable {
+            override fun run() {
+                if (!stateManager.enabled) return
+                processAccelWindow()
+                mainHandler.postDelayed(this, accelWindowMs)
+            }
+        }
+        mainHandler.postDelayed(accelWindowRunnable!!, accelWindowMs)
+
+        if (impactDetector != null) {
+            impactConfirmRunnable = object : Runnable {
+                override fun run() {
+                    if (!stateManager.enabled) return
+                    impactDetector?.checkConfirmations(System.currentTimeMillis())?.forEach(::emitImpact)
+                    mainHandler.postDelayed(this, impactConfirmPollMs)
+                }
+            }
+            mainHandler.postDelayed(impactConfirmRunnable!!, impactConfirmPollMs)
+        }
+    }
+
+    private fun stopBehaviorSampling() {
+        accelWindowRunnable?.let { mainHandler.removeCallbacks(it) }
+        accelWindowRunnable = null
+        impactConfirmRunnable?.let { mainHandler.removeCallbacks(it) }
+        impactConfirmRunnable = null
+        accelBuffer.clear()
+    }
+
+    /** Snapshots the accel buffer into one window and feeds classifier + impact. */
+    private fun processAccelWindow() {
+        val samples: List<Double>
+        synchronized(accelBuffer) {
+            if (accelBuffer.isEmpty()) return
+            samples = ArrayList(accelBuffer)
+            accelBuffer.clear()
+        }
+        val now = System.currentTimeMillis()
+        val window = try {
+            uniffi.tracelet_core.computeAccelWindow(samples, accelWindowMs)
+        } catch (e: Exception) {
+            logger.error("computeAccelWindow failed: ${e.message}")
+            return
+        }
+
+        transportClassifier?.let { classifier ->
+            val result = classifier.classify(window, lastSpeedMps, now)
+            if (result.changed) {
+                eventSender.sendModeChange(
+                    mapOf(
+                        "mode" to result.mode.name.lowercase(),
+                        "confidence" to result.confidence,
+                    ),
+                )
+            }
+        }
+
+        impactDetector?.let { detector ->
+            val onFoot = lastSpeedMps * 3.6 < configManager.getCrashMinSpeedKmh()
+            val candidate = detector.onImpactWindow(
+                window.peakG,
+                lastSpeedMps,
+                onFoot,
+                lastLat,
+                lastLng,
+                now,
+            )
+            if (candidate != null) emitImpact(candidate)
+        }
+    }
+
+    private fun emitImpact(e: uniffi.tracelet_core.ImpactEvent) {
+        eventSender.sendImpact(
+            mapOf(
+                "kind" to e.kind,
+                "id" to e.id,
+                "confidence" to e.confidence,
+                "peakG" to e.peakG,
+                "speedBefore" to e.speedBefore,
+                "latitude" to e.latitude,
+                "longitude" to e.longitude,
+                "timestampMs" to e.timestampMs,
+                "confirmDeadlineMs" to e.confirmDeadlineMs,
+            ),
+        )
+    }
+
+    /** Confirms a pending impact candidate (called from the Pigeon host API). */
+    fun confirmImpact(id: Long): Boolean {
+        val confirmed = impactDetector?.confirm(id, System.currentTimeMillis()) ?: return false
+        emitImpact(confirmed)
+        return true
+    }
+
+    /** Cancels a pending impact candidate (called from the Pigeon host API). */
+    fun cancelImpact(id: Long): Boolean = impactDetector?.cancel(id) ?: false
 
     private fun startBatteryBudgetSampling() {
         stopBatteryBudgetSampling()

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/MotionDetector.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/MotionDetector.kt
@@ -152,6 +152,14 @@ class MotionDetector(
      */
     var onActivityChanged: ((type: String, confidence: Int) -> Unit)? = null
 
+    /**
+     * Emitted per accelerometer sample with the gravity-subtracted magnitude
+     * expressed in g (1 g ≈ 9.81 m/s²). Feeds the 3.3.0 transport-mode
+     * classifier and impact detector via the accel-window keystone. Only fires
+     * while an accelerometer listener is active (moving/stillness sampling).
+     */
+    var onAccelSample: ((magnitudeG: Double) -> Unit)? = null
+
     /** Callback: request full tracking stop (`stopOnStationary` mode). */
     var onStopRequested: (() -> Unit)? = null
 
@@ -595,6 +603,7 @@ class MotionDetector(
 
                 // Track max magnitude in last 10 samples
                 val absMag = Math.abs(magnitude)
+                onAccelSample?.invoke(absMag / 9.81)
                 if (absMag > maxMagLast10) {
                     maxMagLast10 = absMag
                 }
@@ -724,6 +733,7 @@ class MotionDetector(
 
                 // Track max magnitude in last 10 samples
                 val absMag = Math.abs(magnitude)
+                onAccelSample?.invoke(absMag / 9.81)
                 if (absMag > maxMagLast10) {
                     maxMagLast10 = absMag
                 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
@@ -640,11 +640,25 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_tracelet_core_checksum_func_is_point_in_polygon(
     ): Short
+    external fun uniffi_tracelet_core_checksum_func_compute_accel_window(
+    ): Short
     external fun uniffi_tracelet_core_checksum_func_build_canonical_string(
     ): Short
     external fun uniffi_tracelet_core_checksum_func_compute_genesis_hash(
     ): Short
     external fun uniffi_tracelet_core_checksum_func_sha256(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_impactdetector_cancel(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_impactdetector_check_confirmations(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_impactdetector_confirm(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_impactdetector_on_impact_window(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_impactdetector_pending_count(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_impactdetector_reset(
     ): Short
     external fun uniffi_tracelet_core_checksum_method_kalmanlocationfilter_estimated_speed(
     ): Short
@@ -667,6 +681,18 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_tracelet_core_checksum_method_scheduleparser_calculate_next_alarms(
     ): Short
     external fun uniffi_tracelet_core_checksum_method_scheduleparser_is_within_schedule(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_telematicsengine_current_score(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_telematicsengine_process_fix(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_telematicsengine_reset(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_transportmodeclassifier_classify(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_transportmodeclassifier_current_mode(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_method_transportmodeclassifier_reset(
     ): Short
     external fun uniffi_tracelet_core_checksum_method_tripmanager_is_trip_active(
     ): Short
@@ -788,6 +814,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Short
     external fun uniffi_tracelet_core_checksum_method_smartmotioncoordinator_set_use_geofences_when_stationary(
     ): Short
+    external fun uniffi_tracelet_core_checksum_constructor_impactdetector_new(
+    ): Short
     external fun uniffi_tracelet_core_checksum_constructor_kalmanlocationfilter_new(
     ): Short
     external fun uniffi_tracelet_core_checksum_constructor_adaptivesamplingengine_new(
@@ -795,6 +823,10 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_tracelet_core_checksum_constructor_locationprocessor_new(
     ): Short
     external fun uniffi_tracelet_core_checksum_constructor_scheduleparser_new(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_constructor_telematicsengine_new(
+    ): Short
+    external fun uniffi_tracelet_core_checksum_constructor_transportmodeclassifier_new(
     ): Short
     external fun uniffi_tracelet_core_checksum_constructor_tripmanager_new(
     ): Short
@@ -832,7 +864,25 @@ internal object UniffiLib {
         Native.register(UniffiLib::class.java, findLibraryName(componentName = "tracelet_core"))
         
     }
-    external fun uniffi_tracelet_core_fn_clone_kalmanlocationfilter(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    external fun uniffi_tracelet_core_fn_clone_impactdetector(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Long
+external fun uniffi_tracelet_core_fn_free_impactdetector(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+external fun uniffi_tracelet_core_fn_constructor_impactdetector_new(`config`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): Long
+external fun uniffi_tracelet_core_fn_method_impactdetector_cancel(`ptr`: Long,`id`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Byte
+external fun uniffi_tracelet_core_fn_method_impactdetector_check_confirmations(`ptr`: Long,`nowMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_tracelet_core_fn_method_impactdetector_confirm(`ptr`: Long,`id`: Long,`nowMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_tracelet_core_fn_method_impactdetector_on_impact_window(`ptr`: Long,`peakG`: Double,`speedBeforeMps`: Double,`isOnFoot`: Byte,`latitude`: Double,`longitude`: Double,`nowMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_tracelet_core_fn_method_impactdetector_pending_count(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Int
+external fun uniffi_tracelet_core_fn_method_impactdetector_reset(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+external fun uniffi_tracelet_core_fn_clone_kalmanlocationfilter(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
 external fun uniffi_tracelet_core_fn_free_kalmanlocationfilter(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -878,6 +928,30 @@ external fun uniffi_tracelet_core_fn_method_scheduleparser_calculate_next_alarms
 ): RustBuffer.ByValue
 external fun uniffi_tracelet_core_fn_method_scheduleparser_is_within_schedule(`ptr`: Long,`schedules`: RustBuffer.ByValue,`timestampMs`: Long,`tzOffsetSeconds`: Int,uniffi_out_err: UniffiRustCallStatus, 
 ): Byte
+external fun uniffi_tracelet_core_fn_clone_telematicsengine(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Long
+external fun uniffi_tracelet_core_fn_free_telematicsengine(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+external fun uniffi_tracelet_core_fn_constructor_telematicsengine_new(`config`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): Long
+external fun uniffi_tracelet_core_fn_method_telematicsengine_current_score(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Double
+external fun uniffi_tracelet_core_fn_method_telematicsengine_process_fix(`ptr`: Long,`speed`: Double,`heading`: Double,`latitude`: Double,`longitude`: Double,`timestampMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_tracelet_core_fn_method_telematicsengine_reset(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+external fun uniffi_tracelet_core_fn_clone_transportmodeclassifier(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Long
+external fun uniffi_tracelet_core_fn_free_transportmodeclassifier(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+external fun uniffi_tracelet_core_fn_constructor_transportmodeclassifier_new(`config`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): Long
+external fun uniffi_tracelet_core_fn_method_transportmodeclassifier_classify(`ptr`: Long,`window`: RustBuffer.ByValue,`speedMps`: Double,`nowMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_tracelet_core_fn_method_transportmodeclassifier_current_mode(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+external fun uniffi_tracelet_core_fn_method_transportmodeclassifier_reset(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
 external fun uniffi_tracelet_core_fn_clone_tripmanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
 external fun uniffi_tracelet_core_fn_free_tripmanager(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -1056,6 +1130,8 @@ external fun uniffi_tracelet_core_fn_func_haversine(`lat1`: Double,`lon1`: Doubl
 ): Double
 external fun uniffi_tracelet_core_fn_func_is_point_in_polygon(`lat`: Double,`lng`: Double,`vertices`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Byte
+external fun uniffi_tracelet_core_fn_func_compute_accel_window(`magnitudesG`: RustBuffer.ByValue,`durationMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 external fun uniffi_tracelet_core_fn_func_build_canonical_string(`previousHash`: RustBuffer.ByValue,`chainIndex`: Int,`loc`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_tracelet_core_fn_func_compute_genesis_hash(`deviceId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1187,6 +1263,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_tracelet_core_checksum_func_is_point_in_polygon() != 16595.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_tracelet_core_checksum_func_compute_accel_window() != 29960.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_tracelet_core_checksum_func_build_canonical_string() != 7071.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1194,6 +1273,24 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_func_sha256() != 14625.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_impactdetector_cancel() != 42443.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_impactdetector_check_confirmations() != 9379.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_impactdetector_confirm() != 51069.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_impactdetector_on_impact_window() != 28969.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_impactdetector_pending_count() != 63414.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_impactdetector_reset() != 57860.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_method_kalmanlocationfilter_estimated_speed() != 64160.toShort()) {
@@ -1227,6 +1324,24 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_method_scheduleparser_is_within_schedule() != 16562.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_telematicsengine_current_score() != 11738.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_telematicsengine_process_fix() != 30835.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_telematicsengine_reset() != 5304.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_transportmodeclassifier_classify() != 52837.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_transportmodeclassifier_current_mode() != 65278.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_method_transportmodeclassifier_reset() != 4812.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_method_tripmanager_is_trip_active() != 47274.toShort()) {
@@ -1409,6 +1524,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_tracelet_core_checksum_method_smartmotioncoordinator_set_use_geofences_when_stationary() != 15189.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_tracelet_core_checksum_constructor_impactdetector_new() != 56951.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_tracelet_core_checksum_constructor_kalmanlocationfilter_new() != 44956.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1419,6 +1537,12 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_constructor_scheduleparser_new() != 36401.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_constructor_telematicsengine_new() != 15489.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_tracelet_core_checksum_constructor_transportmodeclassifier_new() != 21163.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_constructor_tripmanager_new() != 53892.toShort()) {
@@ -1603,6 +1727,29 @@ private class JavaLangRefCleanable(
     val cleanable: java.lang.ref.Cleaner.Cleanable
 ) : UniffiCleaner.Cleanable {
     override fun clean() = cleanable.clean()
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterUInt: FfiConverter<UInt, Int> {
+    override fun lift(value: Int): UInt {
+        return value.toUInt()
+    }
+
+    override fun read(buf: ByteBuffer): UInt {
+        return lift(buf.getInt())
+    }
+
+    override fun lower(value: UInt): Int {
+        return value.toInt()
+    }
+
+    override fun allocationSize(value: UInt) = 4UL
+
+    override fun write(value: UInt, buf: ByteBuffer) {
+        buf.putInt(value.toInt())
+    }
 }
 
 /**
@@ -4608,6 +4755,389 @@ public object FfiConverterTypeGeofenceEvaluator: FfiConverter<GeofenceEvaluator,
 
 
 /**
+ * Detects crash/fall impacts with a confirmation window.
+ */
+public interface ImpactDetectorInterface {
+    
+    /**
+     * User cancels a candidate ("I'm fine") — no confirmed event will fire.
+     */
+    fun `cancel`(`id`: kotlin.Long): kotlin.Boolean
+    
+    /**
+     * Fires confirmed events for candidates whose deadline has elapsed without
+     * a cancel. Call on a timer.
+     */
+    fun `checkConfirmations`(`nowMs`: kotlin.Long): List<ImpactEvent>
+    
+    /**
+     * User (or app) explicitly confirms a candidate is a real emergency now.
+     */
+    fun `confirm`(`id`: kotlin.Long, `nowMs`: kotlin.Long): ImpactEvent?
+    
+    /**
+     * Feeds one accel window's peak plus motion context. Returns a
+     * `potential_*` event when an impact is detected (and registers it for
+     * confirmation), else `None`.
+     */
+    fun `onImpactWindow`(`peakG`: kotlin.Double, `speedBeforeMps`: kotlin.Double, `isOnFoot`: kotlin.Boolean, `latitude`: kotlin.Double, `longitude`: kotlin.Double, `nowMs`: kotlin.Long): ImpactEvent?
+    
+    /**
+     * Number of candidates awaiting confirmation.
+     */
+    fun `pendingCount`(): kotlin.UInt
+    
+    /**
+     * Clears all pending candidates.
+     */
+    fun `reset`()
+    
+    companion object
+}
+
+/**
+ * Detects crash/fall impacts with a confirmation window.
+ */
+open class ImpactDetector: Disposable, AutoCloseable, ImpactDetectorInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+    /**
+     * Creates a detector. Pass `None` for defaults (both detections off).
+     */
+    constructor(`config`: ImpactConfig?) :
+        this(UniffiWithHandle, 
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_constructor_impactdetector_new(
+    
+        FfiConverterOptionalTypeImpactConfig.lower(`config`),_status)
+}
+    )
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_tracelet_core_fn_free_impactdetector(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_tracelet_core_fn_clone_impactdetector(handle, status)
+        }
+    }
+
+    
+    /**
+     * User cancels a candidate ("I'm fine") — no confirmed event will fire.
+     */override fun `cancel`(`id`: kotlin.Long): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_impactdetector_cancel(
+        it,
+        FfiConverterLong.lower(`id`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Fires confirmed events for candidates whose deadline has elapsed without
+     * a cancel. Call on a timer.
+     */override fun `checkConfirmations`(`nowMs`: kotlin.Long): List<ImpactEvent> {
+            return FfiConverterSequenceTypeImpactEvent.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_impactdetector_check_confirmations(
+        it,
+        FfiConverterLong.lower(`nowMs`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * User (or app) explicitly confirms a candidate is a real emergency now.
+     */override fun `confirm`(`id`: kotlin.Long, `nowMs`: kotlin.Long): ImpactEvent? {
+            return FfiConverterOptionalTypeImpactEvent.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_impactdetector_confirm(
+        it,
+        FfiConverterLong.lower(`id`),FfiConverterLong.lower(`nowMs`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Feeds one accel window's peak plus motion context. Returns a
+     * `potential_*` event when an impact is detected (and registers it for
+     * confirmation), else `None`.
+     */override fun `onImpactWindow`(`peakG`: kotlin.Double, `speedBeforeMps`: kotlin.Double, `isOnFoot`: kotlin.Boolean, `latitude`: kotlin.Double, `longitude`: kotlin.Double, `nowMs`: kotlin.Long): ImpactEvent? {
+            return FfiConverterOptionalTypeImpactEvent.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_impactdetector_on_impact_window(
+        it,
+        FfiConverterDouble.lower(`peakG`),FfiConverterDouble.lower(`speedBeforeMps`),FfiConverterBoolean.lower(`isOnFoot`),FfiConverterDouble.lower(`latitude`),FfiConverterDouble.lower(`longitude`),FfiConverterLong.lower(`nowMs`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Number of candidates awaiting confirmation.
+     */override fun `pendingCount`(): kotlin.UInt {
+            return FfiConverterUInt.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_impactdetector_pending_count(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Clears all pending candidates.
+     */override fun `reset`()
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_impactdetector_reset(
+        it,
+        _status)
+}
+    }
+    
+    
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeImpactDetector: FfiConverter<ImpactDetector, Long> {
+    override fun lower(value: ImpactDetector): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): ImpactDetector {
+        return ImpactDetector(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): ImpactDetector {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: ImpactDetector) = 8UL
+
+    override fun write(value: ImpactDetector, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+/**
  * Provides a Kalman filter implementation tailored for smoothing noisy GPS location data.
  */
 public interface KalmanLocationFilterInterface {
@@ -6211,6 +6741,646 @@ public object FfiConverterTypeSmartMotionCoordinator: FfiConverter<SmartMotionCo
 
 
 /**
+ * Detects driving events from a stream of accepted location fixes.
+ */
+public interface TelematicsEngineInterface {
+    
+    /**
+     * Rolling driving score in [0, 100] (100 = flawless). Penalties accrue
+     * per event weighted by severity.
+     */
+    fun `currentScore`(): kotlin.Double
+    
+    /**
+     * Processes one accepted fix and returns any driving events it triggers.
+     *
+     * `speed` is m/s, `heading` is degrees (negative ⇒ unknown), `timestamp_ms`
+     * is epoch ms. Returns empty until a second fix establishes deltas, on
+     * time gaps, or when nothing crosses a threshold.
+     */
+    fun `processFix`(`speed`: kotlin.Double, `heading`: kotlin.Double, `latitude`: kotlin.Double, `longitude`: kotlin.Double, `timestampMs`: kotlin.Long): List<DrivingEvent>
+    
+    /**
+     * Clears all state (call on trip start / tracking restart).
+     */
+    fun `reset`()
+    
+    companion object
+}
+
+/**
+ * Detects driving events from a stream of accepted location fixes.
+ */
+open class TelematicsEngine: Disposable, AutoCloseable, TelematicsEngineInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+    /**
+     * Creates an engine. Pass `None` for default thresholds.
+     */
+    constructor(`config`: TelematicsConfig?) :
+        this(UniffiWithHandle, 
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_constructor_telematicsengine_new(
+    
+        FfiConverterOptionalTypeTelematicsConfig.lower(`config`),_status)
+}
+    )
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_tracelet_core_fn_free_telematicsengine(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_tracelet_core_fn_clone_telematicsengine(handle, status)
+        }
+    }
+
+    
+    /**
+     * Rolling driving score in [0, 100] (100 = flawless). Penalties accrue
+     * per event weighted by severity.
+     */override fun `currentScore`(): kotlin.Double {
+            return FfiConverterDouble.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_telematicsengine_current_score(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Processes one accepted fix and returns any driving events it triggers.
+     *
+     * `speed` is m/s, `heading` is degrees (negative ⇒ unknown), `timestamp_ms`
+     * is epoch ms. Returns empty until a second fix establishes deltas, on
+     * time gaps, or when nothing crosses a threshold.
+     */override fun `processFix`(`speed`: kotlin.Double, `heading`: kotlin.Double, `latitude`: kotlin.Double, `longitude`: kotlin.Double, `timestampMs`: kotlin.Long): List<DrivingEvent> {
+            return FfiConverterSequenceTypeDrivingEvent.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_telematicsengine_process_fix(
+        it,
+        FfiConverterDouble.lower(`speed`),FfiConverterDouble.lower(`heading`),FfiConverterDouble.lower(`latitude`),FfiConverterDouble.lower(`longitude`),FfiConverterLong.lower(`timestampMs`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Clears all state (call on trip start / tracking restart).
+     */override fun `reset`()
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_telematicsengine_reset(
+        it,
+        _status)
+}
+    }
+    
+    
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTelematicsEngine: FfiConverter<TelematicsEngine, Long> {
+    override fun lower(value: TelematicsEngine): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): TelematicsEngine {
+        return TelematicsEngine(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): TelematicsEngine {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: TelematicsEngine) = 8UL
+
+    override fun write(value: TelematicsEngine, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+/**
+ * Fuses accel features + speed into a transport mode with hysteresis.
+ */
+public interface TransportModeClassifierInterface {
+    
+    /**
+     * Classifies one window + speed, applying confidence gating and dwell
+     * hysteresis. Returns the currently committed mode.
+     */
+    fun `classify`(`window`: AccelWindow, `speedMps`: kotlin.Double, `nowMs`: kotlin.Long): ModeResult
+    
+    /**
+     * Currently committed mode.
+     */
+    fun `currentMode`(): TransportMode
+    
+    /**
+     * Resets to `Unknown`.
+     */
+    fun `reset`()
+    
+    companion object
+}
+
+/**
+ * Fuses accel features + speed into a transport mode with hysteresis.
+ */
+open class TransportModeClassifier: Disposable, AutoCloseable, TransportModeClassifierInterface
+{
+
+    @Suppress("UNUSED_PARAMETER")
+    /**
+     * @suppress
+     */
+    constructor(withHandle: UniffiWithHandle, handle: Long) {
+        this.handle = handle
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(handle))
+    }
+
+    /**
+     * @suppress
+     *
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noHandle: NoHandle) {
+        this.handle = 0
+        this.cleanable = null
+    }
+    /**
+     * Creates a classifier. Pass `None` for default tuning.
+     */
+    constructor(`config`: ClassifierConfig?) :
+        this(UniffiWithHandle, 
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_constructor_transportmodeclassifier_new(
+    
+        FfiConverterOptionalTypeClassifierConfig.lower(`config`),_status)
+}
+    )
+
+    protected val handle: Long
+    protected val cleanable: UniffiCleaner.Cleanable?
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(this.uniffiCloneHandle())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable?.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val handle: Long) : Runnable {
+        override fun run() {
+            if (handle == 0.toLong()) {
+                // Fake object created with `NoHandle`, don't try to free.
+                return;
+            }
+            uniffiRustCall { status ->
+                UniffiLib.uniffi_tracelet_core_fn_free_transportmodeclassifier(handle, status)
+            }
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    fun uniffiCloneHandle(): Long {
+        if (handle == 0.toLong()) {
+            throw InternalException("uniffiCloneHandle() called on NoHandle object");
+        }
+        return uniffiRustCall() { status ->
+            UniffiLib.uniffi_tracelet_core_fn_clone_transportmodeclassifier(handle, status)
+        }
+    }
+
+    
+    /**
+     * Classifies one window + speed, applying confidence gating and dwell
+     * hysteresis. Returns the currently committed mode.
+     */override fun `classify`(`window`: AccelWindow, `speedMps`: kotlin.Double, `nowMs`: kotlin.Long): ModeResult {
+            return FfiConverterTypeModeResult.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_transportmodeclassifier_classify(
+        it,
+        FfiConverterTypeAccelWindow.lower(`window`),FfiConverterDouble.lower(`speedMps`),FfiConverterLong.lower(`nowMs`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Currently committed mode.
+     */override fun `currentMode`(): TransportMode {
+            return FfiConverterTypeTransportMode.lift(
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_transportmodeclassifier_current_mode(
+        it,
+        _status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Resets to `Unknown`.
+     */override fun `reset`()
+        = 
+    callWithHandle {
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_method_transportmodeclassifier_reset(
+        it,
+        _status)
+}
+    }
+    
+    
+
+    
+
+    
+
+
+    
+    
+    /**
+     * @suppress
+     */
+    companion object
+    
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTransportModeClassifier: FfiConverter<TransportModeClassifier, Long> {
+    override fun lower(value: TransportModeClassifier): Long {
+        return value.uniffiCloneHandle()
+    }
+
+    override fun lift(value: Long): TransportModeClassifier {
+        return TransportModeClassifier(UniffiWithHandle, value)
+    }
+
+    override fun read(buf: ByteBuffer): TransportModeClassifier {
+        return lift(buf.getLong())
+    }
+
+    override fun allocationSize(value: TransportModeClassifier) = 8UL
+
+    override fun write(value: TransportModeClassifier, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a handle
+// to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque handle to the underlying Rust struct.
+//     Method calls need to read this handle from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+/**
  * Core logic for determining trip boundaries (start/stop) based on location and motion changes.
  */
 public interface TripManagerInterface {
@@ -6447,6 +7617,87 @@ public object FfiConverterTypeTripManager: FfiConverter<TripManager, Long> {
 
     override fun write(value: TripManager, buf: ByteBuffer) {
         buf.putLong(lower(value))
+    }
+}
+
+
+
+/**
+ * Lightweight features summarizing one accelerometer window.
+ */
+data class AccelWindow (
+    /**
+     * Mean magnitude (g, gravity-subtracted).
+     */
+    var `meanG`: kotlin.Double
+    , 
+    /**
+     * Variance of the magnitude — separates steady (vehicle) from bouncy
+     * (running) motion.
+     */
+    var `variance`: kotlin.Double
+    , 
+    /**
+     * Largest single magnitude in the window (g) — the impact signal.
+     */
+    var `peakG`: kotlin.Double
+    , 
+    /**
+     * Dominant oscillation frequency (Hz), estimated from mean-crossings —
+     * the cadence cue distinguishing walking (~2 Hz) from running (~3 Hz).
+     */
+    var `dominantCadenceHz`: kotlin.Double
+    , 
+    /**
+     * Number of samples in the window.
+     */
+    var `sampleCount`: kotlin.UInt
+    , 
+    /**
+     * Window duration (ms).
+     */
+    var `durationMs`: kotlin.Long
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeAccelWindow: FfiConverterRustBuffer<AccelWindow> {
+    override fun read(buf: ByteBuffer): AccelWindow {
+        return AccelWindow(
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterUInt.read(buf),
+            FfiConverterLong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: AccelWindow) = (
+            FfiConverterDouble.allocationSize(value.`meanG`) +
+            FfiConverterDouble.allocationSize(value.`variance`) +
+            FfiConverterDouble.allocationSize(value.`peakG`) +
+            FfiConverterDouble.allocationSize(value.`dominantCadenceHz`) +
+            FfiConverterUInt.allocationSize(value.`sampleCount`) +
+            FfiConverterLong.allocationSize(value.`durationMs`)
+    )
+
+    override fun write(value: AccelWindow, buf: ByteBuffer) {
+            FfiConverterDouble.write(value.`meanG`, buf)
+            FfiConverterDouble.write(value.`variance`, buf)
+            FfiConverterDouble.write(value.`peakG`, buf)
+            FfiConverterDouble.write(value.`dominantCadenceHz`, buf)
+            FfiConverterUInt.write(value.`sampleCount`, buf)
+            FfiConverterLong.write(value.`durationMs`, buf)
     }
 }
 
@@ -6867,6 +8118,53 @@ public object FfiConverterTypeBudgetAdjustmentEvent: FfiConverterRustBuffer<Budg
 
 
 /**
+ * Classifier tuning.
+ */
+data class ClassifierConfig (
+    /**
+     * A candidate mode must persist this long (ms) before it commits.
+     */
+    var `modeSwitchDwellMs`: kotlin.Long
+    , 
+    /**
+     * Below this confidence the result is reported as `Unknown`.
+     */
+    var `minConfidence`: kotlin.Double
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeClassifierConfig: FfiConverterRustBuffer<ClassifierConfig> {
+    override fun read(buf: ByteBuffer): ClassifierConfig {
+        return ClassifierConfig(
+            FfiConverterLong.read(buf),
+            FfiConverterDouble.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ClassifierConfig) = (
+            FfiConverterLong.allocationSize(value.`modeSwitchDwellMs`) +
+            FfiConverterDouble.allocationSize(value.`minConfidence`)
+    )
+
+    override fun write(value: ClassifierConfig, buf: ByteBuffer) {
+            FfiConverterLong.write(value.`modeSwitchDwellMs`, buf)
+            FfiConverterDouble.write(value.`minConfidence`, buf)
+    }
+}
+
+
+
+/**
  * Represents a 2D geographical coordinate using latitude and longitude.
  */
 data class Coordinate (
@@ -7206,6 +8504,85 @@ public object FfiConverterTypeDbLocationRecord: FfiConverterRustBuffer<DbLocatio
             FfiConverterOptionalString.write(value.`routeContext`, buf)
             FfiConverterString.write(value.`eventType`, buf)
             FfiConverterOptionalString.write(value.`eventPayload`, buf)
+    }
+}
+
+
+
+/**
+ * A detected driving event.
+ */
+data class DrivingEvent (
+    /**
+     * `harsh_braking` | `harsh_acceleration` | `harsh_cornering` | `speeding`.
+     */
+    var `kind`: kotlin.String
+    , 
+    /**
+     * Normalized 0–1 severity (how far past the threshold).
+     */
+    var `severity`: kotlin.Double
+    , 
+    /**
+     * Speed at the event (m/s).
+     */
+    var `speed`: kotlin.Double
+    , 
+    /**
+     * The measured magnitude that triggered it: g for harsh events, km/h over
+     * the limit for speeding.
+     */
+    var `value`: kotlin.Double
+    , 
+    var `latitude`: kotlin.Double
+    , 
+    var `longitude`: kotlin.Double
+    , 
+    var `timestampMs`: kotlin.Long
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeDrivingEvent: FfiConverterRustBuffer<DrivingEvent> {
+    override fun read(buf: ByteBuffer): DrivingEvent {
+        return DrivingEvent(
+            FfiConverterString.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterLong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: DrivingEvent) = (
+            FfiConverterString.allocationSize(value.`kind`) +
+            FfiConverterDouble.allocationSize(value.`severity`) +
+            FfiConverterDouble.allocationSize(value.`speed`) +
+            FfiConverterDouble.allocationSize(value.`value`) +
+            FfiConverterDouble.allocationSize(value.`latitude`) +
+            FfiConverterDouble.allocationSize(value.`longitude`) +
+            FfiConverterLong.allocationSize(value.`timestampMs`)
+    )
+
+    override fun write(value: DrivingEvent, buf: ByteBuffer) {
+            FfiConverterString.write(value.`kind`, buf)
+            FfiConverterDouble.write(value.`severity`, buf)
+            FfiConverterDouble.write(value.`speed`, buf)
+            FfiConverterDouble.write(value.`value`, buf)
+            FfiConverterDouble.write(value.`latitude`, buf)
+            FfiConverterDouble.write(value.`longitude`, buf)
+            FfiConverterLong.write(value.`timestampMs`, buf)
     }
 }
 
@@ -7830,6 +9207,187 @@ public object FfiConverterTypeHttpConfig: FfiConverterRustBuffer<HttpConfig> {
 
 
 /**
+ * Impact detector tuning.
+ */
+data class ImpactConfig (
+    /**
+     * Enable vehicle crash detection.
+     */
+    var `enableCrash`: kotlin.Boolean
+    , 
+    /**
+     * Enable personal fall detection (best-effort; more false positives).
+     */
+    var `enableFall`: kotlin.Boolean
+    , 
+    /**
+     * Impact magnitude (g) for a crash candidate.
+     */
+    var `crashGThreshold`: kotlin.Double
+    , 
+    /**
+     * Pre-impact speed (km/h) required to corroborate a crash.
+     */
+    var `crashMinSpeedKmh`: kotlin.Double
+    , 
+    /**
+     * Impact magnitude (g) for a fall candidate.
+     */
+    var `fallGThreshold`: kotlin.Double
+    , 
+    /**
+     * Countdown (ms) before a candidate auto-confirms.
+     */
+    var `confirmWindowMs`: kotlin.Long
+    , 
+    /**
+     * Suppress candidates below this confidence.
+     */
+    var `minConfidence`: kotlin.Double
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeImpactConfig: FfiConverterRustBuffer<ImpactConfig> {
+    override fun read(buf: ByteBuffer): ImpactConfig {
+        return ImpactConfig(
+            FfiConverterBoolean.read(buf),
+            FfiConverterBoolean.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterLong.read(buf),
+            FfiConverterDouble.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ImpactConfig) = (
+            FfiConverterBoolean.allocationSize(value.`enableCrash`) +
+            FfiConverterBoolean.allocationSize(value.`enableFall`) +
+            FfiConverterDouble.allocationSize(value.`crashGThreshold`) +
+            FfiConverterDouble.allocationSize(value.`crashMinSpeedKmh`) +
+            FfiConverterDouble.allocationSize(value.`fallGThreshold`) +
+            FfiConverterLong.allocationSize(value.`confirmWindowMs`) +
+            FfiConverterDouble.allocationSize(value.`minConfidence`)
+    )
+
+    override fun write(value: ImpactConfig, buf: ByteBuffer) {
+            FfiConverterBoolean.write(value.`enableCrash`, buf)
+            FfiConverterBoolean.write(value.`enableFall`, buf)
+            FfiConverterDouble.write(value.`crashGThreshold`, buf)
+            FfiConverterDouble.write(value.`crashMinSpeedKmh`, buf)
+            FfiConverterDouble.write(value.`fallGThreshold`, buf)
+            FfiConverterLong.write(value.`confirmWindowMs`, buf)
+            FfiConverterDouble.write(value.`minConfidence`, buf)
+    }
+}
+
+
+
+/**
+ * An impact event.
+ */
+data class ImpactEvent (
+    /**
+     * `potential_crash` | `crash` | `potential_fall` | `fall`.
+     */
+    var `kind`: kotlin.String
+    , 
+    /**
+     * Candidate id — pair `potential_*` with its later `confirm`/`cancel`.
+     */
+    var `id`: kotlin.Long
+    , 
+    /**
+     * 0–1 confidence.
+     */
+    var `confidence`: kotlin.Double
+    , 
+    /**
+     * Peak magnitude (g) of the impact.
+     */
+    var `peakG`: kotlin.Double
+    , 
+    /**
+     * Speed before impact (m/s).
+     */
+    var `speedBefore`: kotlin.Double
+    , 
+    var `latitude`: kotlin.Double
+    , 
+    var `longitude`: kotlin.Double
+    , 
+    var `timestampMs`: kotlin.Long
+    , 
+    /**
+     * For `potential_*`: epoch ms at which it auto-confirms unless cancelled.
+     */
+    var `confirmDeadlineMs`: kotlin.Long
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeImpactEvent: FfiConverterRustBuffer<ImpactEvent> {
+    override fun read(buf: ByteBuffer): ImpactEvent {
+        return ImpactEvent(
+            FfiConverterString.read(buf),
+            FfiConverterLong.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterLong.read(buf),
+            FfiConverterLong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ImpactEvent) = (
+            FfiConverterString.allocationSize(value.`kind`) +
+            FfiConverterLong.allocationSize(value.`id`) +
+            FfiConverterDouble.allocationSize(value.`confidence`) +
+            FfiConverterDouble.allocationSize(value.`peakG`) +
+            FfiConverterDouble.allocationSize(value.`speedBefore`) +
+            FfiConverterDouble.allocationSize(value.`latitude`) +
+            FfiConverterDouble.allocationSize(value.`longitude`) +
+            FfiConverterLong.allocationSize(value.`timestampMs`) +
+            FfiConverterLong.allocationSize(value.`confirmDeadlineMs`)
+    )
+
+    override fun write(value: ImpactEvent, buf: ByteBuffer) {
+            FfiConverterString.write(value.`kind`, buf)
+            FfiConverterLong.write(value.`id`, buf)
+            FfiConverterDouble.write(value.`confidence`, buf)
+            FfiConverterDouble.write(value.`peakG`, buf)
+            FfiConverterDouble.write(value.`speedBefore`, buf)
+            FfiConverterDouble.write(value.`latitude`, buf)
+            FfiConverterDouble.write(value.`longitude`, buf)
+            FfiConverterLong.write(value.`timestampMs`, buf)
+            FfiConverterLong.write(value.`confirmDeadlineMs`, buf)
+    }
+}
+
+
+
+/**
  * A simple geographical point used for the smoothed output of the Kalman filter.
  */
 data class LatLng (
@@ -8116,6 +9674,55 @@ public object FfiConverterTypeLogEntry: FfiConverterRustBuffer<LogEntry> {
             FfiConverterString.write(value.`message`, buf)
             FfiConverterString.write(value.`timestamp`, buf)
             FfiConverterString.write(value.`source`, buf)
+    }
+}
+
+
+
+/**
+ * Result of a classification step.
+ */
+data class ModeResult (
+    var `mode`: TransportMode
+    , 
+    var `confidence`: kotlin.Double
+    , 
+    /**
+     * True when this call committed a *change* from the previous committed mode.
+     */
+    var `changed`: kotlin.Boolean
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeModeResult: FfiConverterRustBuffer<ModeResult> {
+    override fun read(buf: ByteBuffer): ModeResult {
+        return ModeResult(
+            FfiConverterTypeTransportMode.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterBoolean.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ModeResult) = (
+            FfiConverterTypeTransportMode.allocationSize(value.`mode`) +
+            FfiConverterDouble.allocationSize(value.`confidence`) +
+            FfiConverterBoolean.allocationSize(value.`changed`)
+    )
+
+    override fun write(value: ModeResult, buf: ByteBuffer) {
+            FfiConverterTypeTransportMode.write(value.`mode`, buf)
+            FfiConverterDouble.write(value.`confidence`, buf)
+            FfiConverterBoolean.write(value.`changed`, buf)
     }
 }
 
@@ -8485,6 +10092,105 @@ public object FfiConverterTypeSecurityConfig: FfiConverterRustBuffer<SecurityCon
 
     override fun write(value: SecurityConfig, buf: ByteBuffer) {
             FfiConverterBoolean.write(value.`encryptDatabase`, buf)
+    }
+}
+
+
+
+/**
+ * Tunable thresholds for driving-event detection. Defaults follow common
+ * usage-based-insurance / fleet practice and are overridable by the caller.
+ */
+data class TelematicsConfig (
+    /**
+     * Longitudinal deceleration (g) above which `harsh_braking` fires.
+     */
+    var `harshBrakingG`: kotlin.Double
+    , 
+    /**
+     * Longitudinal acceleration (g) above which `harsh_acceleration` fires.
+     */
+    var `harshAccelerationG`: kotlin.Double
+    , 
+    /**
+     * Lateral acceleration (g) above which `harsh_cornering` fires.
+     */
+    var `harshCorneringG`: kotlin.Double
+    , 
+    /**
+     * Global speed limit in km/h. `0` disables threshold-based speeding
+     * (per-geofence limits can still be applied by the caller).
+     */
+    var `speedLimitKmh`: kotlin.Double
+    , 
+    /**
+     * Grace (km/h) added to the limit before speeding counts.
+     */
+    var `speedingToleranceKmh`: kotlin.Double
+    , 
+    /**
+     * Sustained time over the limit (ms) before `speeding` fires.
+     */
+    var `speedingMinDurationMs`: kotlin.Long
+    , 
+    /**
+     * Suppress brake/accel/corner events below this speed (km/h) to avoid
+     * parking-lot / GPS-jitter noise.
+     */
+    var `minSpeedForEventsKmh`: kotlin.Double
+    , 
+    /**
+     * Minimum time between two events of the same kind (ms) — debounce so a
+     * single maneuver spanning several fixes yields one event.
+     */
+    var `eventDebounceMs`: kotlin.Long
+    
+){
+    
+
+    
+
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTelematicsConfig: FfiConverterRustBuffer<TelematicsConfig> {
+    override fun read(buf: ByteBuffer): TelematicsConfig {
+        return TelematicsConfig(
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterLong.read(buf),
+            FfiConverterDouble.read(buf),
+            FfiConverterLong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: TelematicsConfig) = (
+            FfiConverterDouble.allocationSize(value.`harshBrakingG`) +
+            FfiConverterDouble.allocationSize(value.`harshAccelerationG`) +
+            FfiConverterDouble.allocationSize(value.`harshCorneringG`) +
+            FfiConverterDouble.allocationSize(value.`speedLimitKmh`) +
+            FfiConverterDouble.allocationSize(value.`speedingToleranceKmh`) +
+            FfiConverterLong.allocationSize(value.`speedingMinDurationMs`) +
+            FfiConverterDouble.allocationSize(value.`minSpeedForEventsKmh`) +
+            FfiConverterLong.allocationSize(value.`eventDebounceMs`)
+    )
+
+    override fun write(value: TelematicsConfig, buf: ByteBuffer) {
+            FfiConverterDouble.write(value.`harshBrakingG`, buf)
+            FfiConverterDouble.write(value.`harshAccelerationG`, buf)
+            FfiConverterDouble.write(value.`harshCorneringG`, buf)
+            FfiConverterDouble.write(value.`speedLimitKmh`, buf)
+            FfiConverterDouble.write(value.`speedingToleranceKmh`, buf)
+            FfiConverterLong.write(value.`speedingMinDurationMs`, buf)
+            FfiConverterDouble.write(value.`minSpeedForEventsKmh`, buf)
+            FfiConverterLong.write(value.`eventDebounceMs`, buf)
     }
 }
 
@@ -8932,6 +10638,48 @@ public object FfiConverterTypeTrackingMode: FfiConverterRustBuffer<TrackingMode>
 
 
 
+/**
+ * Detected travel mode. Distinct from the platform `ActivityType` so adding
+ * `Cycling` here doesn't perturb existing activity plumbing.
+ */
+
+enum class TransportMode {
+    
+    UNKNOWN,
+    STILL,
+    WALKING,
+    RUNNING,
+    CYCLING,
+    VEHICLE;
+
+    
+
+
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTransportMode: FfiConverterRustBuffer<TransportMode> {
+    override fun read(buf: ByteBuffer) = try {
+        TransportMode.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: TransportMode) = 4UL
+
+    override fun write(value: TransportMode, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
 
 /**
  * @suppress
@@ -9192,6 +10940,38 @@ public object FfiConverterOptionalTypeBudgetAdjustmentEvent: FfiConverterRustBuf
 /**
  * @suppress
  */
+public object FfiConverterOptionalTypeClassifierConfig: FfiConverterRustBuffer<ClassifierConfig?> {
+    override fun read(buf: ByteBuffer): ClassifierConfig? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeClassifierConfig.read(buf)
+    }
+
+    override fun allocationSize(value: ClassifierConfig?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeClassifierConfig.allocationSize(value)
+        }
+    }
+
+    override fun write(value: ClassifierConfig?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeClassifierConfig.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalTypeDbLocationRecord: FfiConverterRustBuffer<DbLocationRecord?> {
     override fun read(buf: ByteBuffer): DbLocationRecord? {
         if (buf.get().toInt() == 0) {
@@ -9214,6 +10994,70 @@ public object FfiConverterOptionalTypeDbLocationRecord: FfiConverterRustBuffer<D
         } else {
             buf.put(1)
             FfiConverterTypeDbLocationRecord.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeImpactConfig: FfiConverterRustBuffer<ImpactConfig?> {
+    override fun read(buf: ByteBuffer): ImpactConfig? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeImpactConfig.read(buf)
+    }
+
+    override fun allocationSize(value: ImpactConfig?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeImpactConfig.allocationSize(value)
+        }
+    }
+
+    override fun write(value: ImpactConfig?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeImpactConfig.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeImpactEvent: FfiConverterRustBuffer<ImpactEvent?> {
+    override fun read(buf: ByteBuffer): ImpactEvent? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeImpactEvent.read(buf)
+    }
+
+    override fun allocationSize(value: ImpactEvent?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeImpactEvent.allocationSize(value)
+        }
+    }
+
+    override fun write(value: ImpactEvent?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeImpactEvent.write(value, buf)
         }
     }
 }
@@ -9278,6 +11122,38 @@ public object FfiConverterOptionalTypeLocationRecord: FfiConverterRustBuffer<Loc
         } else {
             buf.put(1)
             FfiConverterTypeLocationRecord.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeTelematicsConfig: FfiConverterRustBuffer<TelematicsConfig?> {
+    override fun read(buf: ByteBuffer): TelematicsConfig? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeTelematicsConfig.read(buf)
+    }
+
+    override fun allocationSize(value: TelematicsConfig?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeTelematicsConfig.allocationSize(value)
+        }
+    }
+
+    override fun write(value: TelematicsConfig?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeTelematicsConfig.write(value, buf)
         }
     }
 }
@@ -9438,6 +11314,34 @@ public object FfiConverterOptionalMapStringString: FfiConverterRustBuffer<Map<ko
         } else {
             buf.put(1)
             FfiConverterMapStringString.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceDouble: FfiConverterRustBuffer<List<kotlin.Double>> {
+    override fun read(buf: ByteBuffer): List<kotlin.Double> {
+        val len = buf.getInt()
+        return List<kotlin.Double>(len) {
+            FfiConverterDouble.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<kotlin.Double>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterDouble.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<kotlin.Double>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterDouble.write(it, buf)
         }
     }
 }
@@ -9644,6 +11548,34 @@ public object FfiConverterSequenceTypeDbLocationRecord: FfiConverterRustBuffer<L
 /**
  * @suppress
  */
+public object FfiConverterSequenceTypeDrivingEvent: FfiConverterRustBuffer<List<DrivingEvent>> {
+    override fun read(buf: ByteBuffer): List<DrivingEvent> {
+        val len = buf.getInt()
+        return List<DrivingEvent>(len) {
+            FfiConverterTypeDrivingEvent.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<DrivingEvent>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeDrivingEvent.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<DrivingEvent>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeDrivingEvent.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterSequenceTypeGeofenceTransition: FfiConverterRustBuffer<List<GeofenceTransition>> {
     override fun read(buf: ByteBuffer): List<GeofenceTransition> {
         val len = buf.getInt()
@@ -9662,6 +11594,34 @@ public object FfiConverterSequenceTypeGeofenceTransition: FfiConverterRustBuffer
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypeGeofenceTransition.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceTypeImpactEvent: FfiConverterRustBuffer<List<ImpactEvent>> {
+    override fun read(buf: ByteBuffer): List<ImpactEvent> {
+        val len = buf.getInt()
+        return List<ImpactEvent>(len) {
+            FfiConverterTypeImpactEvent.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<ImpactEvent>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeImpactEvent.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<ImpactEvent>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeImpactEvent.write(it, buf)
         }
     }
 }
@@ -9782,6 +11742,20 @@ public object FfiConverterMapStringString: FfiConverterRustBuffer<Map<kotlin.Str
     UniffiLib.uniffi_tracelet_core_fn_func_is_point_in_polygon(
     
         FfiConverterDouble.lower(`lat`),FfiConverterDouble.lower(`lng`),FfiConverterSequenceTypeCoordinate.lower(`vertices`),_status)
+}
+    )
+    }
+    
+
+        /**
+         * Computes [`AccelWindow`] features from a batch of gravity-subtracted
+         * magnitudes (g) spanning `duration_ms`.
+         */ fun `computeAccelWindow`(`magnitudesG`: List<kotlin.Double>, `durationMs`: kotlin.Long): AccelWindow {
+            return FfiConverterTypeAccelWindow.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_tracelet_core_fn_func_compute_accel_window(
+    
+        FfiConverterSequenceDouble.lower(`magnitudesG`),FfiConverterLong.lower(`durationMs`),_status)
 }
     )
     }

--- a/sdk/ios/CHANGELOG.md
+++ b/sdk/ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+* **FEAT**: Native runtime for the 3.3.0 behavior engines — TelematicsEngine (driving events), TransportModeClassifier (fused transport mode), and ImpactDetector (crash/fall) wired into the location + accelerometer pipeline. All opt-in / default-off. ([#163](https://github.com/Ikolvi/Tracelet/issues/163), [#164](https://github.com/Ikolvi/Tracelet/issues/164), [#165](https://github.com/Ikolvi/Tracelet/issues/165))
+
 ## 3.2.19
 
 **CHORE**: version bump for patch release

--- a/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
@@ -330,6 +330,30 @@ public final class ConfigManager {
     // MARK: - Battery Budget
     public func getBatteryBudgetPerHour() -> Double { cache["batteryBudgetPerHour"] as? Double ?? 0.0 }
 
+    // MARK: - Telematics / classifier / impact (3.3.0)
+    public func getEnableDrivingEvents() -> Bool { cache["enableDrivingEvents"] as? Bool ?? false }
+    public func getHarshBrakingG() -> Double { cache["harshBrakingG"] as? Double ?? 0.40 }
+    public func getHarshAccelerationG() -> Double { cache["harshAccelerationG"] as? Double ?? 0.35 }
+    public func getHarshCorneringG() -> Double { cache["harshCorneringG"] as? Double ?? 0.40 }
+    public func getSpeedLimitKmh() -> Double { cache["speedLimitKmh"] as? Double ?? 0.0 }
+    public func getSpeedingToleranceKmh() -> Double { cache["speedingToleranceKmh"] as? Double ?? 5.0 }
+    public func getSpeedingMinDurationMs() -> Int64 { (cache["speedingMinDurationMs"] as? NSNumber)?.int64Value ?? 3000 }
+    public func getMinSpeedForEventsKmh() -> Double { cache["minSpeedForEventsKmh"] as? Double ?? 5.0 }
+    public func getEventDebounceMs() -> Int64 { (cache["eventDebounceMs"] as? NSNumber)?.int64Value ?? 2000 }
+
+    public func getEnableFusedClassifier() -> Bool { cache["enableFusedClassifier"] as? Bool ?? false }
+    public func getFusedClassifierAuthoritative() -> Bool { cache["fusedClassifierAuthoritative"] as? Bool ?? false }
+    public func getModeSwitchDwellMs() -> Int64 { (cache["modeSwitchDwellMs"] as? NSNumber)?.int64Value ?? 8000 }
+    public func getMinModeConfidence() -> Double { cache["minModeConfidence"] as? Double ?? 0.6 }
+
+    public func getEnableCrashDetection() -> Bool { cache["enableCrashDetection"] as? Bool ?? false }
+    public func getEnableFallDetection() -> Bool { cache["enableFallDetection"] as? Bool ?? false }
+    public func getCrashGThreshold() -> Double { cache["crashGThreshold"] as? Double ?? 3.0 }
+    public func getCrashMinSpeedKmh() -> Double { cache["crashMinSpeedKmh"] as? Double ?? 25.0 }
+    public func getFallGThreshold() -> Double { cache["fallGThreshold"] as? Double ?? 2.5 }
+    public func getConfirmWindowMs() -> Int64 { (cache["confirmWindowMs"] as? NSNumber)?.int64Value ?? 15000 }
+    public func getMinImpactConfidence() -> Double { cache["minImpactConfidence"] as? Double ?? 0.6 }
+
     // MARK: - SSL Pinning
 
     public func getSslPinningCertificates() -> [String] {

--- a/sdk/ios/Sources/TraceletSDK/DelegateEventSender.swift
+++ b/sdk/ios/Sources/TraceletSDK/DelegateEventSender.swift
@@ -104,6 +104,13 @@ final class DelegateEventSender: TraceletEventSending {
         dispatch { sdk, delegate in delegate.tracelet(sdk, didAdjustBudget: data) }
     }
 
+    // Driving/impact/mode events are consumed by the Flutter plugin
+    // (PluginEventDispatcher). Native-Swift delegate hooks are an extension
+    // point for future use, mirroring sendRemoteConfigEvent.
+    func sendDrivingEvent(_ data: [String: Any]) {}
+    func sendImpact(_ data: [String: Any]) {}
+    func sendModeChange(_ data: [String: Any]) {}
+
     func hasListener(eventName: String) -> Bool {
         return delegate != nil || headlessDispatcher?.isRegistered() == true
     }

--- a/sdk/ios/Sources/TraceletSDK/TraceletEventSending.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletEventSending.swift
@@ -25,5 +25,8 @@ public protocol TraceletEventSending: AnyObject {
     func sendRemoteConfigEvent(_ data: [String: Any])
     func sendTrip(_ data: [String: Any])
     func sendBudgetAdjustment(_ data: [String: Any])
+    func sendDrivingEvent(_ data: [String: Any])
+    func sendImpact(_ data: [String: Any])
+    func sendModeChange(_ data: [String: Any])
     func hasListener(eventName: String) -> Bool
 }

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -106,6 +106,19 @@ public final class TraceletSdk {
     /// Battery budget sampling interval: 5 minutes.
     private static let batterySampleInterval: TimeInterval = 5 * 60
 
+    // 3.3.0 behavior engines (opt-in, default off)
+    private var telematicsEngine: TelematicsEngine?
+    private var transportClassifier: TransportModeClassifier?
+    private var impactDetector: ImpactDetector?
+    private var accelBuffer: [Double] = []
+    private let accelBufferLock = NSLock()
+    private var accelWindowTimer: Timer?
+    private var impactConfirmTimer: Timer?
+    private var lastSpeedMps: Double = 0
+    private var lastLat: Double = 0
+    private var lastLng: Double = 0
+    private static let accelWindowInterval: TimeInterval = 1.0
+
     /// Whether ``ready(config:)`` has been called.
     public var isReadyState: Bool { isReady }
 
@@ -263,6 +276,8 @@ public final class TraceletSdk {
             batteryBudgetEngine = nil
         }
 
+        initBehaviorEngines()
+
         isReady = true
         syncConfigToRustFlat()
         checkSyncProvider()
@@ -362,6 +377,7 @@ public final class TraceletSdk {
         startHeartbeat()
         startStopAfterElapsedTimer()
         startBatteryBudgetSampling()
+        startBehaviorSampling()
         preventSuspendManager.start()
         serviceSessionManager.start()
 
@@ -399,6 +415,8 @@ public final class TraceletSdk {
             tripManager.reset()
             stopBatteryBudgetSampling()
             batteryBudgetEngine?.reset()
+            stopBehaviorSampling()
+            telematicsEngine?.reset()
             eventSender.sendEnabledChange(false)
             logger.info("stop() — tracking stopped")
         }
@@ -1510,6 +1528,7 @@ public final class TraceletSdk {
             eventDispatcher: eventSender
         )
         locationEngine.registerSink(RustDatabaseSinkWrapper(sdk: self))
+        locationEngine.registerSink(TelematicsSinkWrapper(sdk: self))
         if let syncSink = syncProvider as? LocationDataSink {
             locationEngine.registerSink(syncSink)
         }
@@ -1540,6 +1559,10 @@ public final class TraceletSdk {
         // report a permanent "unknown" (#155).
         motionDetector.onActivityChanged = { [weak self] type, _ in
             self?.locationEngine.currentActivityType = type
+        }
+        // 3.3.0: feed accelerometer samples (g) to the classifier/impact keystone.
+        motionDetector.onAccelSample = { [weak self] magnitudeG in
+            self?.feedAccelSample(magnitudeG)
         }
         motionDetector.onStopTimeoutStarted = { [weak self] in
             self?.locationEngine.overrideDistanceFilter(forStopTimeout: true, source: "MotionDetector")
@@ -1743,6 +1766,140 @@ public final class TraceletSdk {
     private func stopSyncIntervalTimer() {
         syncIntervalTimer?.invalidate()
         syncIntervalTimer = nil
+    }
+
+    // MARK: - 3.3.0 behavior engines (telematics / classifier / impact)
+
+    private func initBehaviorEngines() {
+        telematicsEngine = configManager.getEnableDrivingEvents()
+            ? TelematicsEngine(config: TelematicsConfig(
+                harshBrakingG: configManager.getHarshBrakingG(),
+                harshAccelerationG: configManager.getHarshAccelerationG(),
+                harshCorneringG: configManager.getHarshCorneringG(),
+                speedLimitKmh: configManager.getSpeedLimitKmh(),
+                speedingToleranceKmh: configManager.getSpeedingToleranceKmh(),
+                speedingMinDurationMs: configManager.getSpeedingMinDurationMs(),
+                minSpeedForEventsKmh: configManager.getMinSpeedForEventsKmh(),
+                eventDebounceMs: configManager.getEventDebounceMs()))
+            : nil
+
+        transportClassifier = configManager.getEnableFusedClassifier()
+            ? TransportModeClassifier(config: ClassifierConfig(
+                modeSwitchDwellMs: configManager.getModeSwitchDwellMs(),
+                minConfidence: configManager.getMinModeConfidence()))
+            : nil
+
+        impactDetector = (configManager.getEnableCrashDetection() || configManager.getEnableFallDetection())
+            ? ImpactDetector(config: ImpactConfig(
+                enableCrash: configManager.getEnableCrashDetection(),
+                enableFall: configManager.getEnableFallDetection(),
+                crashGThreshold: configManager.getCrashGThreshold(),
+                crashMinSpeedKmh: configManager.getCrashMinSpeedKmh(),
+                fallGThreshold: configManager.getFallGThreshold(),
+                confirmWindowMs: configManager.getConfirmWindowMs(),
+                minConfidence: configManager.getMinImpactConfidence()))
+            : nil
+    }
+
+    /// Feeds an accepted location fix to the telematics engine and emits events.
+    func processTelematics(_ location: [String: Any]) {
+        guard let engine = telematicsEngine else { return }
+        let coords = location["coords"] as? [String: Any] ?? location
+        let speed = (coords["speed"] as? Double) ?? 0.0
+        let heading = (coords["heading"] as? Double) ?? -1.0
+        let lat = (coords["latitude"] as? Double) ?? 0.0
+        let lng = (coords["longitude"] as? Double) ?? 0.0
+        lastSpeedMps = speed
+        lastLat = lat
+        lastLng = lng
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let events = engine.processFix(speed: speed, heading: heading, latitude: lat, longitude: lng, timestampMs: nowMs)
+        for e in events {
+            eventSender.sendDrivingEvent([
+                "kind": e.kind, "severity": e.severity, "speed": e.speed,
+                "value": e.value, "latitude": e.latitude, "longitude": e.longitude,
+                "timestampMs": e.timestampMs,
+            ])
+        }
+    }
+
+    /// Buffers one accelerometer sample (gravity-subtracted g) for the window loop.
+    func feedAccelSample(_ magnitudeG: Double) {
+        guard transportClassifier != nil || impactDetector != nil else { return }
+        accelBufferLock.lock()
+        accelBuffer.append(magnitudeG)
+        accelBufferLock.unlock()
+    }
+
+    private func startBehaviorSampling() {
+        stopBehaviorSampling()
+        guard transportClassifier != nil || impactDetector != nil else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.accelWindowTimer = Timer.scheduledTimer(withTimeInterval: Self.accelWindowInterval, repeats: true) { [weak self] _ in
+                self?.processAccelWindow()
+            }
+            if self.impactDetector != nil {
+                self.impactConfirmTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                    guard let self = self, let detector = self.impactDetector else { return }
+                    let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+                    for e in detector.checkConfirmations(nowMs: nowMs) { self.emitImpact(e) }
+                }
+            }
+        }
+    }
+
+    private func stopBehaviorSampling() {
+        accelWindowTimer?.invalidate(); accelWindowTimer = nil
+        impactConfirmTimer?.invalidate(); impactConfirmTimer = nil
+        accelBufferLock.lock(); accelBuffer.removeAll(); accelBufferLock.unlock()
+    }
+
+    private func processAccelWindow() {
+        accelBufferLock.lock()
+        let samples = accelBuffer
+        accelBuffer.removeAll()
+        accelBufferLock.unlock()
+        guard !samples.isEmpty else { return }
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let window = computeAccelWindow(magnitudesG: samples, durationMs: Int64(Self.accelWindowInterval * 1000))
+
+        if let classifier = transportClassifier {
+            let result = classifier.classify(window: window, speedMps: lastSpeedMps, nowMs: nowMs)
+            if result.changed {
+                eventSender.sendModeChange([
+                    "mode": String(describing: result.mode).lowercased(),
+                    "confidence": result.confidence,
+                ])
+            }
+        }
+        if let detector = impactDetector {
+            let onFoot = lastSpeedMps * 3.6 < configManager.getCrashMinSpeedKmh()
+            if let candidate = detector.onImpactWindow(peakG: window.peakG, speedBeforeMps: lastSpeedMps, isOnFoot: onFoot, latitude: lastLat, longitude: lastLng, nowMs: nowMs) {
+                emitImpact(candidate)
+            }
+        }
+    }
+
+    private func emitImpact(_ e: ImpactEvent) {
+        eventSender.sendImpact([
+            "kind": e.kind, "id": e.id, "confidence": e.confidence, "peakG": e.peakG,
+            "speedBefore": e.speedBefore, "latitude": e.latitude, "longitude": e.longitude,
+            "timestampMs": e.timestampMs, "confirmDeadlineMs": e.confirmDeadlineMs,
+        ])
+    }
+
+    /// Confirms a pending impact candidate (called from the Pigeon host API).
+    public func confirmImpact(_ id: Int64) -> Bool {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        guard let confirmed = impactDetector?.confirm(id: id, nowMs: nowMs) else { return false }
+        emitImpact(confirmed)
+        return true
+    }
+
+    /// Cancels a pending impact candidate (called from the Pigeon host API).
+    public func cancelImpact(_ id: Int64) -> Bool {
+        return impactDetector?.cancel(id: id) ?? false
     }
 
     // MARK: - Private: Battery Budget Sampling
@@ -2435,6 +2592,16 @@ private struct RustDatabaseSinkWrapper: LocationDataSink {
 
     func insertLocation(_ location: [String: Any]) -> String {
         return sdk?.insertLocation(location) ?? ""
+    }
+}
+
+/// Feeds each accepted location into the telematics engine (3.3.0).
+private struct TelematicsSinkWrapper: LocationDataSink {
+    weak var sdk: TraceletSdk?
+
+    func insertLocation(_ location: [String: Any]) -> String {
+        sdk?.processTelematics(location)
+        return ""
     }
 }
 

--- a/sdk/ios/Sources/TraceletSDK/motion/MotionDetector.swift
+++ b/sdk/ios/Sources/TraceletSDK/motion/MotionDetector.swift
@@ -103,6 +103,10 @@ public final class MotionDetector {
     /// Called when motion state changes (isMoving).
     public var onMotionStateChanged: ((Bool) -> Void)?
 
+    /// Emitted per accelerometer sample with the gravity-subtracted magnitude
+    /// in g — feeds the 3.3.0 transport-mode classifier and impact detector.
+    public var onAccelSample: ((Double) -> Void)?
+
     /// Called when stopOnStationary fires — requests full tracking stop.
     public var onStopRequested: (() -> Void)?
 
@@ -310,8 +314,10 @@ public final class MotionDetector {
 
     // Internal for testing
     internal func handleAcceleration(_ acc: CMAcceleration) {
-        // Compute magnitude and subtract gravity (~1g)
+        // Compute magnitude and subtract gravity (~1g). iOS CMAccelerometer
+        // reports in g units, so this residual is already in g.
         let magnitude = sqrt(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z) - 1.0
+        onAccelSample?(abs(magnitude))
 
         if stateManager.isMoving {
             // Currently moving — detect sustained stillness

--- a/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
@@ -7,8 +7,8 @@ import Foundation
 // Depending on the consumer's build setup, the low-level FFI code
 // might be in a separate module, or it might be compiled inline into
 // this module. This is a bit of light hackery to work with both.
-#if canImport(tracelet_coreFFI)
-import tracelet_coreFFI
+#if SWIFT_PACKAGE
+import TraceletCore
 #endif
 
 fileprivate extension RustBuffer {

--- a/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
@@ -7,8 +7,8 @@ import Foundation
 // Depending on the consumer's build setup, the low-level FFI code
 // might be in a separate module, or it might be compiled inline into
 // this module. This is a bit of light hackery to work with both.
-#if SWIFT_PACKAGE
-import TraceletCore
+#if canImport(tracelet_coreFFI)
+import tracelet_coreFFI
 #endif
 
 fileprivate extension RustBuffer {
@@ -415,6 +415,22 @@ fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
 
 // Public interface members begin here.
 
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
+    typealias FfiType = UInt32
+    typealias SwiftType = UInt32
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt32 {
+        return try lift(readInt(&buf))
+    }
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2196,6 +2212,240 @@ public func FfiConverterTypeGeofenceEvaluator_lower(_ value: GeofenceEvaluator) 
 
 
 /**
+ * Detects crash/fall impacts with a confirmation window.
+ */
+public protocol ImpactDetectorProtocol: AnyObject, Sendable {
+    
+    /**
+     * User cancels a candidate ("I'm fine") — no confirmed event will fire.
+     */
+    func cancel(id: Int64)  -> Bool
+    
+    /**
+     * Fires confirmed events for candidates whose deadline has elapsed without
+     * a cancel. Call on a timer.
+     */
+    func checkConfirmations(nowMs: Int64)  -> [ImpactEvent]
+    
+    /**
+     * User (or app) explicitly confirms a candidate is a real emergency now.
+     */
+    func confirm(id: Int64, nowMs: Int64)  -> ImpactEvent?
+    
+    /**
+     * Feeds one accel window's peak plus motion context. Returns a
+     * `potential_*` event when an impact is detected (and registers it for
+     * confirmation), else `None`.
+     */
+    func onImpactWindow(peakG: Double, speedBeforeMps: Double, isOnFoot: Bool, latitude: Double, longitude: Double, nowMs: Int64)  -> ImpactEvent?
+    
+    /**
+     * Number of candidates awaiting confirmation.
+     */
+    func pendingCount()  -> UInt32
+    
+    /**
+     * Clears all pending candidates.
+     */
+    func reset() 
+    
+}
+/**
+ * Detects crash/fall impacts with a confirmation window.
+ */
+open class ImpactDetector: ImpactDetectorProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_tracelet_core_fn_clone_impactdetector(self.handle, $0) }
+    }
+    /**
+     * Creates a detector. Pass `None` for defaults (both detections off).
+     */
+public convenience init(config: ImpactConfig?) {
+    let handle =
+        try! rustCall() {
+    uniffi_tracelet_core_fn_constructor_impactdetector_new(
+        FfiConverterOptionTypeImpactConfig.lower(config),$0
+    )
+}
+    self.init(unsafeFromHandle: handle)
+}
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_tracelet_core_fn_free_impactdetector(handle, $0) }
+    }
+
+    
+
+    
+    /**
+     * User cancels a candidate ("I'm fine") — no confirmed event will fire.
+     */
+open func cancel(id: Int64) -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_impactdetector_cancel(
+            self.uniffiCloneHandle(),
+        FfiConverterInt64.lower(id),$0
+    )
+})
+}
+    
+    /**
+     * Fires confirmed events for candidates whose deadline has elapsed without
+     * a cancel. Call on a timer.
+     */
+open func checkConfirmations(nowMs: Int64) -> [ImpactEvent]  {
+    return try!  FfiConverterSequenceTypeImpactEvent.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_impactdetector_check_confirmations(
+            self.uniffiCloneHandle(),
+        FfiConverterInt64.lower(nowMs),$0
+    )
+})
+}
+    
+    /**
+     * User (or app) explicitly confirms a candidate is a real emergency now.
+     */
+open func confirm(id: Int64, nowMs: Int64) -> ImpactEvent?  {
+    return try!  FfiConverterOptionTypeImpactEvent.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_impactdetector_confirm(
+            self.uniffiCloneHandle(),
+        FfiConverterInt64.lower(id),
+        FfiConverterInt64.lower(nowMs),$0
+    )
+})
+}
+    
+    /**
+     * Feeds one accel window's peak plus motion context. Returns a
+     * `potential_*` event when an impact is detected (and registers it for
+     * confirmation), else `None`.
+     */
+open func onImpactWindow(peakG: Double, speedBeforeMps: Double, isOnFoot: Bool, latitude: Double, longitude: Double, nowMs: Int64) -> ImpactEvent?  {
+    return try!  FfiConverterOptionTypeImpactEvent.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_impactdetector_on_impact_window(
+            self.uniffiCloneHandle(),
+        FfiConverterDouble.lower(peakG),
+        FfiConverterDouble.lower(speedBeforeMps),
+        FfiConverterBool.lower(isOnFoot),
+        FfiConverterDouble.lower(latitude),
+        FfiConverterDouble.lower(longitude),
+        FfiConverterInt64.lower(nowMs),$0
+    )
+})
+}
+    
+    /**
+     * Number of candidates awaiting confirmation.
+     */
+open func pendingCount() -> UInt32  {
+    return try!  FfiConverterUInt32.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_impactdetector_pending_count(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * Clears all pending candidates.
+     */
+open func reset()  {try! rustCall() {
+    uniffi_tracelet_core_fn_method_impactdetector_reset(
+            self.uniffiCloneHandle(),$0
+    )
+}
+}
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeImpactDetector: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = ImpactDetector
+
+    public static func lift(_ handle: UInt64) throws -> ImpactDetector {
+        return ImpactDetector(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: ImpactDetector) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ImpactDetector {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: ImpactDetector, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpactDetector_lift(_ handle: UInt64) throws -> ImpactDetector {
+    return try FfiConverterTypeImpactDetector.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpactDetector_lower(_ value: ImpactDetector) -> UInt64 {
+    return FfiConverterTypeImpactDetector.lower(value)
+}
+
+
+
+
+
+
+/**
  * Provides a Kalman filter implementation tailored for smoothing noisy GPS location data.
  */
 public protocol KalmanLocationFilterProtocol: AnyObject, Sendable {
@@ -3096,6 +3346,366 @@ public func FfiConverterTypeSmartMotionCoordinator_lower(_ value: SmartMotionCoo
 
 
 /**
+ * Detects driving events from a stream of accepted location fixes.
+ */
+public protocol TelematicsEngineProtocol: AnyObject, Sendable {
+    
+    /**
+     * Rolling driving score in [0, 100] (100 = flawless). Penalties accrue
+     * per event weighted by severity.
+     */
+    func currentScore()  -> Double
+    
+    /**
+     * Processes one accepted fix and returns any driving events it triggers.
+     *
+     * `speed` is m/s, `heading` is degrees (negative ⇒ unknown), `timestamp_ms`
+     * is epoch ms. Returns empty until a second fix establishes deltas, on
+     * time gaps, or when nothing crosses a threshold.
+     */
+    func processFix(speed: Double, heading: Double, latitude: Double, longitude: Double, timestampMs: Int64)  -> [DrivingEvent]
+    
+    /**
+     * Clears all state (call on trip start / tracking restart).
+     */
+    func reset() 
+    
+}
+/**
+ * Detects driving events from a stream of accepted location fixes.
+ */
+open class TelematicsEngine: TelematicsEngineProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_tracelet_core_fn_clone_telematicsengine(self.handle, $0) }
+    }
+    /**
+     * Creates an engine. Pass `None` for default thresholds.
+     */
+public convenience init(config: TelematicsConfig?) {
+    let handle =
+        try! rustCall() {
+    uniffi_tracelet_core_fn_constructor_telematicsengine_new(
+        FfiConverterOptionTypeTelematicsConfig.lower(config),$0
+    )
+}
+    self.init(unsafeFromHandle: handle)
+}
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_tracelet_core_fn_free_telematicsengine(handle, $0) }
+    }
+
+    
+
+    
+    /**
+     * Rolling driving score in [0, 100] (100 = flawless). Penalties accrue
+     * per event weighted by severity.
+     */
+open func currentScore() -> Double  {
+    return try!  FfiConverterDouble.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_telematicsengine_current_score(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * Processes one accepted fix and returns any driving events it triggers.
+     *
+     * `speed` is m/s, `heading` is degrees (negative ⇒ unknown), `timestamp_ms`
+     * is epoch ms. Returns empty until a second fix establishes deltas, on
+     * time gaps, or when nothing crosses a threshold.
+     */
+open func processFix(speed: Double, heading: Double, latitude: Double, longitude: Double, timestampMs: Int64) -> [DrivingEvent]  {
+    return try!  FfiConverterSequenceTypeDrivingEvent.lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_telematicsengine_process_fix(
+            self.uniffiCloneHandle(),
+        FfiConverterDouble.lower(speed),
+        FfiConverterDouble.lower(heading),
+        FfiConverterDouble.lower(latitude),
+        FfiConverterDouble.lower(longitude),
+        FfiConverterInt64.lower(timestampMs),$0
+    )
+})
+}
+    
+    /**
+     * Clears all state (call on trip start / tracking restart).
+     */
+open func reset()  {try! rustCall() {
+    uniffi_tracelet_core_fn_method_telematicsengine_reset(
+            self.uniffiCloneHandle(),$0
+    )
+}
+}
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeTelematicsEngine: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = TelematicsEngine
+
+    public static func lift(_ handle: UInt64) throws -> TelematicsEngine {
+        return TelematicsEngine(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: TelematicsEngine) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TelematicsEngine {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: TelematicsEngine, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTelematicsEngine_lift(_ handle: UInt64) throws -> TelematicsEngine {
+    return try FfiConverterTypeTelematicsEngine.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTelematicsEngine_lower(_ value: TelematicsEngine) -> UInt64 {
+    return FfiConverterTypeTelematicsEngine.lower(value)
+}
+
+
+
+
+
+
+/**
+ * Fuses accel features + speed into a transport mode with hysteresis.
+ */
+public protocol TransportModeClassifierProtocol: AnyObject, Sendable {
+    
+    /**
+     * Classifies one window + speed, applying confidence gating and dwell
+     * hysteresis. Returns the currently committed mode.
+     */
+    func classify(window: AccelWindow, speedMps: Double, nowMs: Int64)  -> ModeResult
+    
+    /**
+     * Currently committed mode.
+     */
+    func currentMode()  -> TransportMode
+    
+    /**
+     * Resets to `Unknown`.
+     */
+    func reset() 
+    
+}
+/**
+ * Fuses accel features + speed into a transport mode with hysteresis.
+ */
+open class TransportModeClassifier: TransportModeClassifierProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_tracelet_core_fn_clone_transportmodeclassifier(self.handle, $0) }
+    }
+    /**
+     * Creates a classifier. Pass `None` for default tuning.
+     */
+public convenience init(config: ClassifierConfig?) {
+    let handle =
+        try! rustCall() {
+    uniffi_tracelet_core_fn_constructor_transportmodeclassifier_new(
+        FfiConverterOptionTypeClassifierConfig.lower(config),$0
+    )
+}
+    self.init(unsafeFromHandle: handle)
+}
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_tracelet_core_fn_free_transportmodeclassifier(handle, $0) }
+    }
+
+    
+
+    
+    /**
+     * Classifies one window + speed, applying confidence gating and dwell
+     * hysteresis. Returns the currently committed mode.
+     */
+open func classify(window: AccelWindow, speedMps: Double, nowMs: Int64) -> ModeResult  {
+    return try!  FfiConverterTypeModeResult_lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_transportmodeclassifier_classify(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeAccelWindow_lower(window),
+        FfiConverterDouble.lower(speedMps),
+        FfiConverterInt64.lower(nowMs),$0
+    )
+})
+}
+    
+    /**
+     * Currently committed mode.
+     */
+open func currentMode() -> TransportMode  {
+    return try!  FfiConverterTypeTransportMode_lift(try! rustCall() {
+    uniffi_tracelet_core_fn_method_transportmodeclassifier_current_mode(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+    /**
+     * Resets to `Unknown`.
+     */
+open func reset()  {try! rustCall() {
+    uniffi_tracelet_core_fn_method_transportmodeclassifier_reset(
+            self.uniffiCloneHandle(),$0
+    )
+}
+}
+    
+
+    
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeTransportModeClassifier: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = TransportModeClassifier
+
+    public static func lift(_ handle: UInt64) throws -> TransportModeClassifier {
+        return TransportModeClassifier(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: TransportModeClassifier) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TransportModeClassifier {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: TransportModeClassifier, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTransportModeClassifier_lift(_ handle: UInt64) throws -> TransportModeClassifier {
+    return try FfiConverterTypeTransportModeClassifier.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTransportModeClassifier_lower(_ value: TransportModeClassifier) -> UInt64 {
+    return FfiConverterTypeTransportModeClassifier.lower(value)
+}
+
+
+
+
+
+
+/**
  * Core logic for determining trip boundaries (start/stop) based on location and motion changes.
  */
 public protocol TripManagerProtocol: AnyObject, Sendable {
@@ -3285,6 +3895,119 @@ public func FfiConverterTypeTripManager_lower(_ value: TripManager) -> UInt64 {
 }
 
 
+
+
+/**
+ * Lightweight features summarizing one accelerometer window.
+ */
+public struct AccelWindow: Equatable, Hashable {
+    /**
+     * Mean magnitude (g, gravity-subtracted).
+     */
+    public var meanG: Double
+    /**
+     * Variance of the magnitude — separates steady (vehicle) from bouncy
+     * (running) motion.
+     */
+    public var variance: Double
+    /**
+     * Largest single magnitude in the window (g) — the impact signal.
+     */
+    public var peakG: Double
+    /**
+     * Dominant oscillation frequency (Hz), estimated from mean-crossings —
+     * the cadence cue distinguishing walking (~2 Hz) from running (~3 Hz).
+     */
+    public var dominantCadenceHz: Double
+    /**
+     * Number of samples in the window.
+     */
+    public var sampleCount: UInt32
+    /**
+     * Window duration (ms).
+     */
+    public var durationMs: Int64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Mean magnitude (g, gravity-subtracted).
+         */meanG: Double, 
+        /**
+         * Variance of the magnitude — separates steady (vehicle) from bouncy
+         * (running) motion.
+         */variance: Double, 
+        /**
+         * Largest single magnitude in the window (g) — the impact signal.
+         */peakG: Double, 
+        /**
+         * Dominant oscillation frequency (Hz), estimated from mean-crossings —
+         * the cadence cue distinguishing walking (~2 Hz) from running (~3 Hz).
+         */dominantCadenceHz: Double, 
+        /**
+         * Number of samples in the window.
+         */sampleCount: UInt32, 
+        /**
+         * Window duration (ms).
+         */durationMs: Int64) {
+        self.meanG = meanG
+        self.variance = variance
+        self.peakG = peakG
+        self.dominantCadenceHz = dominantCadenceHz
+        self.sampleCount = sampleCount
+        self.durationMs = durationMs
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension AccelWindow: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeAccelWindow: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccelWindow {
+        return
+            try AccelWindow(
+                meanG: FfiConverterDouble.read(from: &buf), 
+                variance: FfiConverterDouble.read(from: &buf), 
+                peakG: FfiConverterDouble.read(from: &buf), 
+                dominantCadenceHz: FfiConverterDouble.read(from: &buf), 
+                sampleCount: FfiConverterUInt32.read(from: &buf), 
+                durationMs: FfiConverterInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: AccelWindow, into buf: inout [UInt8]) {
+        FfiConverterDouble.write(value.meanG, into: &buf)
+        FfiConverterDouble.write(value.variance, into: &buf)
+        FfiConverterDouble.write(value.peakG, into: &buf)
+        FfiConverterDouble.write(value.dominantCadenceHz, into: &buf)
+        FfiConverterUInt32.write(value.sampleCount, into: &buf)
+        FfiConverterInt64.write(value.durationMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeAccelWindow_lift(_ buf: RustBuffer) throws -> AccelWindow {
+    return try FfiConverterTypeAccelWindow.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeAccelWindow_lower(_ value: AccelWindow) -> RustBuffer {
+    return FfiConverterTypeAccelWindow.lower(value)
+}
 
 
 /**
@@ -3820,6 +4543,75 @@ public func FfiConverterTypeBudgetAdjustmentEvent_lower(_ value: BudgetAdjustmen
 
 
 /**
+ * Classifier tuning.
+ */
+public struct ClassifierConfig: Equatable, Hashable {
+    /**
+     * A candidate mode must persist this long (ms) before it commits.
+     */
+    public var modeSwitchDwellMs: Int64
+    /**
+     * Below this confidence the result is reported as `Unknown`.
+     */
+    public var minConfidence: Double
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * A candidate mode must persist this long (ms) before it commits.
+         */modeSwitchDwellMs: Int64, 
+        /**
+         * Below this confidence the result is reported as `Unknown`.
+         */minConfidence: Double) {
+        self.modeSwitchDwellMs = modeSwitchDwellMs
+        self.minConfidence = minConfidence
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension ClassifierConfig: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeClassifierConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ClassifierConfig {
+        return
+            try ClassifierConfig(
+                modeSwitchDwellMs: FfiConverterInt64.read(from: &buf), 
+                minConfidence: FfiConverterDouble.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ClassifierConfig, into buf: inout [UInt8]) {
+        FfiConverterInt64.write(value.modeSwitchDwellMs, into: &buf)
+        FfiConverterDouble.write(value.minConfidence, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeClassifierConfig_lift(_ buf: RustBuffer) throws -> ClassifierConfig {
+    return try FfiConverterTypeClassifierConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeClassifierConfig_lower(_ value: ClassifierConfig) -> RustBuffer {
+    return FfiConverterTypeClassifierConfig.lower(value)
+}
+
+
+/**
  * Represents a 2D geographical coordinate using latitude and longitude.
  */
 public struct Coordinate: Equatable, Hashable {
@@ -4239,6 +5031,109 @@ public func FfiConverterTypeDbLocationRecord_lift(_ buf: RustBuffer) throws -> D
 #endif
 public func FfiConverterTypeDbLocationRecord_lower(_ value: DbLocationRecord) -> RustBuffer {
     return FfiConverterTypeDbLocationRecord.lower(value)
+}
+
+
+/**
+ * A detected driving event.
+ */
+public struct DrivingEvent: Equatable, Hashable {
+    /**
+     * `harsh_braking` | `harsh_acceleration` | `harsh_cornering` | `speeding`.
+     */
+    public var kind: String
+    /**
+     * Normalized 0–1 severity (how far past the threshold).
+     */
+    public var severity: Double
+    /**
+     * Speed at the event (m/s).
+     */
+    public var speed: Double
+    /**
+     * The measured magnitude that triggered it: g for harsh events, km/h over
+     * the limit for speeding.
+     */
+    public var value: Double
+    public var latitude: Double
+    public var longitude: Double
+    public var timestampMs: Int64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * `harsh_braking` | `harsh_acceleration` | `harsh_cornering` | `speeding`.
+         */kind: String, 
+        /**
+         * Normalized 0–1 severity (how far past the threshold).
+         */severity: Double, 
+        /**
+         * Speed at the event (m/s).
+         */speed: Double, 
+        /**
+         * The measured magnitude that triggered it: g for harsh events, km/h over
+         * the limit for speeding.
+         */value: Double, latitude: Double, longitude: Double, timestampMs: Int64) {
+        self.kind = kind
+        self.severity = severity
+        self.speed = speed
+        self.value = value
+        self.latitude = latitude
+        self.longitude = longitude
+        self.timestampMs = timestampMs
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension DrivingEvent: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeDrivingEvent: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DrivingEvent {
+        return
+            try DrivingEvent(
+                kind: FfiConverterString.read(from: &buf), 
+                severity: FfiConverterDouble.read(from: &buf), 
+                speed: FfiConverterDouble.read(from: &buf), 
+                value: FfiConverterDouble.read(from: &buf), 
+                latitude: FfiConverterDouble.read(from: &buf), 
+                longitude: FfiConverterDouble.read(from: &buf), 
+                timestampMs: FfiConverterInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: DrivingEvent, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.kind, into: &buf)
+        FfiConverterDouble.write(value.severity, into: &buf)
+        FfiConverterDouble.write(value.speed, into: &buf)
+        FfiConverterDouble.write(value.value, into: &buf)
+        FfiConverterDouble.write(value.latitude, into: &buf)
+        FfiConverterDouble.write(value.longitude, into: &buf)
+        FfiConverterInt64.write(value.timestampMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeDrivingEvent_lift(_ buf: RustBuffer) throws -> DrivingEvent {
+    return try FfiConverterTypeDrivingEvent.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeDrivingEvent_lower(_ value: DrivingEvent) -> RustBuffer {
+    return FfiConverterTypeDrivingEvent.lower(value)
 }
 
 
@@ -5063,6 +5958,246 @@ public func FfiConverterTypeHttpConfig_lower(_ value: HttpConfig) -> RustBuffer 
 
 
 /**
+ * Impact detector tuning.
+ */
+public struct ImpactConfig: Equatable, Hashable {
+    /**
+     * Enable vehicle crash detection.
+     */
+    public var enableCrash: Bool
+    /**
+     * Enable personal fall detection (best-effort; more false positives).
+     */
+    public var enableFall: Bool
+    /**
+     * Impact magnitude (g) for a crash candidate.
+     */
+    public var crashGThreshold: Double
+    /**
+     * Pre-impact speed (km/h) required to corroborate a crash.
+     */
+    public var crashMinSpeedKmh: Double
+    /**
+     * Impact magnitude (g) for a fall candidate.
+     */
+    public var fallGThreshold: Double
+    /**
+     * Countdown (ms) before a candidate auto-confirms.
+     */
+    public var confirmWindowMs: Int64
+    /**
+     * Suppress candidates below this confidence.
+     */
+    public var minConfidence: Double
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Enable vehicle crash detection.
+         */enableCrash: Bool, 
+        /**
+         * Enable personal fall detection (best-effort; more false positives).
+         */enableFall: Bool, 
+        /**
+         * Impact magnitude (g) for a crash candidate.
+         */crashGThreshold: Double, 
+        /**
+         * Pre-impact speed (km/h) required to corroborate a crash.
+         */crashMinSpeedKmh: Double, 
+        /**
+         * Impact magnitude (g) for a fall candidate.
+         */fallGThreshold: Double, 
+        /**
+         * Countdown (ms) before a candidate auto-confirms.
+         */confirmWindowMs: Int64, 
+        /**
+         * Suppress candidates below this confidence.
+         */minConfidence: Double) {
+        self.enableCrash = enableCrash
+        self.enableFall = enableFall
+        self.crashGThreshold = crashGThreshold
+        self.crashMinSpeedKmh = crashMinSpeedKmh
+        self.fallGThreshold = fallGThreshold
+        self.confirmWindowMs = confirmWindowMs
+        self.minConfidence = minConfidence
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension ImpactConfig: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeImpactConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ImpactConfig {
+        return
+            try ImpactConfig(
+                enableCrash: FfiConverterBool.read(from: &buf), 
+                enableFall: FfiConverterBool.read(from: &buf), 
+                crashGThreshold: FfiConverterDouble.read(from: &buf), 
+                crashMinSpeedKmh: FfiConverterDouble.read(from: &buf), 
+                fallGThreshold: FfiConverterDouble.read(from: &buf), 
+                confirmWindowMs: FfiConverterInt64.read(from: &buf), 
+                minConfidence: FfiConverterDouble.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ImpactConfig, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.enableCrash, into: &buf)
+        FfiConverterBool.write(value.enableFall, into: &buf)
+        FfiConverterDouble.write(value.crashGThreshold, into: &buf)
+        FfiConverterDouble.write(value.crashMinSpeedKmh, into: &buf)
+        FfiConverterDouble.write(value.fallGThreshold, into: &buf)
+        FfiConverterInt64.write(value.confirmWindowMs, into: &buf)
+        FfiConverterDouble.write(value.minConfidence, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpactConfig_lift(_ buf: RustBuffer) throws -> ImpactConfig {
+    return try FfiConverterTypeImpactConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpactConfig_lower(_ value: ImpactConfig) -> RustBuffer {
+    return FfiConverterTypeImpactConfig.lower(value)
+}
+
+
+/**
+ * An impact event.
+ */
+public struct ImpactEvent: Equatable, Hashable {
+    /**
+     * `potential_crash` | `crash` | `potential_fall` | `fall`.
+     */
+    public var kind: String
+    /**
+     * Candidate id — pair `potential_*` with its later `confirm`/`cancel`.
+     */
+    public var id: Int64
+    /**
+     * 0–1 confidence.
+     */
+    public var confidence: Double
+    /**
+     * Peak magnitude (g) of the impact.
+     */
+    public var peakG: Double
+    /**
+     * Speed before impact (m/s).
+     */
+    public var speedBefore: Double
+    public var latitude: Double
+    public var longitude: Double
+    public var timestampMs: Int64
+    /**
+     * For `potential_*`: epoch ms at which it auto-confirms unless cancelled.
+     */
+    public var confirmDeadlineMs: Int64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * `potential_crash` | `crash` | `potential_fall` | `fall`.
+         */kind: String, 
+        /**
+         * Candidate id — pair `potential_*` with its later `confirm`/`cancel`.
+         */id: Int64, 
+        /**
+         * 0–1 confidence.
+         */confidence: Double, 
+        /**
+         * Peak magnitude (g) of the impact.
+         */peakG: Double, 
+        /**
+         * Speed before impact (m/s).
+         */speedBefore: Double, latitude: Double, longitude: Double, timestampMs: Int64, 
+        /**
+         * For `potential_*`: epoch ms at which it auto-confirms unless cancelled.
+         */confirmDeadlineMs: Int64) {
+        self.kind = kind
+        self.id = id
+        self.confidence = confidence
+        self.peakG = peakG
+        self.speedBefore = speedBefore
+        self.latitude = latitude
+        self.longitude = longitude
+        self.timestampMs = timestampMs
+        self.confirmDeadlineMs = confirmDeadlineMs
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension ImpactEvent: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeImpactEvent: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ImpactEvent {
+        return
+            try ImpactEvent(
+                kind: FfiConverterString.read(from: &buf), 
+                id: FfiConverterInt64.read(from: &buf), 
+                confidence: FfiConverterDouble.read(from: &buf), 
+                peakG: FfiConverterDouble.read(from: &buf), 
+                speedBefore: FfiConverterDouble.read(from: &buf), 
+                latitude: FfiConverterDouble.read(from: &buf), 
+                longitude: FfiConverterDouble.read(from: &buf), 
+                timestampMs: FfiConverterInt64.read(from: &buf), 
+                confirmDeadlineMs: FfiConverterInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ImpactEvent, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.kind, into: &buf)
+        FfiConverterInt64.write(value.id, into: &buf)
+        FfiConverterDouble.write(value.confidence, into: &buf)
+        FfiConverterDouble.write(value.peakG, into: &buf)
+        FfiConverterDouble.write(value.speedBefore, into: &buf)
+        FfiConverterDouble.write(value.latitude, into: &buf)
+        FfiConverterDouble.write(value.longitude, into: &buf)
+        FfiConverterInt64.write(value.timestampMs, into: &buf)
+        FfiConverterInt64.write(value.confirmDeadlineMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpactEvent_lift(_ buf: RustBuffer) throws -> ImpactEvent {
+    return try FfiConverterTypeImpactEvent.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpactEvent_lower(_ value: ImpactEvent) -> RustBuffer {
+    return FfiConverterTypeImpactEvent.lower(value)
+}
+
+
+/**
  * A simple geographical point used for the smoothed output of the Kalman filter.
  */
 public struct LatLng: Equatable, Hashable {
@@ -5413,6 +6548,73 @@ public func FfiConverterTypeLogEntry_lift(_ buf: RustBuffer) throws -> LogEntry 
 #endif
 public func FfiConverterTypeLogEntry_lower(_ value: LogEntry) -> RustBuffer {
     return FfiConverterTypeLogEntry.lower(value)
+}
+
+
+/**
+ * Result of a classification step.
+ */
+public struct ModeResult: Equatable, Hashable {
+    public var mode: TransportMode
+    public var confidence: Double
+    /**
+     * True when this call committed a *change* from the previous committed mode.
+     */
+    public var changed: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(mode: TransportMode, confidence: Double, 
+        /**
+         * True when this call committed a *change* from the previous committed mode.
+         */changed: Bool) {
+        self.mode = mode
+        self.confidence = confidence
+        self.changed = changed
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension ModeResult: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeModeResult: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ModeResult {
+        return
+            try ModeResult(
+                mode: FfiConverterTypeTransportMode.read(from: &buf), 
+                confidence: FfiConverterDouble.read(from: &buf), 
+                changed: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ModeResult, into buf: inout [UInt8]) {
+        FfiConverterTypeTransportMode.write(value.mode, into: &buf)
+        FfiConverterDouble.write(value.confidence, into: &buf)
+        FfiConverterBool.write(value.changed, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeModeResult_lift(_ buf: RustBuffer) throws -> ModeResult {
+    return try FfiConverterTypeModeResult.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeModeResult_lower(_ value: ModeResult) -> RustBuffer {
+    return FfiConverterTypeModeResult.lower(value)
 }
 
 
@@ -5915,6 +7117,142 @@ public func FfiConverterTypeSecurityConfig_lift(_ buf: RustBuffer) throws -> Sec
 #endif
 public func FfiConverterTypeSecurityConfig_lower(_ value: SecurityConfig) -> RustBuffer {
     return FfiConverterTypeSecurityConfig.lower(value)
+}
+
+
+/**
+ * Tunable thresholds for driving-event detection. Defaults follow common
+ * usage-based-insurance / fleet practice and are overridable by the caller.
+ */
+public struct TelematicsConfig: Equatable, Hashable {
+    /**
+     * Longitudinal deceleration (g) above which `harsh_braking` fires.
+     */
+    public var harshBrakingG: Double
+    /**
+     * Longitudinal acceleration (g) above which `harsh_acceleration` fires.
+     */
+    public var harshAccelerationG: Double
+    /**
+     * Lateral acceleration (g) above which `harsh_cornering` fires.
+     */
+    public var harshCorneringG: Double
+    /**
+     * Global speed limit in km/h. `0` disables threshold-based speeding
+     * (per-geofence limits can still be applied by the caller).
+     */
+    public var speedLimitKmh: Double
+    /**
+     * Grace (km/h) added to the limit before speeding counts.
+     */
+    public var speedingToleranceKmh: Double
+    /**
+     * Sustained time over the limit (ms) before `speeding` fires.
+     */
+    public var speedingMinDurationMs: Int64
+    /**
+     * Suppress brake/accel/corner events below this speed (km/h) to avoid
+     * parking-lot / GPS-jitter noise.
+     */
+    public var minSpeedForEventsKmh: Double
+    /**
+     * Minimum time between two events of the same kind (ms) — debounce so a
+     * single maneuver spanning several fixes yields one event.
+     */
+    public var eventDebounceMs: Int64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Longitudinal deceleration (g) above which `harsh_braking` fires.
+         */harshBrakingG: Double, 
+        /**
+         * Longitudinal acceleration (g) above which `harsh_acceleration` fires.
+         */harshAccelerationG: Double, 
+        /**
+         * Lateral acceleration (g) above which `harsh_cornering` fires.
+         */harshCorneringG: Double, 
+        /**
+         * Global speed limit in km/h. `0` disables threshold-based speeding
+         * (per-geofence limits can still be applied by the caller).
+         */speedLimitKmh: Double, 
+        /**
+         * Grace (km/h) added to the limit before speeding counts.
+         */speedingToleranceKmh: Double, 
+        /**
+         * Sustained time over the limit (ms) before `speeding` fires.
+         */speedingMinDurationMs: Int64, 
+        /**
+         * Suppress brake/accel/corner events below this speed (km/h) to avoid
+         * parking-lot / GPS-jitter noise.
+         */minSpeedForEventsKmh: Double, 
+        /**
+         * Minimum time between two events of the same kind (ms) — debounce so a
+         * single maneuver spanning several fixes yields one event.
+         */eventDebounceMs: Int64) {
+        self.harshBrakingG = harshBrakingG
+        self.harshAccelerationG = harshAccelerationG
+        self.harshCorneringG = harshCorneringG
+        self.speedLimitKmh = speedLimitKmh
+        self.speedingToleranceKmh = speedingToleranceKmh
+        self.speedingMinDurationMs = speedingMinDurationMs
+        self.minSpeedForEventsKmh = minSpeedForEventsKmh
+        self.eventDebounceMs = eventDebounceMs
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension TelematicsConfig: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeTelematicsConfig: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TelematicsConfig {
+        return
+            try TelematicsConfig(
+                harshBrakingG: FfiConverterDouble.read(from: &buf), 
+                harshAccelerationG: FfiConverterDouble.read(from: &buf), 
+                harshCorneringG: FfiConverterDouble.read(from: &buf), 
+                speedLimitKmh: FfiConverterDouble.read(from: &buf), 
+                speedingToleranceKmh: FfiConverterDouble.read(from: &buf), 
+                speedingMinDurationMs: FfiConverterInt64.read(from: &buf), 
+                minSpeedForEventsKmh: FfiConverterDouble.read(from: &buf), 
+                eventDebounceMs: FfiConverterInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: TelematicsConfig, into buf: inout [UInt8]) {
+        FfiConverterDouble.write(value.harshBrakingG, into: &buf)
+        FfiConverterDouble.write(value.harshAccelerationG, into: &buf)
+        FfiConverterDouble.write(value.harshCorneringG, into: &buf)
+        FfiConverterDouble.write(value.speedLimitKmh, into: &buf)
+        FfiConverterDouble.write(value.speedingToleranceKmh, into: &buf)
+        FfiConverterInt64.write(value.speedingMinDurationMs, into: &buf)
+        FfiConverterDouble.write(value.minSpeedForEventsKmh, into: &buf)
+        FfiConverterInt64.write(value.eventDebounceMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTelematicsConfig_lift(_ buf: RustBuffer) throws -> TelematicsConfig {
+    return try FfiConverterTypeTelematicsConfig.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTelematicsConfig_lower(_ value: TelematicsConfig) -> RustBuffer {
+    return FfiConverterTypeTelematicsConfig.lower(value)
 }
 
 
@@ -6618,6 +7956,105 @@ public func FfiConverterTypeTrackingMode_lower(_ value: TrackingMode) -> RustBuf
 }
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Detected travel mode. Distinct from the platform `ActivityType` so adding
+ * `Cycling` here doesn't perturb existing activity plumbing.
+ */
+
+public enum TransportMode: Equatable, Hashable {
+    
+    case unknown
+    case still
+    case walking
+    case running
+    case cycling
+    case vehicle
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension TransportMode: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeTransportMode: FfiConverterRustBuffer {
+    typealias SwiftType = TransportMode
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TransportMode {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .unknown
+        
+        case 2: return .still
+        
+        case 3: return .walking
+        
+        case 4: return .running
+        
+        case 5: return .cycling
+        
+        case 6: return .vehicle
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: TransportMode, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .unknown:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .still:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .walking:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .running:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .cycling:
+            writeInt(&buf, Int32(5))
+        
+        
+        case .vehicle:
+            writeInt(&buf, Int32(6))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTransportMode_lift(_ buf: RustBuffer) throws -> TransportMode {
+    return try FfiConverterTypeTransportMode.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeTransportMode_lower(_ value: TransportMode) -> RustBuffer {
+    return FfiConverterTypeTransportMode.lower(value)
+}
+
+
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
@@ -6813,6 +8250,30 @@ fileprivate struct FfiConverterOptionTypeBudgetAdjustmentEvent: FfiConverterRust
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeClassifierConfig: FfiConverterRustBuffer {
+    typealias SwiftType = ClassifierConfig?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeClassifierConfig.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeClassifierConfig.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeDbLocationRecord: FfiConverterRustBuffer {
     typealias SwiftType = DbLocationRecord?
 
@@ -6829,6 +8290,54 @@ fileprivate struct FfiConverterOptionTypeDbLocationRecord: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeDbLocationRecord.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeImpactConfig: FfiConverterRustBuffer {
+    typealias SwiftType = ImpactConfig?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeImpactConfig.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeImpactConfig.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeImpactEvent: FfiConverterRustBuffer {
+    typealias SwiftType = ImpactEvent?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeImpactEvent.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeImpactEvent.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -6877,6 +8386,30 @@ fileprivate struct FfiConverterOptionTypeLocationRecord: FfiConverterRustBuffer 
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeLocationRecord.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeTelematicsConfig: FfiConverterRustBuffer {
+    typealias SwiftType = TelematicsConfig?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeTelematicsConfig.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeTelematicsConfig.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -6999,6 +8532,31 @@ fileprivate struct FfiConverterOptionDictionaryStringString: FfiConverterRustBuf
         case 1: return try FfiConverterDictionaryStringString.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceDouble: FfiConverterRustBuffer {
+    typealias SwiftType = [Double]
+
+    public static func write(_ value: [Double], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterDouble.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [Double] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [Double]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterDouble.read(from: &buf))
+        }
+        return seq
     }
 }
 
@@ -7180,6 +8738,31 @@ fileprivate struct FfiConverterSequenceTypeDbLocationRecord: FfiConverterRustBuf
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeDrivingEvent: FfiConverterRustBuffer {
+    typealias SwiftType = [DrivingEvent]
+
+    public static func write(_ value: [DrivingEvent], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeDrivingEvent.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [DrivingEvent] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [DrivingEvent]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeDrivingEvent.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeGeofenceTransition: FfiConverterRustBuffer {
     typealias SwiftType = [GeofenceTransition]
 
@@ -7197,6 +8780,31 @@ fileprivate struct FfiConverterSequenceTypeGeofenceTransition: FfiConverterRustB
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeGeofenceTransition.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeImpactEvent: FfiConverterRustBuffer {
+    typealias SwiftType = [ImpactEvent]
+
+    public static func write(_ value: [ImpactEvent], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeImpactEvent.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [ImpactEvent] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [ImpactEvent]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeImpactEvent.read(from: &buf))
         }
         return seq
     }
@@ -7304,6 +8912,18 @@ public func isPointInPolygon(lat: Double, lng: Double, vertices: [Coordinate]) -
 })
 }
 /**
+ * Computes [`AccelWindow`] features from a batch of gravity-subtracted
+ * magnitudes (g) spanning `duration_ms`.
+ */
+public func computeAccelWindow(magnitudesG: [Double], durationMs: Int64) -> AccelWindow  {
+    return try!  FfiConverterTypeAccelWindow_lift(try! rustCall() {
+    uniffi_tracelet_core_fn_func_compute_accel_window(
+        FfiConverterSequenceDouble.lower(magnitudesG),
+        FfiConverterInt64.lower(durationMs),$0
+    )
+})
+}
+/**
  * Builds a deterministic canonical string from a location record and its preceding chain hash.
  */
 public func buildCanonicalString(previousHash: String, chainIndex: Int32, loc: LocationRecord) -> String  {
@@ -7357,6 +8977,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_tracelet_core_checksum_func_is_point_in_polygon() != 16595) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_tracelet_core_checksum_func_compute_accel_window() != 29960) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_tracelet_core_checksum_func_build_canonical_string() != 7071) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -7364,6 +8987,24 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_func_sha256() != 14625) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_impactdetector_cancel() != 42443) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_impactdetector_check_confirmations() != 9379) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_impactdetector_confirm() != 51069) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_impactdetector_on_impact_window() != 28969) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_impactdetector_pending_count() != 63414) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_impactdetector_reset() != 57860) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_method_kalmanlocationfilter_estimated_speed() != 64160) {
@@ -7397,6 +9038,24 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_method_scheduleparser_is_within_schedule() != 16562) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_telematicsengine_current_score() != 11738) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_telematicsengine_process_fix() != 30835) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_telematicsengine_reset() != 5304) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_transportmodeclassifier_classify() != 52837) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_transportmodeclassifier_current_mode() != 65278) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_method_transportmodeclassifier_reset() != 4812) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_method_tripmanager_is_trip_active() != 47274) {
@@ -7579,6 +9238,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_tracelet_core_checksum_method_smartmotioncoordinator_set_use_geofences_when_stationary() != 15189) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_tracelet_core_checksum_constructor_impactdetector_new() != 56951) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_tracelet_core_checksum_constructor_kalmanlocationfilter_new() != 44956) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -7589,6 +9251,12 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_constructor_scheduleparser_new() != 36401) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_constructor_telematicsengine_new() != 15489) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_tracelet_core_checksum_constructor_transportmodeclassifier_new() != 21163) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_constructor_tripmanager_new() != 53892) {

--- a/sdk/rust-core/core/src/algorithms/impact.rs
+++ b/sdk/rust-core/core/src/algorithms/impact.rs
@@ -1,0 +1,338 @@
+//! Crash & fall detection.
+//!
+//! Safety-critical, so the design centers on **false-positive suppression**: a
+//! crash is only raised when an impact spike is *corroborated* by motion
+//! context (the device was moving at speed), never from a lone spike. Detection
+//! emits a `potential_*` event with a confirmation deadline so the host app can
+//! show a cancel countdown (standard SOS UX); if not cancelled, a confirmed
+//! event fires. Tracelet provides the trustworthy trigger + cancel window; it
+//! never places emergency calls itself.
+//!
+//! Consumes the peak magnitude from the [`AccelWindow`](crate::algorithms::sensor_features)
+//! keystone plus speed/context supplied by the location pipeline.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Impact detector tuning.
+#[derive(uniffi::Record, Clone, Copy, Debug)]
+pub struct ImpactConfig {
+    /// Enable vehicle crash detection.
+    pub enable_crash: bool,
+    /// Enable personal fall detection (best-effort; more false positives).
+    pub enable_fall: bool,
+    /// Impact magnitude (g) for a crash candidate.
+    pub crash_g_threshold: f64,
+    /// Pre-impact speed (km/h) required to corroborate a crash.
+    pub crash_min_speed_kmh: f64,
+    /// Impact magnitude (g) for a fall candidate.
+    pub fall_g_threshold: f64,
+    /// Countdown (ms) before a candidate auto-confirms.
+    pub confirm_window_ms: i64,
+    /// Suppress candidates below this confidence.
+    pub min_confidence: f64,
+}
+
+impl Default for ImpactConfig {
+    fn default() -> Self {
+        Self {
+            enable_crash: false,
+            enable_fall: false,
+            crash_g_threshold: 3.0,
+            crash_min_speed_kmh: 25.0,
+            fall_g_threshold: 2.5,
+            confirm_window_ms: 15000,
+            min_confidence: 0.6,
+        }
+    }
+}
+
+/// An impact event.
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct ImpactEvent {
+    /// `potential_crash` | `crash` | `potential_fall` | `fall`.
+    pub kind: String,
+    /// Candidate id — pair `potential_*` with its later `confirm`/`cancel`.
+    pub id: i64,
+    /// 0–1 confidence.
+    pub confidence: f64,
+    /// Peak magnitude (g) of the impact.
+    pub peak_g: f64,
+    /// Speed before impact (m/s).
+    pub speed_before: f64,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub timestamp_ms: i64,
+    /// For `potential_*`: epoch ms at which it auto-confirms unless cancelled.
+    pub confirm_deadline_ms: i64,
+}
+
+struct Pending {
+    is_crash: bool,
+    confidence: f64,
+    peak_g: f64,
+    speed_before: f64,
+    latitude: f64,
+    longitude: f64,
+    deadline_ms: i64,
+}
+
+struct DetectorState {
+    next_id: i64,
+    pending: HashMap<i64, Pending>,
+}
+
+/// Detects crash/fall impacts with a confirmation window.
+#[derive(uniffi::Object)]
+pub struct ImpactDetector {
+    config: ImpactConfig,
+    state: Mutex<DetectorState>,
+}
+
+fn confidence(peak_g: f64, threshold: f64, speed_factor: f64) -> f64 {
+    let over = if threshold > 0.0 {
+        ((peak_g - threshold) / threshold).clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    (0.5 + 0.5 * over).min(1.0) * speed_factor
+}
+
+#[uniffi::export]
+impl ImpactDetector {
+    /// Creates a detector. Pass `None` for defaults (both detections off).
+    #[uniffi::constructor]
+    pub fn new(config: Option<ImpactConfig>) -> Self {
+        Self {
+            config: config.unwrap_or_default(),
+            state: Mutex::new(DetectorState {
+                next_id: 1,
+                pending: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Feeds one accel window's peak plus motion context. Returns a
+    /// `potential_*` event when an impact is detected (and registers it for
+    /// confirmation), else `None`.
+    pub fn on_impact_window(
+        &self,
+        peak_g: f64,
+        speed_before_mps: f64,
+        is_on_foot: bool,
+        latitude: f64,
+        longitude: f64,
+        now_ms: i64,
+    ) -> Option<ImpactEvent> {
+        let cfg = &self.config;
+        let speed_kmh = speed_before_mps * 3.6;
+
+        // ── Crash: spike corroborated by pre-impact speed ──
+        if cfg.enable_crash
+            && peak_g >= cfg.crash_g_threshold
+            && speed_kmh >= cfg.crash_min_speed_kmh
+        {
+            let conf = confidence(peak_g, cfg.crash_g_threshold, 1.0);
+            if conf >= cfg.min_confidence {
+                return Some(self.register(true, conf, peak_g, speed_before_mps, latitude, longitude, now_ms));
+            }
+        }
+
+        // ── Fall: spike while on foot at low speed (best-effort, opt-in) ──
+        if cfg.enable_fall
+            && is_on_foot
+            && peak_g >= cfg.fall_g_threshold
+            && speed_kmh < cfg.crash_min_speed_kmh
+        {
+            // On-foot context gives weaker corroboration ⇒ scale confidence down.
+            let conf = confidence(peak_g, cfg.fall_g_threshold, 0.85);
+            if conf >= cfg.min_confidence {
+                return Some(self.register(false, conf, peak_g, speed_before_mps, latitude, longitude, now_ms));
+            }
+        }
+
+        None
+    }
+
+    /// Fires confirmed events for candidates whose deadline has elapsed without
+    /// a cancel. Call on a timer.
+    pub fn check_confirmations(&self, now_ms: i64) -> Vec<ImpactEvent> {
+        let mut st = self.state.lock().unwrap();
+        let due: Vec<i64> = st
+            .pending
+            .iter()
+            .filter(|(_, p)| now_ms >= p.deadline_ms)
+            .map(|(id, _)| *id)
+            .collect();
+
+        let mut out = Vec::new();
+        for id in due {
+            if let Some(p) = st.pending.remove(&id) {
+                out.push(confirmed_event(id, &p, now_ms));
+            }
+        }
+        out
+    }
+
+    /// User (or app) explicitly confirms a candidate is a real emergency now.
+    pub fn confirm(&self, id: i64, now_ms: i64) -> Option<ImpactEvent> {
+        let mut st = self.state.lock().unwrap();
+        st.pending.remove(&id).map(|p| confirmed_event(id, &p, now_ms))
+    }
+
+    /// User cancels a candidate ("I'm fine") — no confirmed event will fire.
+    pub fn cancel(&self, id: i64) -> bool {
+        self.state.lock().unwrap().pending.remove(&id).is_some()
+    }
+
+    /// Number of candidates awaiting confirmation.
+    pub fn pending_count(&self) -> u32 {
+        self.state.lock().unwrap().pending.len() as u32
+    }
+
+    /// Clears all pending candidates.
+    pub fn reset(&self) {
+        let mut st = self.state.lock().unwrap();
+        st.pending.clear();
+    }
+}
+
+impl ImpactDetector {
+    #[allow(clippy::too_many_arguments)]
+    fn register(
+        &self,
+        is_crash: bool,
+        conf: f64,
+        peak_g: f64,
+        speed_before: f64,
+        latitude: f64,
+        longitude: f64,
+        now_ms: i64,
+    ) -> ImpactEvent {
+        let mut st = self.state.lock().unwrap();
+        let id = st.next_id;
+        st.next_id += 1;
+        let deadline = now_ms + self.config.confirm_window_ms;
+        st.pending.insert(
+            id,
+            Pending {
+                is_crash,
+                confidence: conf,
+                peak_g,
+                speed_before,
+                latitude,
+                longitude,
+                deadline_ms: deadline,
+            },
+        );
+        ImpactEvent {
+            kind: if is_crash { "potential_crash" } else { "potential_fall" }.to_string(),
+            id,
+            confidence: conf,
+            peak_g,
+            speed_before,
+            latitude,
+            longitude,
+            timestamp_ms: now_ms,
+            confirm_deadline_ms: deadline,
+        }
+    }
+}
+
+fn confirmed_event(id: i64, p: &Pending, now_ms: i64) -> ImpactEvent {
+    ImpactEvent {
+        kind: if p.is_crash { "crash" } else { "fall" }.to_string(),
+        id,
+        confidence: p.confidence,
+        peak_g: p.peak_g,
+        speed_before: p.speed_before,
+        latitude: p.latitude,
+        longitude: p.longitude,
+        timestamp_ms: now_ms,
+        confirm_deadline_ms: now_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn crash_cfg() -> ImpactConfig {
+        ImpactConfig {
+            enable_crash: true,
+            confirm_window_ms: 15000,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn lone_spike_without_speed_is_not_a_crash() {
+        let d = ImpactDetector::new(Some(crash_cfg()));
+        // 4 g but stationary ⇒ no crash (corroboration fails).
+        assert!(d.on_impact_window(4.0, 0.0, false, 0.0, 0.0, 0).is_none());
+    }
+
+    #[test]
+    fn crash_candidate_then_auto_confirm() {
+        let d = ImpactDetector::new(Some(crash_cfg()));
+        let speed = 60.0 / 3.6;
+        let cand = d.on_impact_window(4.0, speed, false, 1.0, 2.0, 1000).unwrap();
+        assert_eq!(cand.kind, "potential_crash");
+        assert_eq!(d.pending_count(), 1);
+
+        // Before deadline ⇒ nothing.
+        assert!(d.check_confirmations(5000).is_empty());
+        // After deadline ⇒ confirmed crash.
+        let confirmed = d.check_confirmations(20000);
+        assert_eq!(confirmed.len(), 1);
+        assert_eq!(confirmed[0].kind, "crash");
+        assert_eq!(confirmed[0].id, cand.id);
+        assert_eq!(d.pending_count(), 0);
+    }
+
+    #[test]
+    fn cancel_prevents_confirmation() {
+        let d = ImpactDetector::new(Some(crash_cfg()));
+        let cand = d.on_impact_window(5.0, 70.0 / 3.6, false, 0.0, 0.0, 0).unwrap();
+        assert!(d.cancel(cand.id));
+        assert!(d.check_confirmations(60000).is_empty());
+        assert_eq!(d.pending_count(), 0);
+    }
+
+    #[test]
+    fn explicit_confirm_fires_immediately_and_once() {
+        let d = ImpactDetector::new(Some(crash_cfg()));
+        let cand = d.on_impact_window(4.5, 80.0 / 3.6, false, 0.0, 0.0, 0).unwrap();
+        let ev = d.confirm(cand.id, 2000).unwrap();
+        assert_eq!(ev.kind, "crash");
+        // Not double-emitted later.
+        assert!(d.check_confirmations(60000).is_empty());
+    }
+
+    #[test]
+    fn fall_disabled_by_default() {
+        let d = ImpactDetector::new(Some(crash_cfg())); // enable_fall = false
+        assert!(d.on_impact_window(3.0, 1.0, true, 0.0, 0.0, 0).is_none());
+    }
+
+    #[test]
+    fn fall_detected_when_enabled() {
+        let cfg = ImpactConfig {
+            enable_fall: true,
+            ..Default::default()
+        };
+        let d = ImpactDetector::new(Some(cfg));
+        // A real fall spikes well past the 2.5 g floor; 3.0 g is below the
+        // confidence gate by design (weak corroboration on foot).
+        let cand = d.on_impact_window(5.0, 0.5, true, 0.0, 0.0, 0).unwrap();
+        assert_eq!(cand.kind, "potential_fall");
+        let confirmed = d.check_confirmations(60000);
+        assert_eq!(confirmed[0].kind, "fall");
+    }
+
+    #[test]
+    fn weak_spike_below_threshold_ignored() {
+        let d = ImpactDetector::new(Some(crash_cfg()));
+        assert!(d.on_impact_window(2.0, 60.0 / 3.6, false, 0.0, 0.0, 0).is_none());
+    }
+}

--- a/sdk/rust-core/core/src/algorithms/mod.rs
+++ b/sdk/rust-core/core/src/algorithms/mod.rs
@@ -1,5 +1,9 @@
 pub mod geo_utils;
+pub mod impact;
 pub mod kalman;
 pub mod location_processor;
 pub mod schedule_parser;
+pub mod sensor_features;
+pub mod telematics;
+pub mod transport_mode;
 pub mod trip_manager;

--- a/sdk/rust-core/core/src/algorithms/sensor_features.rs
+++ b/sdk/rust-core/core/src/algorithms/sensor_features.rs
@@ -1,0 +1,119 @@
+//! Accelerometer feature-window computation — the shared keystone.
+//!
+//! Both platforms already sample the accelerometer at ~10 Hz for motion
+//! detection. Rather than push raw 10 Hz samples across the FFI continuously,
+//! the native layer forwards ~1 s batches of gravity-subtracted magnitudes
+//! (in g) into [`compute_accel_window`], which derives the lightweight features
+//! consumed by the transport-mode classifier and the impact detector. Keeping
+//! the DSP here makes it the single, testable source of truth for both
+//! consumers instead of being re-implemented per platform.
+
+/// Lightweight features summarizing one accelerometer window.
+#[derive(uniffi::Record, Clone, Copy, Debug, PartialEq)]
+pub struct AccelWindow {
+    /// Mean magnitude (g, gravity-subtracted).
+    pub mean_g: f64,
+    /// Variance of the magnitude — separates steady (vehicle) from bouncy
+    /// (running) motion.
+    pub variance: f64,
+    /// Largest single magnitude in the window (g) — the impact signal.
+    pub peak_g: f64,
+    /// Dominant oscillation frequency (Hz), estimated from mean-crossings —
+    /// the cadence cue distinguishing walking (~2 Hz) from running (~3 Hz).
+    pub dominant_cadence_hz: f64,
+    /// Number of samples in the window.
+    pub sample_count: u32,
+    /// Window duration (ms).
+    pub duration_ms: i64,
+}
+
+impl AccelWindow {
+    /// An all-zero window (used when no samples are present).
+    pub fn empty(duration_ms: i64) -> Self {
+        Self {
+            mean_g: 0.0,
+            variance: 0.0,
+            peak_g: 0.0,
+            dominant_cadence_hz: 0.0,
+            sample_count: 0,
+            duration_ms,
+        }
+    }
+}
+
+/// Computes [`AccelWindow`] features from a batch of gravity-subtracted
+/// magnitudes (g) spanning `duration_ms`.
+#[uniffi::export]
+pub fn compute_accel_window(magnitudes_g: Vec<f64>, duration_ms: i64) -> AccelWindow {
+    let n = magnitudes_g.len();
+    if n == 0 {
+        return AccelWindow::empty(duration_ms);
+    }
+
+    let mean = magnitudes_g.iter().sum::<f64>() / n as f64;
+    let variance =
+        magnitudes_g.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n as f64;
+    let peak = magnitudes_g
+        .iter()
+        .fold(0.0_f64, |acc, v| acc.max(v.abs()));
+
+    // Cadence via mean-crossings: each full oscillation crosses the mean twice.
+    let mut crossings = 0_u32;
+    for pair in magnitudes_g.windows(2) {
+        let a = pair[0] - mean;
+        let b = pair[1] - mean;
+        if (a <= 0.0 && b > 0.0) || (a > 0.0 && b <= 0.0) {
+            crossings += 1;
+        }
+    }
+    let duration_s = (duration_ms as f64 / 1000.0).max(1e-3);
+    let dominant_cadence_hz = (crossings as f64 / 2.0) / duration_s;
+
+    AccelWindow {
+        mean_g: mean,
+        variance,
+        peak_g: peak,
+        dominant_cadence_hz,
+        sample_count: n as u32,
+        duration_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_batch_is_zeroed() {
+        let w = compute_accel_window(vec![], 1000);
+        assert_eq!(w.sample_count, 0);
+        assert_eq!(w.peak_g, 0.0);
+        assert_eq!(w.dominant_cadence_hz, 0.0);
+    }
+
+    #[test]
+    fn peak_is_absolute_max() {
+        let w = compute_accel_window(vec![0.1, -0.9, 0.3], 1000);
+        assert!((w.peak_g - 0.9).abs() < 1e-9);
+    }
+
+    #[test]
+    fn steady_signal_has_low_variance_and_no_cadence() {
+        let w = compute_accel_window(vec![0.05; 10], 1000);
+        assert!(w.variance < 1e-9);
+        assert_eq!(w.dominant_cadence_hz, 0.0);
+    }
+
+    #[test]
+    fn oscillation_yields_expected_cadence() {
+        // 20 samples over 1 s oscillating +/- around 0 at 2 full cycles ⇒ ~2 Hz.
+        // Build 2 cycles: 4 mean-crossings ⇒ cadence = 4/2 / 1s = 2 Hz.
+        let mut s = Vec::new();
+        for cycle in 0..2 {
+            let _ = cycle;
+            s.extend_from_slice(&[1.0, 1.0, -1.0, -1.0, 1.0]); // up/down per cycle
+        }
+        let w = compute_accel_window(s, 1000);
+        assert!(w.dominant_cadence_hz >= 1.0 && w.dominant_cadence_hz <= 3.0);
+    }
+}

--- a/sdk/rust-core/core/src/algorithms/telematics.rs
+++ b/sdk/rust-core/core/src/algorithms/telematics.rs
@@ -1,0 +1,436 @@
+//! Driving-behavior (telematics) event detection — Tier 1, GPS-derived.
+//!
+//! Scores successive accepted location fixes into driving events:
+//! `harsh_braking`, `harsh_acceleration`, `harsh_cornering`, and `speeding`.
+//! All inputs (speed, heading, timestamp) already exist in the location
+//! pipeline, so this tier needs **no new sensors** and runs on every platform.
+//!
+//! GPS speed is ~1 Hz and noisy, so the engine favors **specificity over
+//! sensitivity**: thresholds are expressed in g, gaps are rejected, and a
+//! per-kind debounce collapses one maneuver into one event. A fused
+//! accelerometer tier (higher fidelity + crash detection) is layered on later
+//! via the accel-sample feed; this module is the GPS-only foundation.
+
+use std::sync::Mutex;
+
+/// Standard gravity (m/s²) used to express accelerations in g.
+const GRAVITY: f64 = 9.81;
+
+/// Tunable thresholds for driving-event detection. Defaults follow common
+/// usage-based-insurance / fleet practice and are overridable by the caller.
+#[derive(uniffi::Record, Clone, Copy, Debug)]
+pub struct TelematicsConfig {
+    /// Longitudinal deceleration (g) above which `harsh_braking` fires.
+    pub harsh_braking_g: f64,
+    /// Longitudinal acceleration (g) above which `harsh_acceleration` fires.
+    pub harsh_acceleration_g: f64,
+    /// Lateral acceleration (g) above which `harsh_cornering` fires.
+    pub harsh_cornering_g: f64,
+    /// Global speed limit in km/h. `0` disables threshold-based speeding
+    /// (per-geofence limits can still be applied by the caller).
+    pub speed_limit_kmh: f64,
+    /// Grace (km/h) added to the limit before speeding counts.
+    pub speeding_tolerance_kmh: f64,
+    /// Sustained time over the limit (ms) before `speeding` fires.
+    pub speeding_min_duration_ms: i64,
+    /// Suppress brake/accel/corner events below this speed (km/h) to avoid
+    /// parking-lot / GPS-jitter noise.
+    pub min_speed_for_events_kmh: f64,
+    /// Minimum time between two events of the same kind (ms) — debounce so a
+    /// single maneuver spanning several fixes yields one event.
+    pub event_debounce_ms: i64,
+}
+
+impl Default for TelematicsConfig {
+    fn default() -> Self {
+        Self {
+            harsh_braking_g: 0.40,
+            harsh_acceleration_g: 0.35,
+            harsh_cornering_g: 0.40,
+            speed_limit_kmh: 0.0,
+            speeding_tolerance_kmh: 5.0,
+            speeding_min_duration_ms: 3000,
+            min_speed_for_events_kmh: 5.0,
+            event_debounce_ms: 2000,
+        }
+    }
+}
+
+/// A detected driving event.
+#[derive(uniffi::Record, Clone, Debug, PartialEq)]
+pub struct DrivingEvent {
+    /// `harsh_braking` | `harsh_acceleration` | `harsh_cornering` | `speeding`.
+    pub kind: String,
+    /// Normalized 0–1 severity (how far past the threshold).
+    pub severity: f64,
+    /// Speed at the event (m/s).
+    pub speed: f64,
+    /// The measured magnitude that triggered it: g for harsh events, km/h over
+    /// the limit for speeding.
+    pub value: f64,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub timestamp_ms: i64,
+}
+
+struct EngineState {
+    prev_speed: Option<f64>,
+    prev_heading: Option<f64>,
+    prev_ts: Option<i64>,
+    /// When the device first went over the speed limit (None = under).
+    speeding_since_ms: Option<i64>,
+    /// Whether a speeding event has already fired for the current overspeed run.
+    speeding_fired: bool,
+    /// Last fire time per kind, for debounce.
+    last_braking_ms: i64,
+    last_accel_ms: i64,
+    last_corner_ms: i64,
+    /// Accumulated score penalty (driving score = 100 − penalty, clamped).
+    penalty: f64,
+}
+
+impl EngineState {
+    fn new() -> Self {
+        Self {
+            prev_speed: None,
+            prev_heading: None,
+            prev_ts: None,
+            speeding_since_ms: None,
+            speeding_fired: false,
+            last_braking_ms: i64::MIN,
+            last_accel_ms: i64::MIN,
+            last_corner_ms: i64::MIN,
+            penalty: 0.0,
+        }
+    }
+}
+
+/// Detects driving events from a stream of accepted location fixes.
+#[derive(uniffi::Object)]
+pub struct TelematicsEngine {
+    config: TelematicsConfig,
+    state: Mutex<EngineState>,
+}
+
+/// Normalizes a heading delta (degrees) to the range [-180, 180].
+fn normalize_heading_delta(mut d: f64) -> f64 {
+    while d > 180.0 {
+        d -= 360.0;
+    }
+    while d < -180.0 {
+        d += 360.0;
+    }
+    d
+}
+
+/// Severity as a fraction past threshold, clamped to [0, 1].
+fn severity(magnitude: f64, threshold: f64) -> f64 {
+    if threshold <= 0.0 {
+        return 1.0;
+    }
+    ((magnitude - threshold) / threshold).clamp(0.0, 1.0)
+}
+
+#[uniffi::export]
+impl TelematicsEngine {
+    /// Creates an engine. Pass `None` for default thresholds.
+    #[uniffi::constructor]
+    pub fn new(config: Option<TelematicsConfig>) -> Self {
+        Self {
+            config: config.unwrap_or_default(),
+            state: Mutex::new(EngineState::new()),
+        }
+    }
+
+    /// Processes one accepted fix and returns any driving events it triggers.
+    ///
+    /// `speed` is m/s, `heading` is degrees (negative ⇒ unknown), `timestamp_ms`
+    /// is epoch ms. Returns empty until a second fix establishes deltas, on
+    /// time gaps, or when nothing crosses a threshold.
+    pub fn process_fix(
+        &self,
+        speed: f64,
+        heading: f64,
+        latitude: f64,
+        longitude: f64,
+        timestamp_ms: i64,
+    ) -> Vec<DrivingEvent> {
+        let cfg = &self.config;
+        let mut st = self.state.lock().unwrap();
+        let mut events = Vec::new();
+
+        // Speeding is evaluated from the absolute speed (no previous fix needed).
+        if cfg.speed_limit_kmh > 0.0 {
+            let speed_kmh = speed * 3.6;
+            let ceiling = cfg.speed_limit_kmh + cfg.speeding_tolerance_kmh;
+            if speed_kmh > ceiling {
+                let since = *st.speeding_since_ms.get_or_insert(timestamp_ms);
+                if !st.speeding_fired
+                    && timestamp_ms - since >= cfg.speeding_min_duration_ms
+                {
+                    st.speeding_fired = true;
+                    let over = speed_kmh - cfg.speed_limit_kmh;
+                    let sev = severity(over, cfg.speeding_tolerance_kmh.max(1.0));
+                    st.penalty += 5.0 * (0.5 + sev);
+                    events.push(DrivingEvent {
+                        kind: "speeding".to_string(),
+                        severity: sev,
+                        speed,
+                        value: over,
+                        latitude,
+                        longitude,
+                        timestamp_ms,
+                    });
+                }
+            } else {
+                // Back under the ceiling — reset the overspeed run.
+                st.speeding_since_ms = None;
+                st.speeding_fired = false;
+            }
+        }
+
+        // Harsh events need a previous fix and a sane time delta.
+        let (prev_speed, prev_ts) = match (st.prev_speed, st.prev_ts) {
+            (Some(s), Some(t)) => (s, t),
+            _ => {
+                st.prev_speed = Some(speed);
+                st.prev_heading = Some(heading);
+                st.prev_ts = Some(timestamp_ms);
+                return events;
+            }
+        };
+        let prev_heading = st.prev_heading;
+
+        let dt = (timestamp_ms - prev_ts) as f64 / 1000.0;
+        // Reject non-positive or large gaps (signal loss / resume).
+        let valid_dt = dt > 0.0 && dt <= 10.0;
+        // Suppress maneuver events at very low speed (jitter dominates).
+        let fast_enough =
+            speed.max(prev_speed) * 3.6 >= cfg.min_speed_for_events_kmh;
+
+        if valid_dt && fast_enough {
+            // ── Longitudinal: braking / acceleration ──
+            let long_accel = (speed - prev_speed) / dt; // m/s²
+            let long_g = long_accel / GRAVITY;
+
+            if long_g <= -cfg.harsh_braking_g
+                && timestamp_ms.saturating_sub(st.last_braking_ms) >= cfg.event_debounce_ms
+            {
+                st.last_braking_ms = timestamp_ms;
+                let mag = long_g.abs();
+                let sev = severity(mag, cfg.harsh_braking_g);
+                st.penalty += 4.0 * (0.5 + sev);
+                events.push(DrivingEvent {
+                    kind: "harsh_braking".to_string(),
+                    severity: sev,
+                    speed,
+                    value: mag,
+                    latitude,
+                    longitude,
+                    timestamp_ms,
+                });
+            } else if long_g >= cfg.harsh_acceleration_g
+                && timestamp_ms.saturating_sub(st.last_accel_ms) >= cfg.event_debounce_ms
+            {
+                st.last_accel_ms = timestamp_ms;
+                let sev = severity(long_g, cfg.harsh_acceleration_g);
+                st.penalty += 3.0 * (0.5 + sev);
+                events.push(DrivingEvent {
+                    kind: "harsh_acceleration".to_string(),
+                    severity: sev,
+                    speed,
+                    value: long_g,
+                    latitude,
+                    longitude,
+                    timestamp_ms,
+                });
+            }
+
+            // ── Lateral: cornering (needs valid headings) ──
+            if heading >= 0.0 {
+                if let Some(ph) = prev_heading.filter(|h| *h >= 0.0) {
+                    let yaw_rad = normalize_heading_delta(heading - ph).to_radians();
+                    let yaw_rate = yaw_rad / dt; // rad/s
+                    let lateral = (yaw_rate * speed).abs(); // m/s²
+                    let lat_g = lateral / GRAVITY;
+                    if lat_g >= cfg.harsh_cornering_g
+                        && timestamp_ms.saturating_sub(st.last_corner_ms) >= cfg.event_debounce_ms
+                    {
+                        st.last_corner_ms = timestamp_ms;
+                        let sev = severity(lat_g, cfg.harsh_cornering_g);
+                        st.penalty += 3.0 * (0.5 + sev);
+                        events.push(DrivingEvent {
+                            kind: "harsh_cornering".to_string(),
+                            severity: sev,
+                            speed,
+                            value: lat_g,
+                            latitude,
+                            longitude,
+                            timestamp_ms,
+                        });
+                    }
+                }
+            }
+        }
+
+        st.prev_speed = Some(speed);
+        st.prev_heading = Some(heading);
+        st.prev_ts = Some(timestamp_ms);
+        events
+    }
+
+    /// Rolling driving score in [0, 100] (100 = flawless). Penalties accrue
+    /// per event weighted by severity.
+    pub fn current_score(&self) -> f64 {
+        let penalty = self.state.lock().unwrap().penalty;
+        (100.0 - penalty).clamp(0.0, 100.0)
+    }
+
+    /// Clears all state (call on trip start / tracking restart).
+    pub fn reset(&self) {
+        *self.state.lock().unwrap() = EngineState::new();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn engine() -> TelematicsEngine {
+        TelematicsEngine::new(None)
+    }
+
+    // Helper: feed a fix and return the kinds emitted.
+    fn kinds(ev: &[DrivingEvent]) -> Vec<&str> {
+        ev.iter().map(|e| e.kind.as_str()).collect()
+    }
+
+    #[test]
+    fn first_fix_emits_nothing() {
+        let e = engine();
+        assert!(e.process_fix(20.0, 90.0, 0.0, 0.0, 0).is_empty());
+    }
+
+    #[test]
+    fn harsh_braking_detected() {
+        let e = engine();
+        e.process_fix(20.0, 90.0, 0.0, 0.0, 0); // prime
+        // 20 → 8 m/s in 1 s = -12 m/s² ≈ -1.22 g
+        let ev = e.process_fix(8.0, 90.0, 0.0, 0.0, 1000);
+        assert_eq!(kinds(&ev), vec!["harsh_braking"]);
+        assert!(ev[0].severity > 0.5);
+    }
+
+    #[test]
+    fn harsh_acceleration_detected() {
+        let e = engine();
+        e.process_fix(5.0, 90.0, 0.0, 0.0, 0);
+        // 5 → 12 m/s in 1 s = 7 m/s² ≈ 0.71 g (> 0.35)
+        let ev = e.process_fix(12.0, 90.0, 0.0, 0.0, 1000);
+        assert_eq!(kinds(&ev), vec!["harsh_acceleration"]);
+    }
+
+    #[test]
+    fn gentle_changes_ignored() {
+        let e = engine();
+        e.process_fix(10.0, 90.0, 0.0, 0.0, 0);
+        // +1 m/s over 1 s ≈ 0.1 g
+        assert!(e.process_fix(11.0, 90.0, 0.0, 0.0, 1000).is_empty());
+    }
+
+    #[test]
+    fn harsh_cornering_detected() {
+        let e = engine();
+        e.process_fix(15.0, 0.0, 0.0, 0.0, 0);
+        // 30° turn in 1 s at 15 m/s ⇒ lateral ≈ 7.85 m/s² ≈ 0.8 g
+        let ev = e.process_fix(15.0, 30.0, 0.0, 0.0, 1000);
+        assert!(kinds(&ev).contains(&"harsh_cornering"));
+    }
+
+    #[test]
+    fn cornering_skipped_when_heading_unknown() {
+        let e = engine();
+        e.process_fix(15.0, -1.0, 0.0, 0.0, 0);
+        let ev = e.process_fix(15.0, -1.0, 0.0, 0.0, 1000);
+        assert!(!kinds(&ev).contains(&"harsh_cornering"));
+    }
+
+    #[test]
+    fn low_speed_suppresses_events() {
+        let e = engine();
+        e.process_fix(1.0, 90.0, 0.0, 0.0, 0);
+        // big relative change but both speeds < 5 km/h
+        assert!(e.process_fix(0.0, 90.0, 0.0, 0.0, 1000).is_empty());
+    }
+
+    #[test]
+    fn time_gap_rejected() {
+        let e = engine();
+        e.process_fix(20.0, 90.0, 0.0, 0.0, 0);
+        // 30 s gap (> 10 s) ⇒ no event despite big delta
+        assert!(e.process_fix(2.0, 90.0, 0.0, 0.0, 30_000).is_empty());
+    }
+
+    #[test]
+    fn braking_debounced_across_adjacent_fixes() {
+        let e = engine();
+        e.process_fix(25.0, 90.0, 0.0, 0.0, 0);
+        // Three consecutive hard-braking samples 500 ms apart; debounce = 2 s.
+        let mut total = 0;
+        for (i, s) in [15.0, 6.0, 0.0].iter().enumerate() {
+            let t = 500 * (i as i64 + 1);
+            total += e
+                .process_fix(*s, 90.0, 0.0, 0.0, t)
+                .iter()
+                .filter(|e| e.kind == "harsh_braking")
+                .count();
+        }
+        assert_eq!(total, 1, "debounce should collapse one maneuver to one event");
+    }
+
+    #[test]
+    fn speeding_requires_sustained_duration() {
+        let cfg = TelematicsConfig {
+            speed_limit_kmh: 50.0,
+            ..Default::default()
+        };
+        let e = TelematicsEngine::new(Some(cfg));
+        // 60 km/h = 16.67 m/s, ceiling = 55 km/h. min duration 3 s.
+        let s = 60.0 / 3.6;
+        assert!(e.process_fix(s, 90.0, 0.0, 0.0, 0).is_empty()); // just started
+        assert!(e.process_fix(s, 90.0, 0.0, 0.0, 2000).is_empty()); // 2 s < 3 s
+        let ev = e.process_fix(s, 90.0, 0.0, 0.0, 3500); // 3.5 s ≥ 3 s
+        assert!(kinds(&ev).contains(&"speeding"));
+        // Doesn't re-fire while still speeding.
+        assert!(!kinds(&e.process_fix(s, 90.0, 0.0, 0.0, 5000)).contains(&"speeding"));
+    }
+
+    #[test]
+    fn speeding_resets_when_back_under_limit() {
+        let cfg = TelematicsConfig {
+            speed_limit_kmh: 50.0,
+            ..Default::default()
+        };
+        let e = TelematicsEngine::new(Some(cfg));
+        let fast = 60.0 / 3.6;
+        let slow = 40.0 / 3.6;
+        e.process_fix(fast, 90.0, 0.0, 0.0, 0);
+        e.process_fix(fast, 90.0, 0.0, 0.0, 4000); // fires
+        e.process_fix(slow, 90.0, 0.0, 0.0, 6000); // back under — reset
+        // New overspeed run can fire again after its own duration.
+        e.process_fix(fast, 90.0, 0.0, 0.0, 8000);
+        let ev = e.process_fix(fast, 90.0, 0.0, 0.0, 12_000);
+        assert!(kinds(&ev).contains(&"speeding"));
+    }
+
+    #[test]
+    fn score_decreases_after_events_and_resets() {
+        let e = engine();
+        assert_eq!(e.current_score(), 100.0);
+        e.process_fix(25.0, 90.0, 0.0, 0.0, 0);
+        e.process_fix(5.0, 90.0, 0.0, 0.0, 1000); // hard brake
+        assert!(e.current_score() < 100.0);
+        e.reset();
+        assert_eq!(e.current_score(), 100.0);
+    }
+}

--- a/sdk/rust-core/core/src/algorithms/transport_mode.rs
+++ b/sdk/rust-core/core/src/algorithms/transport_mode.rs
@@ -1,0 +1,264 @@
+//! On-device transport-mode classifier (fused accelerometer + GPS speed).
+//!
+//! Augments the coarse, laggy platform Activity-Recognition signal with a
+//! deterministic, explainable rule classifier over [`AccelWindow`] features
+//! and GPS speed. Output is annotate-by-default (the platform value stays
+//! authoritative unless the host opts in), with hysteresis so a mode must
+//! persist before it commits — mirroring the moving/stationary coordinator.
+//!
+//! Rule-based and transparent on purpose: no opaque model weights, zero binary
+//! bloat, fully unit-testable. A pluggable model can come later if needed.
+
+use std::sync::Mutex;
+
+use crate::algorithms::sensor_features::AccelWindow;
+
+/// Detected travel mode. Distinct from the platform `ActivityType` so adding
+/// `Cycling` here doesn't perturb existing activity plumbing.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransportMode {
+    Unknown,
+    Still,
+    Walking,
+    Running,
+    Cycling,
+    Vehicle,
+}
+
+/// Classifier tuning.
+#[derive(uniffi::Record, Clone, Copy, Debug)]
+pub struct ClassifierConfig {
+    /// A candidate mode must persist this long (ms) before it commits.
+    pub mode_switch_dwell_ms: i64,
+    /// Below this confidence the result is reported as `Unknown`.
+    pub min_confidence: f64,
+}
+
+impl Default for ClassifierConfig {
+    fn default() -> Self {
+        Self {
+            mode_switch_dwell_ms: 8000,
+            min_confidence: 0.6,
+        }
+    }
+}
+
+/// Result of a classification step.
+#[derive(uniffi::Record, Clone, Copy, Debug, PartialEq)]
+pub struct ModeResult {
+    pub mode: TransportMode,
+    pub confidence: f64,
+    /// True when this call committed a *change* from the previous committed mode.
+    pub changed: bool,
+}
+
+struct ClassifierState {
+    committed: TransportMode,
+    candidate: TransportMode,
+    candidate_since_ms: i64,
+    has_candidate: bool,
+}
+
+/// Fuses accel features + speed into a transport mode with hysteresis.
+#[derive(uniffi::Object)]
+pub struct TransportModeClassifier {
+    config: ClassifierConfig,
+    state: Mutex<ClassifierState>,
+}
+
+/// Pure instantaneous classification (pre-hysteresis): returns the raw
+/// candidate mode + confidence from one window + speed.
+fn classify_instant(window: AccelWindow, speed_mps: f64) -> (TransportMode, f64) {
+    let speed_kmh = speed_mps * 3.6;
+    let cadence = window.dominant_cadence_hz;
+    let variance = window.variance;
+
+    // Vehicle: sustained higher speed with relatively steady acceleration.
+    if speed_kmh >= 25.0 {
+        let conf = if speed_kmh >= 45.0 { 0.95 } else { 0.8 };
+        return (TransportMode::Vehicle, conf);
+    }
+
+    // Still: near-zero speed and little vibration.
+    if speed_kmh < 2.0 && variance < 0.02 {
+        return (TransportMode::Still, 0.85);
+    }
+
+    // Running: fast cadence, on-foot speed band.
+    if (2.5..=3.6).contains(&cadence) && (6.0..=20.0).contains(&speed_kmh) {
+        return (TransportMode::Running, 0.8);
+    }
+
+    // Walking: moderate cadence, pedestrian speed.
+    if (1.3..=2.6).contains(&cadence) && (1.5..=9.0).contains(&speed_kmh) {
+        return (TransportMode::Walking, 0.8);
+    }
+
+    // Cycling: mid speed band, low pedal cadence, moderate steadiness.
+    if (8.0..25.0).contains(&speed_kmh) && cadence < 1.6 {
+        return (TransportMode::Cycling, 0.7);
+    }
+
+    (TransportMode::Unknown, 0.0)
+}
+
+#[uniffi::export]
+impl TransportModeClassifier {
+    /// Creates a classifier. Pass `None` for default tuning.
+    #[uniffi::constructor]
+    pub fn new(config: Option<ClassifierConfig>) -> Self {
+        Self {
+            config: config.unwrap_or_default(),
+            state: Mutex::new(ClassifierState {
+                committed: TransportMode::Unknown,
+                candidate: TransportMode::Unknown,
+                candidate_since_ms: 0,
+                has_candidate: false,
+            }),
+        }
+    }
+
+    /// Classifies one window + speed, applying confidence gating and dwell
+    /// hysteresis. Returns the currently committed mode.
+    pub fn classify(
+        &self,
+        window: AccelWindow,
+        speed_mps: f64,
+        now_ms: i64,
+    ) -> ModeResult {
+        let (raw_mode, raw_conf) = classify_instant(window, speed_mps);
+        let mode = if raw_conf < self.config.min_confidence {
+            TransportMode::Unknown
+        } else {
+            raw_mode
+        };
+
+        let mut st = self.state.lock().unwrap();
+
+        // Track how long the latest instantaneous mode has persisted.
+        if !st.has_candidate || st.candidate != mode {
+            st.candidate = mode;
+            st.candidate_since_ms = now_ms;
+            st.has_candidate = true;
+        }
+
+        let mut changed = false;
+        if mode != st.committed
+            && now_ms - st.candidate_since_ms >= self.config.mode_switch_dwell_ms
+        {
+            st.committed = mode;
+            changed = true;
+        }
+
+        ModeResult {
+            mode: st.committed,
+            confidence: raw_conf,
+            changed,
+        }
+    }
+
+    /// Currently committed mode.
+    pub fn current_mode(&self) -> TransportMode {
+        self.state.lock().unwrap().committed
+    }
+
+    /// Resets to `Unknown`.
+    pub fn reset(&self) {
+        let mut st = self.state.lock().unwrap();
+        st.committed = TransportMode::Unknown;
+        st.candidate = TransportMode::Unknown;
+        st.has_candidate = false;
+        st.candidate_since_ms = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithms::sensor_features::AccelWindow;
+
+    fn win(variance: f64, cadence: f64, peak: f64) -> AccelWindow {
+        AccelWindow {
+            mean_g: 0.0,
+            variance,
+            peak_g: peak,
+            dominant_cadence_hz: cadence,
+            sample_count: 10,
+            duration_ms: 1000,
+        }
+    }
+
+    #[test]
+    fn vehicle_from_high_speed() {
+        let (m, c) = classify_instant(win(0.05, 0.5, 0.2), 60.0 / 3.6);
+        assert_eq!(m, TransportMode::Vehicle);
+        assert!(c >= 0.9);
+    }
+
+    #[test]
+    fn still_from_low_speed_low_variance() {
+        let (m, _) = classify_instant(win(0.005, 0.0, 0.02), 0.0);
+        assert_eq!(m, TransportMode::Still);
+    }
+
+    #[test]
+    fn walking_and_running_separated_by_cadence() {
+        let (walk, _) = classify_instant(win(0.3, 2.0, 0.4), 5.0 / 3.6);
+        assert_eq!(walk, TransportMode::Walking);
+        let (run, _) = classify_instant(win(0.8, 3.0, 0.9), 12.0 / 3.6);
+        assert_eq!(run, TransportMode::Running);
+    }
+
+    #[test]
+    fn cycling_band() {
+        let (m, _) = classify_instant(win(0.2, 1.2, 0.3), 18.0 / 3.6);
+        assert_eq!(m, TransportMode::Cycling);
+    }
+
+    #[test]
+    fn hysteresis_requires_dwell_before_commit() {
+        let c = TransportModeClassifier::new(Some(ClassifierConfig {
+            mode_switch_dwell_ms: 8000,
+            min_confidence: 0.6,
+        }));
+        let w = win(0.3, 2.0, 0.4);
+        let speed = 5.0 / 3.6;
+        // First observation at t=0: candidate Walking, not yet committed.
+        let r0 = c.classify(w, speed, 0);
+        assert_eq!(r0.mode, TransportMode::Unknown);
+        assert!(!r0.changed);
+        // Still Walking at t=4 s — under dwell.
+        assert_eq!(c.classify(w, speed, 4000).mode, TransportMode::Unknown);
+        // At t=8 s — commits.
+        let r = c.classify(w, speed, 8000);
+        assert_eq!(r.mode, TransportMode::Walking);
+        assert!(r.changed);
+    }
+
+    #[test]
+    fn brief_blip_does_not_commit() {
+        let c = TransportModeClassifier::new(None); // dwell 8 s
+        let walk = win(0.3, 2.0, 0.4);
+        let veh = win(0.05, 0.5, 0.2);
+        c.classify(walk, 5.0 / 3.6, 0);
+        c.classify(walk, 5.0 / 3.6, 8000); // commit Walking
+        assert_eq!(c.current_mode(), TransportMode::Walking);
+        // A single vehicle window then back to walking — must not flip.
+        c.classify(veh, 60.0 / 3.6, 9000);
+        c.classify(walk, 5.0 / 3.6, 10000);
+        assert_eq!(c.current_mode(), TransportMode::Walking);
+    }
+
+    #[test]
+    fn low_confidence_reported_unknown() {
+        // Ambiguous: mid speed, no matching cadence rule.
+        let (m, _) = classify_instant(win(0.5, 0.9, 0.3), 22.0 / 3.6);
+        // 22 km/h, cadence 0.9 < 1.6 ⇒ Cycling actually matches; pick a true gap:
+        let _ = m;
+        let (m2, c2) = classify_instant(win(0.5, 2.2, 0.3), 22.0 / 3.6);
+        // 22 km/h with cadence 2.2: no vehicle (<25), no walk (speed>9), no run
+        // (speed>20), cycling needs cadence<1.6 ⇒ Unknown.
+        assert_eq!(m2, TransportMode::Unknown);
+        assert_eq!(c2, 0.0);
+    }
+}

--- a/website/app/en/core/_meta.js
+++ b/website/app/en/core/_meta.js
@@ -2,6 +2,7 @@ export default {
   "packages": "Ecosystem & Packages",
   "core-concepts": "Core Concepts",
   "motion-detection": "Motion Detection",
+  "driving-safety": "Driving & Safety",
   "tracelet-sync": "Tracelet Sync",
   "advanced-geo": "Advanced Geolocation",
   "geofencing": "Geofencing",

--- a/website/app/en/core/driving-safety/page.mdx
+++ b/website/app/en/core/driving-safety/page.mdx
@@ -1,0 +1,103 @@
+import { Callout } from 'nextra/components'
+
+# Driving & Safety
+
+Added in **3.3.0**, Tracelet turns the location + accelerometer stream into
+higher-level **behavior signals** — entirely on device, in the shared Rust core.
+Three independent, **opt-in, default-off** engines:
+
+| Feature | Config | Stream |
+|---|---|---|
+| Driving-behavior (telematics) | `TelematicsConfig` | `Tracelet.onDrivingEvent` |
+| Transport-mode classifier | `ClassifierConfig` | `Tracelet.onModeChange` |
+| Crash / fall detection | `ImpactConfig` | `Tracelet.onImpact` |
+
+<Callout type="info">
+All three are **default-off**. With their config blocks at defaults, no engine
+is created and behavior is identical to 3.2.x. They are pure *side-channel*
+events — they never alter the location pipeline, odometer, or `onLocation`.
+</Callout>
+
+---
+
+## Driving-behavior events (telematics)
+
+GPS-derived `harsh_braking`, `harsh_acceleration`, `harsh_cornering`, and
+`speeding`. No extra sensors — thresholds in **g** (1 g ≈ 9.81 m/s²).
+
+```dart
+await Tracelet.ready(Config(
+  telematics: TelematicsConfig(
+    enableDrivingEvents: true,
+    harshBrakingG: 0.40,
+    speedLimitKmh: 50,            // 0 disables speeding
+    speedingMinDurationMs: 3000,  // sustained over limit
+  ),
+));
+
+Tracelet.onDrivingEvent((e) {
+  // e.kind: harsh_braking | harsh_acceleration | harsh_cornering | speeding
+  // e.severity: 0–1, e.value: g (harsh) or km/h over limit (speeding)
+  print('${e.kind} sev=${e.severity}');
+});
+```
+
+GPS speed is ~1 Hz and noisy, so the engine favors **specificity** (high
+thresholds, gap rejection, one event per maneuver). Ideal for usage-based
+insurance and fleet-safety scoring.
+
+## Transport-mode classifier
+
+Fuses accelerometer cadence/variance with GPS speed to classify
+`still`/`walking`/`running`/`cycling`/`vehicle`, with dwell **hysteresis**.
+
+```dart
+await Tracelet.ready(Config(
+  classifier: ClassifierConfig(enableFusedClassifier: true),
+));
+
+Tracelet.onModeChange((e) => print('mode: ${e.mode} (${e.confidence})'));
+```
+
+By default it **annotates** (platform Activity Recognition stays authoritative);
+set `fusedClassifierAuthoritative: true` to let the fused mode drive sampling.
+
+## Crash & fall detection
+
+Safety-critical: a high-g spike alone is **never** a crash — it must be
+corroborated by motion context, and uses a **cancel-countdown** flow.
+
+```dart
+await Tracelet.ready(Config(
+  impact: ImpactConfig(
+    enableCrashDetection: true,
+    crashGThreshold: 3.0,
+    crashMinSpeedKmh: 25,     // must have been moving
+    confirmWindowMs: 15000,   // countdown before auto-confirm
+  ),
+));
+
+Tracelet.onImpact((e) async {
+  if (e.isPotential) {
+    // Show a countdown; user is fine →
+    await Tracelet.cancelImpact(e.id);
+    // or escalate now → await Tracelet.confirmImpact(e.id);
+  } else {
+    // e.kind == 'crash' / 'fall' — confirmed
+  }
+});
+```
+
+<Callout type="warning">
+Tracelet provides the trustworthy **trigger + cancel window** — it does **not**
+place emergency calls. Wiring an SOS/emergency flow is the host app's
+responsibility.
+</Callout>
+
+---
+
+## Permissions
+
+Driving events need only your existing location permission. The classifier and
+crash/fall use the accelerometer (already used by motion detection on Android;
+Motion & Fitness improves fidelity on iOS). See the platform-setup pages.


### PR DESCRIPTION
# 3.3.0 — Driving telematics, transport-mode classifier, crash/fall, battery

Implements the 3.3.0 program (umbrella #161). Three new **opt-in, default-off**
behavior engines built on one shared native accelerometer→Rust-core feed, plus
confirmation that battery WS-A Phase 1 was already shipped.

## What's in
- **Rust core** (`algorithms/{telematics,sensor_features,transport_mode,impact}.rs`): `TelematicsEngine`, `compute_accel_window`, `TransportModeClassifier` (+Cycling), `ImpactDetector` (crash/fall + confirm/cancel). **52 Rust tests pass.**
- **Pigeon + Dart**: `TelematicsConfig`/`ClassifierConfig`/`ImpactConfig`, `DrivingEvent`/`ImpactEvent`/`ModeChangeEvent`, streams `onDrivingEvent`/`onImpact`/`onModeChange`, and `confirmImpact`/`cancelImpact`. **Dart tests pass; analyze clean.**
- **Android runtime**: engine instantiation, location-pipeline telematics hook, MotionDetector accel feed → 1 Hz window loop, event emission, confirm/cancel. **Example debug APK builds** (`.so` rebuilt for all 3 ABIs).
- **iOS runtime**: full parity. **Example iOS app builds; all 4 integration tests pass on a real wired iPhone** (config round-trip, live streams, cancelImpact no-op, no-regression).
- **Example**: dedicated *Driving & Safety* page + dashboard button.
- **Docs**: `help/DRIVING-AND-SAFETY.md` + website `en/core/driving-safety`.
- **Release**: all 9 federated packages 3.2.19 → 3.3.0; 3.3.0 CHANGELOG across 11 changelogs.

## No-regression
All three features default-off → engines never instantiated; events are pure side-channel (never touch the location pipeline/odometer/`onLocation`). Verified by the on-device no-regression integration test.

## Validation
- Rust: 52 unit tests ✅
- Dart: config + event tests ✅, `dart analyze` clean ✅
- Android: example APK builds ✅
- iOS: example builds + 4/4 integration tests pass on device ✅

Closes #163
Closes #164
Closes #165

**Not closed here:** #162 (battery WS-A) — Phase 1 (budget-engine wiring) was already shipped on both platforms (confirmed); the opt-in **motion-gated wakelock** remains outstanding. #161 (umbrella) tracks any remaining follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
