### PR TITLE
fix(plugin): correct native-map to Pigeon field mapping (#175)

### DIFF
--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -92,11 +92,13 @@ class TraceletHostApiImpl(
             ),
             battery = TlBattery(
                 level = (battery["level"] as? Number)?.toDouble() ?: -1.0,
-                isCharging = battery["isCharging"] as? Boolean ?: false,
+                // Native emits snake_case `is_charging`; accept both for safety.
+                isCharging = (battery["is_charging"] ?: battery["isCharging"]) as? Boolean ?: false,
             ),
             timestamp = m["timestamp"] as? String ?: "",
             uuid = m["uuid"] as? String ?: "",
-            isMoving = m["isMoving"] as? Boolean ?: false,
+            // Native emits snake_case `is_moving`; accept both for safety.
+            isMoving = (m["is_moving"] ?: m["isMoving"]) as? Boolean ?: false,
             odometer = (m["odometer"] as? Number)?.toDouble() ?: 0.0,
             event = m["event"] as? String,
             activity = if (activity != null) TlActivity(
@@ -145,12 +147,16 @@ class TraceletHostApiImpl(
         "vertices" to g.vertices,
     )
 
-    private fun tlOptionsToMap(o: TlCurrentPositionOptions): Map<String, Any?> = mapOf(
-        "timeout" to o.timeout,
-        "maximumAge" to o.maximumAge,
-        "persist" to o.persist,
-        "samples" to o.samples,
-    )
+    private fun tlOptionsToMap(o: TlCurrentPositionOptions): Map<String, Any?> = buildMap {
+        put("timeout", o.timeout)
+        put("maximumAge", o.maximumAge)
+        put("persist", o.persist)
+        put("samples", o.samples)
+        // Previously dropped here, so getCurrentPosition(desiredAccuracy:/extras:)
+        // were silently ignored (#175). Forward them to the SDK.
+        o.desiredAccuracy?.let { put("desiredAccuracy", it.raw) }
+        o.extras?.let { put("extras", it) }
+    }
 
     private fun tlConfigToSdkMap(c: TlConfig): Map<String, Any?> = buildMap {
         put("geo", buildMap {

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/LocationMappingRegressionTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/LocationMappingRegressionTest.kt
@@ -1,0 +1,138 @@
+package com.ikolvi.tracelet.flutter
+
+import android.content.Context
+import com.ikolvi.tracelet.TlCurrentPositionOptions
+import com.ikolvi.tracelet.TlDesiredAccuracy
+import com.ikolvi.tracelet.TlLocation
+import com.ikolvi.tracelet.flutter.service.HeadlessTaskService
+import org.junit.Test
+import org.mockito.Mockito.mock
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Field-by-field regression tests for the native-map ↔ Pigeon converters in
+ * [TraceletHostApiImpl] (#175). These guard the exact key contracts between the
+ * SDK's enriched location map (snake_case: `is_moving`, `is_charging`) and the
+ * Pigeon [TlLocation], and that `getCurrentPosition` options (extras /
+ * desiredAccuracy) are forwarded to the SDK. They fail if any field is dropped
+ * or read under the wrong key — the class of bug reported in #175.
+ */
+class LocationMappingRegressionTest {
+
+    private fun hostApi(): TraceletHostApiImpl =
+        TraceletHostApiImpl(mock(Context::class.java), mock(HeadlessTaskService::class.java))
+
+    /** Invokes the private `mapToTlLocation(Map)` via reflection. */
+    private fun mapToTlLocation(m: Map<String, Any?>): TlLocation {
+        val method = TraceletHostApiImpl::class.java
+            .getDeclaredMethod("mapToTlLocation", Map::class.java)
+        method.isAccessible = true
+        return method.invoke(hostApi(), m) as TlLocation
+    }
+
+    /** Invokes the private `tlOptionsToMap(TlCurrentPositionOptions)` via reflection. */
+    @Suppress("UNCHECKED_CAST")
+    private fun tlOptionsToMap(o: TlCurrentPositionOptions): Map<String, Any?> {
+        val method = TraceletHostApiImpl::class.java
+            .getDeclaredMethod("tlOptionsToMap", TlCurrentPositionOptions::class.java)
+        method.isAccessible = true
+        return method.invoke(hostApi(), o) as Map<String, Any?>
+    }
+
+    /** A native enriched location map, exactly as the SDK emits it (snake_case). */
+    private fun enrichedMap(): Map<String, Any?> = mapOf(
+        "uuid" to "uuid-123",
+        "timestamp" to "2026-06-15T10:00:00.000Z",
+        "is_moving" to true,                       // snake_case — the #175 bug key
+        "odometer" to 1234.5,
+        "event" to "location",
+        "coords" to mapOf(
+            "latitude" to 37.4220,
+            "longitude" to -122.0841,
+            "accuracy" to 8.0,
+            "speed" to 14.0,
+            "heading" to 90.0,
+            "altitude" to 12.0,
+            "altitudeAccuracy" to 3.0,
+            "speedAccuracy" to 1.0,
+            "headingAccuracy" to 2.0,
+        ),
+        "activity" to mapOf("type" to "in_vehicle", "confidence" to 95),
+        "battery" to mapOf("level" to 0.87, "is_charging" to true), // snake_case — the #175 bug key
+        "extras" to mapOf("alarm" to "sos"),
+        "address" to mapOf("city" to "Mountain View", "country" to "US"),
+    )
+
+    @Test
+    fun mapToTlLocation_roundtrips_every_field() {
+        val loc = mapToTlLocation(enrichedMap())
+
+        // Identity / motion
+        assertEquals("uuid-123", loc.uuid)
+        assertEquals("2026-06-15T10:00:00.000Z", loc.timestamp)
+        assertEquals("location", loc.event)
+        assertEquals(1234.5, loc.odometer)
+        assertTrue(loc.isMoving, "isMoving must come from native `is_moving` (#175)")
+
+        // Coords
+        assertEquals(37.4220, loc.coords.latitude)
+        assertEquals(-122.0841, loc.coords.longitude)
+        assertEquals(8.0, loc.coords.accuracy)
+        assertEquals(14.0, loc.coords.speed)
+        assertEquals(90.0, loc.coords.heading)
+        assertEquals(12.0, loc.coords.altitude)
+
+        // Battery — the regression: level must be real and isCharging must come
+        // from native `is_charging`, not default false.
+        assertEquals(0.87, loc.battery.level)
+        assertTrue(loc.battery.isCharging, "isCharging must come from native `is_charging` (#175)")
+
+        // Activity
+        assertEquals("in_vehicle", loc.activity?.type)
+        assertEquals(95L, loc.activity?.confidence)
+
+        // Extras must survive (not be dropped)
+        assertEquals("sos", loc.extras?.get("alarm"))
+
+        // Address
+        assertEquals("Mountain View", loc.address?.city)
+        assertEquals("US", loc.address?.country)
+    }
+
+    @Test
+    fun mapToTlLocation_accepts_camelCase_battery_and_moving_too() {
+        // Robustness: if a path ever emits camelCase, it must still parse.
+        val m = enrichedMap().toMutableMap().apply {
+            this["is_moving"] = null
+            this["isMoving"] = true
+            this["battery"] = mapOf("level" to 0.5, "isCharging" to true)
+        }
+        val loc = mapToTlLocation(m)
+        assertTrue(loc.isMoving)
+        assertTrue(loc.battery.isCharging)
+    }
+
+    @Test
+    fun tlOptionsToMap_forwards_extras_and_desiredAccuracy() {
+        val opts = TlCurrentPositionOptions(
+            desiredAccuracy = TlDesiredAccuracy.HIGH,
+            timeout = 30,
+            maximumAge = 0,
+            persist = true,
+            samples = 1,
+            extras = mapOf("alarm" to "sos"),
+        )
+        val map = tlOptionsToMap(opts)
+
+        assertEquals(30L, map["timeout"])
+        assertEquals(0L, map["maximumAge"])
+        assertEquals(true, map["persist"])
+        assertEquals(1L, map["samples"])
+        // The #175 fixes: these were previously dropped.
+        assertEquals(0, map["desiredAccuracy"], "desiredAccuracy must be forwarded (#175)")
+        @Suppress("UNCHECKED_CAST")
+        val extras = map["extras"] as? Map<String?, Any?>
+        assertEquals("sos", extras?.get("alarm"), "extras must be forwarded to the SDK (#175)")
+    }
+}

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
@@ -182,7 +182,9 @@ class TraceletHostApiImpl: TraceletHostApi {
         )
     }
 
-    private func dictToTlLocation(_ d: [String: Any]) -> TlLocation {
+    // `internal` (not private) so the regression tests can verify the native-map
+    // → Pigeon field contract directly (#175).
+    func dictToTlLocation(_ d: [String: Any]) -> TlLocation {
         let coords = d["coords"] as? [String: Any] ?? [:]
         let battery = d["battery"] as? [String: Any] ?? [:]
         let activity = d["activity"] as? [String: Any]
@@ -203,11 +205,13 @@ class TraceletHostApiImpl: TraceletHostApi {
             ),
             battery: TlBattery(
                 level: battery["level"] as? Double ?? -1.0,
-                isCharging: battery["isCharging"] as? Bool ?? false
+                // Native emits snake_case `is_charging`; accept both for safety.
+                isCharging: (battery["is_charging"] ?? battery["isCharging"]) as? Bool ?? false
             ),
             timestamp: d["timestamp"] as? String ?? "",
             uuid: d["uuid"] as? String ?? "",
-            isMoving: d["isMoving"] as? Bool ?? false,
+            // Native emits snake_case `is_moving`; accept both for safety.
+            isMoving: (d["is_moving"] ?? d["isMoving"]) as? Bool ?? false,
             odometer: d["odometer"] as? Double ?? 0.0,
             event: d["event"] as? String,
             activity: activity.map {

--- a/packages/tracelet_ios/ios/tracelet_ios/Tests/tracelet_iosTests/LocationMappingRegressionTests.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Tests/tracelet_iosTests/LocationMappingRegressionTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import tracelet_ios
+
+/// Field-by-field regression tests for the native-map → Pigeon `TlLocation`
+/// converter in `TraceletHostApiImpl` (#175). Guards the key contract between
+/// the SDK's enriched location map (snake_case: `is_moving`, `is_charging`) and
+/// `TlLocation`, so a field is never silently dropped or read under the wrong key.
+final class LocationMappingRegressionTests: XCTestCase {
+
+    private func hostApi() -> TraceletHostApiImpl {
+        TraceletHostApiImpl(headlessRunner: HeadlessRunner())
+    }
+
+    /// A native enriched location map, exactly as the SDK emits it (snake_case).
+    private func enrichedDict() -> [String: Any] {
+        [
+            "uuid": "uuid-123",
+            "timestamp": "2026-06-15T10:00:00.000Z",
+            "is_moving": true,                       // snake_case — the #175 bug key
+            "odometer": 1234.5,
+            "event": "location",
+            "coords": [
+                "latitude": 37.4220,
+                "longitude": -122.0841,
+                "accuracy": 8.0,
+                "speed": 14.0,
+                "heading": 90.0,
+                "altitude": 12.0,
+            ],
+            "activity": ["type": "automotive", "confidence": 95],
+            "battery": ["level": 0.87, "is_charging": true], // snake_case — the #175 bug key
+            "extras": ["alarm": "sos"],
+            "address": ["city": "Mountain View", "country": "US"],
+        ]
+    }
+
+    func testDictToTlLocation_roundtripsEveryField() {
+        let loc = hostApi().dictToTlLocation(enrichedDict())
+
+        XCTAssertEqual(loc.uuid, "uuid-123")
+        XCTAssertEqual(loc.timestamp, "2026-06-15T10:00:00.000Z")
+        XCTAssertEqual(loc.event, "location")
+        XCTAssertEqual(loc.odometer, 1234.5)
+        XCTAssertTrue(loc.isMoving, "isMoving must come from native `is_moving` (#175)")
+
+        XCTAssertEqual(loc.coords.latitude, 37.4220)
+        XCTAssertEqual(loc.coords.longitude, -122.0841)
+        XCTAssertEqual(loc.coords.accuracy, 8.0)
+        XCTAssertEqual(loc.coords.speed, 14.0)
+
+        XCTAssertEqual(loc.battery.level, 0.87)
+        XCTAssertTrue(loc.battery.isCharging, "isCharging must come from native `is_charging` (#175)")
+
+        XCTAssertEqual(loc.activity?.type, "automotive")
+        XCTAssertEqual(loc.activity?.confidence, 95)
+
+        XCTAssertEqual(loc.extras?["alarm"] as? String, "sos", "extras must not be dropped (#175)")
+        XCTAssertEqual(loc.address?.city, "Mountain View")
+        XCTAssertEqual(loc.address?.country, "US")
+    }
+
+    func testDictToTlLocation_acceptsCamelCaseToo() {
+        var d = enrichedDict()
+        d["is_moving"] = nil
+        d["isMoving"] = true
+        d["battery"] = ["level": 0.5, "isCharging": true]
+        let loc = hostApi().dictToTlLocation(d)
+        XCTAssertTrue(loc.isMoving)
+        XCTAssertTrue(loc.battery.isCharging)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the data-integrity regressions in #175 where `battery`, `isMoving`, and `extras` showed static/default values in the Dart layer. Root cause was the plugin's **native-map → Pigeon `TlLocation` converters**, not the SDK core.

## Fixes
- **`getCurrentPosition(extras:/desiredAccuracy:)` ignored** — Android `tlOptionsToMap` never forwarded `extras`/`desiredAccuracy` to the SDK. Now forwarded. (iOS already did.)
- **`isCharging` always false** — both converters read `battery["isCharging"]` but the SDK emits snake_case **`is_charging`**. Fixed (both platforms; camelCase fallback kept).
- **`isMoving` always false** — read `isMoving` instead of native **`is_moving`**. Fixed (both platforms).

## Tests (regression guards)
Field-by-field tests over the converters, so any dropped/mis-keyed field fails CI:
- Android `LocationMappingRegressionTest.kt` — passing (full plugin suite green).
- iOS `LocationMappingRegressionTests.swift` — mirror tests (made `dictToTlLocation` internal for `@testable`); run by CI.

Both example apps build (Android APK + iOS simulator).

## Not included (tracked in #175)
- **Boot/reboot "Failed" flags** — verified to be the documented Samsung One UI autostart / battery-optimization restriction, not a code bug (BootReceiver wiring is correct).
- **battery `level: -1` / `extras` on DB read-back** — the local SQLite store has no battery/extras columns, so those default on `getLocations()` / sync read-back. Needs a product decision on whether to persist them.

Addresses #175 (partial — converter regressions). Leaving #175 open for the boot/persistence items.
