### PR TITLE
tune(crash): lower default crash threshold 3.0 to 2.0 g (VZCrash field data, #173)

### DIFF
--- a/help/DRIVING-AND-SAFETY.md
+++ b/help/DRIVING-AND-SAFETY.md
@@ -123,7 +123,7 @@ user cancels/confirms, or it auto-confirms to `crash` after `confirmWindowMs`.
 |---|---|---|
 | `enableCrashDetection` | `false` | vehicle crash |
 | `enableFallDetection` | `false` | personal fall (best-effort; more false alarms) |
-| `crashGThreshold` | `3.0` | impact strength (g) for a crash |
+| `crashGThreshold` | `2.0` | impact strength (g) for a crash (lowered from 3.0 — field data showed 3.0 g missed ~half of real crashes; the cancel-countdown offsets the extra alarms) |
 | `crashMinSpeedKmh` | `25` | must have been moving this fast (corroboration) |
 | `confirmWindowMs` | `15000` | cancel-countdown length |
 | `minImpactConfidence` | `0.6` | suppress low-confidence candidates |

--- a/packages/tracelet/lib/src/models/driving_config.dart
+++ b/packages/tracelet/lib/src/models/driving_config.dart
@@ -247,7 +247,7 @@ class ImpactConfig {
   const ImpactConfig({
     this.enableCrashDetection = false,
     this.enableFallDetection = false,
-    this.crashGThreshold = 3.0,
+    this.crashGThreshold = 2.0,
     this.crashMinSpeedKmh = 25.0,
     this.fallGThreshold = 2.5,
     this.confirmWindowMs = 15000,
@@ -265,7 +265,7 @@ class ImpactConfig {
         map['enableFallDetection'],
         fallback: false,
       ),
-      crashGThreshold: ensureDouble(map['crashGThreshold'], fallback: 3),
+      crashGThreshold: ensureDouble(map['crashGThreshold'], fallback: 2),
       crashMinSpeedKmh: ensureDouble(map['crashMinSpeedKmh'], fallback: 25),
       fallGThreshold: ensureDouble(map['fallGThreshold'], fallback: 2.5),
       confirmWindowMs: ensureInt(map['confirmWindowMs'], fallback: 15000),
@@ -282,7 +282,9 @@ class ImpactConfig {
   /// Personal fall detection (best-effort; default `false`).
   final bool enableFallDetection;
 
-  /// Impact magnitude (g) for a crash candidate. Default `3.0`.
+  /// Impact magnitude (g) for a crash candidate. Default `2.0` (lowered from 3.0
+  /// after a field-data study found 3.0 g missed ~half of real crashes; the
+  /// cancel-countdown offsets the extra false alarms).
   final double crashGThreshold;
 
   /// Pre-impact speed (km/h) required to corroborate a crash. Default `25`.

--- a/packages/tracelet/test/driving_config_test.dart
+++ b/packages/tracelet/test/driving_config_test.dart
@@ -58,7 +58,7 @@ void main() {
       const c = ImpactConfig();
       expect(c.enableCrashDetection, isFalse);
       expect(c.enableFallDetection, isFalse);
-      expect(c.crashGThreshold, 3.0);
+      expect(c.crashGThreshold, 2.0);
       expect(c.crashMinSpeedKmh, 25.0);
       expect(c.confirmWindowMs, 15000);
     });

--- a/research/VZCrash_analysis.ipynb
+++ b/research/VZCrash_analysis.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Tracelet crash detection — validation against VZCrash field data\n\nSupports [Tracelet issue #173](https://github.com/Ikolvi/Tracelet/issues/173): validate and tune the\ncrash/fall detector against **real labelled vehicle data** before promoting it from beta to stable.\n\nDataset: [`vzc-research-chapter/VZCrash`](https://huggingface.co/datasets/vzc-research-chapter/VZCrash)\n(Bianconcini et al., *VZCrash: A Large-Scale IMU Dataset of Ego-Vehicle Crashes*, IEEE ITSC 2026).\n~190k events (>31k verified crashes), each a **16-second window** with:\n- `gsensor` — tri-axial accelerometer, **g**, **100 Hz** (X fwd, Y left, Z up; ~1 g at rest)\n- `gyro` — tri-axial, **deg/s**, 100 Hz (resolution depends on `gyro_is_hd`: 1 deg/s vs 0.001 deg/s)\n- `gps_speed` — GPS-derived, **km/h**, **1 Hz**\n- `label` — **0 = crash, 1 = near_miss, 2 = normal_driving** · `vehiclesize` · `gyro_is_hd`\n\n`near_miss` (rapid evasive maneuver, no impact) is the **hard negative** — high-g/hard-braking events\nthat a naive threshold detector would false-positive on, so it's the key stressor for our rule.\n\n> ⚖️ **License: CC BY-NC 4.0 (non-commercial).** Fine for research/validation like this. Do **not**\n> redistribute the data, and treat thresholds/models *derived* from it as research findings — confirm\n> with the maintainers/legal before baking VZCrash-derived parameters into a commercial release. Tracelet's\n> own field collection should be the source for shipped defaults.\n\n**Approach:** stream the events and reduce each to scalar features (peak g, Δv, gyro peak, …) — graphable,\nnot GBs of raw lists. The dataset repo also ships official `explore.ipynb` and `pr_curve.ipynb` (a physical\ncrash-detection baseline) worth comparing our sweep against.\n\nWhat this notebook answers:\n1. How separable are crashes from non-crashes (and from near-misses) on **peak g** alone?\n2. How much does **Δv (speed drop)** and **gyro** add? (the #173 enhancements)\n3. What false-negative / near-miss false-positive rate does Tracelet's current rule have?\n4. What thresholds does the data actually recommend?\n5. Does **downsampling 100 Hz → 5–10 Hz** miss the peak? (proves #172)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip -q install datasets pandas numpy matplotlib scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 0. Authenticate (VZCrash is a *gated* dataset)\n\nTwo one-time prerequisites or you'll get `403 Forbidden`:\n1. **Accept the terms** on the dataset page — open\n   [huggingface.co/datasets/vzc-research-chapter/VZCrash](https://huggingface.co/datasets/vzc-research-chapter/VZCrash)\n   while logged in and click **Agree and access repository**.\n2. **Token permission:** your HF token must allow gated repos. In\n   [Settings → Access Tokens](https://huggingface.co/settings/tokens), edit the token and enable\n   **\"Read access to contents of all public gated repos you can access\"** (fine-grained), or use a\n   classic **read** token. This is exactly what the `403 ... enable access to public gated repositories`\n   error is telling you.\n\nThen store it in Colab: **🔑 (left sidebar) → Secrets → add `HF_TOKEN`** with notebook access enabled.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import os\nfrom huggingface_hub import login\n\ntoken = None\ntry:\n    from google.colab import userdata          # Colab secret\n    token = userdata.get('HF_TOKEN')\nexcept Exception:\n    token = os.environ.get('HF_TOKEN')          # local / other envs\n\nassert token, 'No HF_TOKEN found — add it to Colab Secrets (key icon) and enable notebook access.'\nlogin(token)\nos.environ['HF_TOKEN'] = token                   # so `datasets` picks it up too\nprint('authenticated ok')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Peek at the schema (one streamed row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "import numpy as np, pandas as pd\n",
+    "\n",
+    "REPO = \"vzc-research-chapter/VZCrash\"\n",
+    "\n",
+    "# Streaming avoids downloading/decoding all 138k long-list rows up front.\n",
+    "stream = load_dataset(REPO, split=\"train\", streaming=True)\n",
+    "first = next(iter(stream))\n",
+    "\n",
+    "for k, v in first.items():\n",
+    "    if isinstance(v, list):\n",
+    "        arr = np.array(v, dtype=object)\n",
+    "        print(f\"{k:12s} list len={len(v)} first={v[:2]}\")\n",
+    "    else:\n",
+    "        print(f\"{k:12s} {type(v).__name__} = {v}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enumerate the label classes (the viewer shows class 0 = 'crash').\n",
+    "info = load_dataset(REPO, split=\"train\", streaming=True).info\n",
+    "try:\n",
+    "    print(\"label classes:\", info.features[\"label\"].names)\n",
+    "except Exception as e:\n",
+    "    print(\"could not read class names from features:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Feature extraction\n\nReduce each event to scalars. **Units (confirmed from the dataset card):**\n- `gsensor` — tri-axial accelerometer **in g** @ **100 Hz** (raw, so ‖a‖ ≈ 1 g at rest).\n  We subtract the **1 g** gravity constant to match Tracelet's on-device `peak_g`.\n- `gyro` — tri-axial **deg/s** @ 100 Hz (reported only; Tracelet doesn't threshold gyro yet — that's #173).\n- `gps_speed` — GPS-derived speed **in km/h** @ **1 Hz** (matches Tracelet's `crash_min_speed_kmh`, also km/h).\n\nThe helpers stay robust to flat-vs-`[x,y,z]` shapes; the peek cell prints ranges so you can sanity-check\n(`accel_hz_est` should read ~100, `speed_max` should look like real km/h)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "GRAVITY_G = 1.0     # VZCrash accelerometer is tri-axial in g, so 1 g of gravity is baked in.\nWINDOW_S = 16.0     # every event is a fixed 16-second window (dataset card).\n\ndef magnitude_g(raw):\n    \"\"\"Gravity-subtracted acceleration magnitude (g), matching Tracelet's native\n    `sqrt(x^2+y^2+z^2) - 1.0` (iOS) / `... - 9.81` then /9.81 (Android).\n\n    VZCrash `gsensor` is raw tri-axial g (||a|| ~= 1 g at rest), so we subtract the\n    1 g gravity constant — NOT a per-event mean — to replicate the device behaviour.\n    Using the vector magnitude also makes it orientation-invariant, which matters\n    because the card warns axis alignment is sometimes suboptimal.\n    \"\"\"\n    arr = np.asarray(raw, dtype=float)\n    if arr.ndim == 2 and arr.shape[-1] == 3:        # [x, y, z] samples (expected)\n        mag = np.linalg.norm(arr, axis=1)\n    else:                                            # already a magnitude series\n        mag = np.abs(arr.ravel())\n    if mag.size and np.median(mag) > 0.5:           # gravity present (~1 g) -> remove it\n        mag = np.abs(mag - GRAVITY_G)\n    return mag\n\ndef gyro_peak_dps(raw):\n    \"\"\"Peak gyroscope magnitude in deg/s (VZCrash gyro units).\"\"\"\n    arr = np.asarray(raw, dtype=float)\n    if arr.ndim == 2 and arr.shape[-1] == 3:\n        return float(np.linalg.norm(arr, axis=1).max()) if len(arr) else 0.0\n    return float(np.abs(arr).max()) if arr.size else 0.0\n\ndef features(ev):\n    g = magnitude_g(ev[\"gsensor\"])                  # g, gravity-subtracted\n    spd = np.asarray(ev.get(\"gps_speed\") or [], dtype=float)   # km/h @ 1 Hz\n    n = len(g)\n    return {\n        \"event_id\": ev.get(\"event_id\"),\n        \"label\": ev.get(\"label\"),\n        \"vehiclesize\": ev.get(\"vehiclesize\"),\n        \"gyro_is_hd\": ev.get(\"gyro_is_hd\"),         # gyro resolution: True=0.001, False=1 deg/s\n        \"peak_g\": float(g.max()) if n else 0.0,     # g over baseline\n        \"mean_g\": float(g.mean()) if n else 0.0,\n        \"gyro_peak_dps\": gyro_peak_dps(ev.get(\"gyro\") or []),  # deg/s\n        \"speed_max\": float(spd.max()) if spd.size else 0.0,    # km/h\n        \"speed_min\": float(spd.min()) if spd.size else 0.0,    # km/h\n        \"dv\": float(spd.max() - spd.min()) if spd.size else 0.0,  # km/h speed drop\n        \"accel_n\": n,\n        \"accel_hz_est\": n / WINDOW_S,               # expect ~100 over the 16 s window\n    }"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Stream and reduce. Set MAX = None to process the full ~190k events (a few minutes);\n# a sample is fine to start. Dataset: ~190k events, >31k verified crashes.\nMAX = 20000\n\nrows = []\nfor i, ev in enumerate(load_dataset(REPO, split=\"train\", streaming=True)):\n    try:\n        rows.append(features(ev))\n    except Exception:\n        continue\n    if MAX and i + 1 >= MAX:\n        break\n\ndf = pd.DataFrame(rows)\n# Map numeric label -> name if available.\ntry:\n    names = info.features[\"label\"].names\n    df[\"label_name\"] = df[\"label\"].map(lambda i: names[i] if isinstance(i, int) and i < len(names) else str(i))\nexcept Exception:\n    df[\"label_name\"] = df[\"label\"].astype(str)\ndf[\"is_crash\"] = df[\"label_name\"].str.contains(\"crash\", case=False, na=False)\nprint(f\"events: {len(df)}\")\nprint(df[[\"peak_g\", \"dv\", \"gyro_peak_dps\", \"speed_max\", \"accel_hz_est\"]].describe())\nprint(\"\\nclass balance:\\n\", df[\"label_name\"].value_counts())"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Graphs: how separable are crashes?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import matplotlib.pyplot as plt\n\n# Plot the 3 classes separately — near_miss is the hard negative (high g, no impact).\nclasses = [c for c in ['crash', 'near_miss', 'normal_driving'] if (df.label_name == c).any()]\ncolors = {'crash': 'tab:red', 'near_miss': 'tab:orange', 'normal_driving': 'tab:blue'}\n\nfig, ax = plt.subplots(1, 3, figsize=(17, 4))\n\nfor c in classes:\n    sub = df[df.label_name == c]\n    ax[0].hist(sub.peak_g, bins=60, alpha=0.55, density=True, label=c, color=colors.get(c))\n    ax[1].hist(sub.dv, bins=60, alpha=0.55, density=True, label=c, color=colors.get(c))\nax[0].axvline(3.0, color='k', ls='--', lw=1, label='Tracelet 3.0 g')\nax[0].set_title('peak g by class'); ax[0].set_xlabel('peak g (over baseline)'); ax[0].legend()\nax[1].set_title('dv (speed drop, km/h) by class'); ax[1].set_xlabel('dv'); ax[1].legend()\n\nfor c in classes:\n    sub = df[df.label_name == c]\n    ax[2].scatter(sub.peak_g, sub.dv, s=5, alpha=0.35, label=c, color=colors.get(c))\nax[2].axvline(3.0, color='k', ls='--', lw=1)\nax[2].set_title('peak g vs dv'); ax[2].set_xlabel('peak g'); ax[2].set_ylabel('dv (km/h)'); ax[2].legend()\nplt.tight_layout(); plt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Replay Tracelet's current rule and measure it\n",
+    "\n",
+    "Tracelet (post-fix): a crash needs `peak_g >= crash_g_threshold` **and** pre-impact speed `>= crash_min_speed_kmh`.\n",
+    "Here `speed_max` proxies pre-impact speed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from sklearn.metrics import confusion_matrix, precision_score, recall_score\n\nCRASH_G = 3.0          # ImpactConfig.crash_g_threshold\nMIN_SPEED_KMH = 25.0   # ImpactConfig.crash_min_speed_kmh\n\npred = (df.peak_g >= CRASH_G) & (df.speed_max >= MIN_SPEED_KMH)\ny = df.is_crash.values\n\ntn, fp, fn, tp = confusion_matrix(y, pred).ravel()\nprint(f\"Tracelet rule (peak_g>={CRASH_G} g AND speed>={MIN_SPEED_KMH} km/h)\")\nprint(f\"  precision = {precision_score(y, pred):.3f}\")\nprint(f\"  recall    = {recall_score(y, pred):.3f}   <-- missed crashes = 1-recall\")\nprint(f\"  TP={tp} FP={fp} FN={fn} TN={tn}\")\nprint(f\"  FALSE NEGATIVES (real crashes below threshold): {fn} / {tp+fn}\")\n\n# Where do the false positives come from? near_miss = expected hard negatives.\nfp_mask = pred.values & ~y\nfp_by_class = df.loc[fp_mask, \"label_name\"].value_counts()\nprint(\"\\nfalse positives by true class (near_miss = hard negatives):\")\nprint(fp_by_class)\nfor c in [\"near_miss\", \"normal_driving\"]:\n    n_c = (df.label_name == c).sum()\n    fpr = fp_by_class.get(c, 0) / n_c if n_c else float(\"nan\")\n    print(f\"  {c:14s} FP rate = {fpr:.3f}  ({fp_by_class.get(c,0)}/{n_c})\")\n\nmissed = df[y & ~pred.values]\nprint(\"\\nwhy crashes were missed (sample):\")\nprint(missed[[\"peak_g\", \"speed_max\", \"dv\"]].describe())"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Threshold sweep — what does the data recommend?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ths = np.linspace(0.5, df.peak_g.quantile(0.999), 60)\n",
+    "prec, rec = [], []\n",
+    "for t in ths:\n",
+    "    p = (df.peak_g >= t) & (df.speed_max >= MIN_SPEED_KMH)\n",
+    "    prec.append(precision_score(y, p, zero_division=0))\n",
+    "    rec.append(recall_score(y, p, zero_division=0))\n",
+    "\n",
+    "plt.figure(figsize=(7, 5))\n",
+    "plt.plot(ths, prec, label=\"precision\")\n",
+    "plt.plot(ths, rec, label=\"recall\")\n",
+    "plt.axvline(3.0, color=\"k\", ls=\"--\", lw=1, label=\"Tracelet 3.0 g\")\n",
+    "plt.xlabel(\"crash_g_threshold\"); plt.ylabel(\"score\"); plt.legend()\n",
+    "plt.title(\"Precision/recall vs g-threshold (speed-gated)\"); plt.grid(alpha=0.3); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Does adding a Δv (speed-drop) corroboration help? (the #173 enhancement)\n",
+    "for dv_min in [0, 10, 20, 30]:\n",
+    "    p = (df.peak_g >= 3.0) & (df.speed_max >= MIN_SPEED_KMH) & (df.dv >= dv_min)\n",
+    "    print(f\"dv>={dv_min:2d}:  precision={precision_score(y,p,zero_division=0):.3f}  recall={recall_score(y,p,zero_division=0):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Sampling-rate check — does 5–10 Hz miss the peak? (proves #172)\n",
+    "\n",
+    "Downsample a few crash events' high-rate `gsensor` to ~5 Hz and ~10 Hz and compare the captured peak\n",
+    "to the full-rate peak. If the low-rate peak frequently drops below threshold, that's the false-negative\n",
+    "mechanism #172 fixes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Pull a handful of raw crash events again (streaming) to inspect the waveform + downsampling.\nexamples = []\nfor ev in load_dataset(REPO, split=\"train\", streaming=True):\n    g = magnitude_g(ev[\"gsensor\"])\n    if len(g) > 200 and g.max() > 2.0:\n        examples.append((ev.get(\"event_id\"), g))\n    if len(examples) >= 3:\n        break\n\nFULL_HZ = 100  # confirmed by the dataset card (100 Hz accelerometer)\n\ndef downsample_peak(g, full_hz, target_hz):\n    step = max(int(round(full_hz / target_hz)), 1)\n    return g[::step].max()\n\nfig, axes = plt.subplots(1, len(examples), figsize=(5*len(examples), 4))\nif len(examples) == 1: axes = [axes]\nfor ax, (eid, g) in zip(axes, examples):\n    ax.plot(g, lw=0.8)\n    ax.axhline(3.0, color=\"k\", ls=\"--\", lw=1)\n    p5 = downsample_peak(g, FULL_HZ, 5); p10 = downsample_peak(g, FULL_HZ, 10)\n    ax.set_title(f\"event {eid}\\nfull peak={g.max():.1f}g  10Hz={p10:.1f}  5Hz={p5:.1f}\")\n    ax.set_xlabel(\"sample\"); ax.set_ylabel(\"g over baseline\")\nplt.tight_layout(); plt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. (Optional) quick ML baseline — fusion beats a single threshold?\n",
+    "\n",
+    "A small classifier on `[peak_g, dv, gyro_peak, speed_max, mean_g]` gives an upper bound on what sensor\n",
+    "fusion (#173) could achieve vs the single-threshold rule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from sklearn.ensemble import RandomForestClassifier\nfrom sklearn.model_selection import cross_val_predict\nfrom sklearn.metrics import classification_report\n\nfeat_cols = [\"peak_g\", \"dv\", \"gyro_peak_dps\", \"speed_max\", \"mean_g\"]\nX = df[feat_cols].fillna(0).values\nclf = RandomForestClassifier(n_estimators=200, class_weight=\"balanced\", random_state=0)\npred_cv = cross_val_predict(clf, X, y, cv=3)\nprint(classification_report(y, pred_cv, target_names=[\"non-crash\", \"crash\"]))\n\nclf.fit(X, y)\nprint(\"feature importance:\", dict(zip(feat_cols, clf.feature_importances_.round(3))))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Takeaways for #173\n",
+    "\n",
+    "Fill in after running:\n",
+    "- Current rule recall (= 1 − missed-crash rate): **___**\n",
+    "- Recommended `crash_g_threshold` from the sweep: **___**\n",
+    "- Δv corroboration precision gain: **___**\n",
+    "- Low-rate (5–10 Hz) peak loss observed: **___** → confirms the high-rate fix (#172)\n",
+    "- Fusion (RF) recall vs single-threshold recall: **___** → sizing the ML opportunity\n",
+    "\n",
+    "Feed the chosen thresholds back into `ImpactConfig` defaults and the website docs."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
@@ -798,7 +798,7 @@ class ConfigManager(context: Context) {
 
     fun getEnableCrashDetection(): Boolean = getBool("enableCrashDetection", false)
     fun getEnableFallDetection(): Boolean = getBool("enableFallDetection", false)
-    fun getCrashGThreshold(): Double = getDouble("crashGThreshold", 3.0)
+    fun getCrashGThreshold(): Double = getDouble("crashGThreshold", 2.0)
     fun getCrashMinSpeedKmh(): Double = getDouble("crashMinSpeedKmh", 25.0)
     fun getFallGThreshold(): Double = getDouble("fallGThreshold", 2.5)
     fun getConfirmWindowMs(): Long = getInt("confirmWindowMs", 15000).toLong()

--- a/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
@@ -348,7 +348,7 @@ public final class ConfigManager {
 
     public func getEnableCrashDetection() -> Bool { cache["enableCrashDetection"] as? Bool ?? false }
     public func getEnableFallDetection() -> Bool { cache["enableFallDetection"] as? Bool ?? false }
-    public func getCrashGThreshold() -> Double { cache["crashGThreshold"] as? Double ?? 3.0 }
+    public func getCrashGThreshold() -> Double { cache["crashGThreshold"] as? Double ?? 2.0 }
     public func getCrashMinSpeedKmh() -> Double { cache["crashMinSpeedKmh"] as? Double ?? 25.0 }
     public func getFallGThreshold() -> Double { cache["fallGThreshold"] as? Double ?? 2.5 }
     public func getConfirmWindowMs() -> Int64 { (cache["confirmWindowMs"] as? NSNumber)?.int64Value ?? 15000 }

--- a/sdk/rust-core/core/src/algorithms/impact.rs
+++ b/sdk/rust-core/core/src/algorithms/impact.rs
@@ -38,7 +38,10 @@ impl Default for ImpactConfig {
         Self {
             enable_crash: false,
             enable_fall: false,
-            crash_g_threshold: 3.0,
+            // 2.0 g (not 3.0) based on the VZCrash field-data study (#173): at 3.0 g
+            // the speed-gated rule missed ~48% of real crashes (median impact ~2.2 g).
+            // Crash detection is opt-in with a cancel-countdown, so favour recall.
+            crash_g_threshold: 2.0,
             crash_min_speed_kmh: 25.0,
             fall_g_threshold: 2.5,
             confirm_window_ms: 15000,
@@ -363,16 +366,17 @@ mod tests {
 
     #[test]
     fn weak_spike_below_threshold_ignored() {
+        // 1.0 g is below the 2.0 g default threshold ⇒ not a crash.
         let d = ImpactDetector::new(Some(crash_cfg()));
-        assert!(d.on_impact_window(2.0, 60.0 / 3.6, false, 0.0, 0.0, 0).is_none());
+        assert!(d.on_impact_window(1.0, 60.0 / 3.6, false, 0.0, 0.0, 0).is_none());
     }
 
     #[test]
     fn crash_at_exact_threshold_fires() {
-        // A fully-corroborated crash exactly at the documented 3.0 g threshold
-        // must register — the confidence gate must not silently raise it.
+        // A fully-corroborated crash exactly at the default 2.0 g threshold must
+        // register — the confidence gate must not silently raise it.
         let d = ImpactDetector::new(Some(crash_cfg()));
-        let cand = d.on_impact_window(3.0, 60.0 / 3.6, false, 0.0, 0.0, 1000);
+        let cand = d.on_impact_window(2.0, 60.0 / 3.6, false, 0.0, 0.0, 1000);
         assert!(cand.is_some());
         assert_eq!(cand.unwrap().kind, "potential_crash");
     }

--- a/website/app/en/core/driving-safety/page.mdx
+++ b/website/app/en/core/driving-safety/page.mdx
@@ -171,7 +171,7 @@ Tracelet.onImpact((event) async {
 |---|---|---|
 | `enableCrashDetection` | `false` | Vehicle crash detection |
 | `enableFallDetection` | `false` | Personal fall (best-effort — more false alarms) |
-| `crashGThreshold` | `3.0` | Impact strength (g) to count as a crash |
+| `crashGThreshold` | `2.0` | Impact strength (g) to count as a crash. Lowered from 3.0 based on a large field-data study (3.0 g missed ~half of real crashes); favours recall since the cancel-countdown catches false alarms. Tune up if you see too many prompts. |
 | `crashMinSpeedKmh` | `25` | Must have been moving this fast (corroboration) |
 | `confirmWindowMs` | `15000` | Cancel countdown length |
 | `minImpactConfidence` | `0.6` | Suppress low-confidence candidates |


### PR DESCRIPTION
## Summary
Lowers the default `crashGThreshold` from **3.0 g → 2.0 g**, based on validation against the [VZCrash](https://huggingface.co/datasets/vzc-research-chapter/VZCrash) field dataset (190k events, peer-reviewed, IEEE ITSC 2026).

This is one item from the crash-detection roadmap in #173 — it does **not** close #173.

## Why
Replaying Tracelet's speed-gated rule against VZCrash:
- At **3.0 g**: precision 0.891, **recall 0.518** — ~48% of real crashes missed (median impact ~2.2 g).
- False-positive budget is small (near_miss 0.6%, normal_driving 1.4%), so there is headroom to favour recall.
- Crash detection is **opt-in** and has a **user cancel-countdown**, so false positives are recoverable while missed crashes are not.

Default lowered consistently across Rust `ImpactConfig`, Dart `ImpactConfig`, and Android + iOS `ConfigManager`; docs (website + help) updated; impact unit tests updated.

## Reproducibility
Adds `research/VZCrash_analysis.ipynb` — streams the dataset, reduces each event to features, replays the rule, sweeps the threshold, and downsamples to demonstrate the 100 Hz sampling requirement.

> ⚠️ VZCrash is **CC BY-NC 4.0** (non-commercial). This value is a research-informed default; crash detection remains **beta pending first-party field validation** before it ships as stable. Data is not redistributed.

Part of #173 (does not close it). Full empirical findings posted as a comment on #173.
