### PR TITLE
fix(android): wire geofence proximity stream on boot for high-accuracy mode (#185)

### DIFF
--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -950,7 +950,24 @@ class LocationService : Service(), DefaultLifecycleObserver {
                 val geoManager = GeofenceManager(ctx, config, eventSender)
                 geoManager.reRegisterAll()
                 GeofenceBroadcastReceiver.geofenceManager = geoManager
-                TraceletLog.debug("Geofence registrations restored after boot/task-removal")
+
+                // Wire the location stream into proximity evaluation. Without this,
+                // geofenceModeHighAccuracy — which suppresses OS-level geofence
+                // transitions and relies entirely on per-location proximity checks
+                // (see GeofenceManager.handleGeofenceEvent / evaluateHighAccuracyProximity)
+                // — produces NO enter/exit events after a reboot or task removal:
+                // the foreground service and engine run, but transitions never fire.
+                // Mirrors TraceletSdk.startGeofences().
+                if (config.getGeofenceModeHighAccuracy()) {
+                    geoManager.clearHighAccuracyState()
+                }
+                bootLocationEngine?.onLocationUpdate = { lat, lng ->
+                    geoManager.updateProximity(lat, lng)
+                    if (config.getGeofenceModeHighAccuracy()) {
+                        geoManager.evaluateHighAccuracyProximity(lat, lng)
+                    }
+                }
+                TraceletLog.debug("Geofence registrations restored after boot/task-removal (proximity stream wired)")
             }
         }
 

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/service/LocationServiceSmartBootTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/service/LocationServiceSmartBootTest.kt
@@ -121,6 +121,37 @@ class LocationServiceSmartBootTest {
     }
 
     @Test
+    fun `boot start in high-accuracy geofence mode wires the proximity location stream (issue 185)`() {
+        // Regression: geofenceModeHighAccuracy suppresses OS-level geofence
+        // transitions and relies ENTIRELY on per-location proximity evaluation
+        // (LocationEngine.onLocationUpdate -> evaluateHighAccuracyProximity). The
+        // boot/task-removal path used to re-register geofences but never wire that
+        // callback, so after a reboot NO enter/exit events ever fired even though
+        // the foreground service and engine were running.
+        config.setConfig(mapOf(
+            "trackingMode" to 1, // GEOFENCES
+            "motionDetectionMode" to 2, // SMART
+            "geofenceModeHighAccuracy" to true,
+            "foregroundChannelId" to "test_channel",
+            "bootStrategy" to true,
+        ))
+        state.enabled = true
+        state.trackingMode = com.ikolvi.tracelet.sdk.model.TrackingMode.GEOFENCES
+
+        val intent = android.content.Intent(context, LocationService::class.java)
+        intent.action = LocationService.ACTION_START
+        intent.putExtra("boot_start", true)
+        serviceController.create().withIntent(intent).startCommand(0, 1)
+
+        val engine = LocationService.bootLocationEngine
+        assertNotNull(engine, "bootLocationEngine should be initialized in geofence boot mode")
+        assertNotNull(
+            engine.onLocationUpdate,
+            "onLocationUpdate must be wired after boot so high-accuracy geofence transitions can fire",
+        )
+    }
+
+    @Test
     fun `when killed state detects motion WITH cached location, sync is called immediately`() {
         val intent = android.content.Intent(context, LocationService::class.java)
         intent.action = LocationService.ACTION_START


### PR DESCRIPTION
## Problem
Reported in #185 (Samsung S23, `tracelet ^3.3.2`) and reproduced from the reporter's [tracelet_demo](https://github.com/ccsframes/tracelet_demo) — a geofence punch-in/out app using `geofenceModeHighAccuracy: true`. After a device reboot the app relaunches in the background (foreground service + engine running) but **no geofence enter/exit events ever fire**.

## Root cause
In `geofenceModeHighAccuracy` mode the SDK **suppresses OS-level geofence transitions** (`GeofenceManager.handleGeofenceEvent` early-returns) and detects enter/exit **entirely** from a per-location proximity check: `LocationEngine.onLocationUpdate → evaluateHighAccuracyProximity()`.

- `TraceletSdk.startGeofences()` wires that callback.
- But the **boot / task-removal path** (`LocationService.startBootTracking()`) re-registered the OS geofences and **never set `engine.onLocationUpdate`**.

Result after reboot: OS events suppressed *and* proximity callback never invoked ⇒ zero transitions. (Plain non-high-accuracy geofencing kept working after reboot, which made it look intermittent.)

## Fix
The boot GEOFENCES branch now wires `bootLocationEngine.onLocationUpdate` to `updateProximity()` + `evaluateHighAccuracyProximity()` and clears high-accuracy state, mirroring `startGeofences()`.

iOS already wires this in its relaunch path (`autoResumeTracking`), so it was unaffected.

## Tests
- New Robolectric regression test `boot start in high-accuracy geofence mode wires the proximity location stream (issue 185)` — asserts `onLocationUpdate` is non-null after a high-accuracy geofence boot (would fail before the fix).
- Full boot suite: **4/4 pass**. Android SDK compiles clean.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)
