### PR TITLE
fix(android): deliver headless geofence events after reboot in high-accuracy mode (#185)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ website/app/ta/
 website/app/ru/
 .supermemory/
 example/ios/build_out.txt
+my_log.txt

--- a/example/integration_test/geofence_start_mode_test.dart
+++ b/example/integration_test/geofence_start_mode_test.dart
@@ -31,9 +31,11 @@ void main() {
         // 1) Initialize Tracelet with high-accuracy geofence mode
         await Tracelet.ready(
           const Config(
+            android: AndroidConfig(
+              geofenceModeHighAccuracy: true,
+            ),
             geofence: GeofenceConfig(
               geofenceProximityRadius: 10000,
-              geofenceModeHighAccuracy: true,
             ),
             geo: GeoConfig(distanceFilter: 0),
             logger: LoggerConfig(debug: true, logLevel: LogLevel.verbose),

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:crypto/crypto.dart';
@@ -59,6 +60,7 @@ class _IssuesPageState extends State<IssuesPage> {
     154,
     159,
     162,
+    185,
   ];
 
   bool _isIssue134Tracking = false;
@@ -103,6 +105,10 @@ class _IssuesPageState extends State<IssuesPage> {
     _issue155Sub?.cancel();
     _issue157Sub?.cancel();
     _issue162Sub?.cancel();
+    _issue185Sub?.cancel();
+    _issue185LatController.dispose();
+    _issue185LngController.dispose();
+    _issue185RadiusController.dispose();
     super.dispose();
   }
 
@@ -1421,6 +1427,18 @@ class _IssuesPageState extends State<IssuesPage> {
   StreamSubscription? _issue162Sub;
   String _issue162Details = '';
 
+  // ==== ISSUE 185: high-accuracy geofence transitions after reboot ====
+  bool _isIssue185Tracking = false;
+  bool _issue185Polygon = false;
+  StreamSubscription? _issue185Sub;
+  int _issue185EventCount = 0;
+  final TextEditingController _issue185LatController =
+      TextEditingController(text: '21.189504');
+  final TextEditingController _issue185LngController =
+      TextEditingController(text: '72.789831');
+  final TextEditingController _issue185RadiusController =
+      TextEditingController(text: '150');
+
   Future<void> _toggleIssue162() async {
     if (_isIssue162Tracking) {
       await Tracelet.stop();
@@ -1470,6 +1488,175 @@ class _IssuesPageState extends State<IssuesPage> {
       });
     } catch (e) {
       _setStatus(162, '❌ FAILED: $e');
+    }
+  }
+
+  // ==== ISSUE 185: high-accuracy geofence transitions after reboot ====
+  // Reproduces ccsframes/tracelet_demo: geofenceModeHighAccuracy + startOnBoot.
+  // High-accuracy mode suppresses OS-level geofence events and detects
+  // transitions purely from the location stream. The boot/task-removal path
+  // used to skip wiring that stream, so after a reboot NO enter/exit fired.
+  // Fills the lat/lng fields from the device's current GPS fix, so you can drop
+  // a geofence on where you are standing instead of typing coordinates.
+  Future<void> _useIssue185CurrentLocation() async {
+    _setStatus(185, 'Getting current position...');
+    try {
+      await Tracelet.requestLocationAuthorization();
+      final loc = await Tracelet.getCurrentPosition(
+        desiredAccuracy: DesiredAccuracy.high,
+        samples: 2,
+      );
+      setState(() {
+        _issue185LatController.text = loc.coords.latitude.toStringAsFixed(6);
+        _issue185LngController.text = loc.coords.longitude.toStringAsFixed(6);
+      });
+      _setStatus(
+        185,
+        '📍 Current location filled '
+        '(${_issue185LatController.text}, ${_issue185LngController.text}). '
+        'Now tap "Start Geofencing".',
+      );
+    } catch (e) {
+      _setStatus(185, '❌ FAILED getting position: $e');
+    }
+  }
+
+  // Builds a square polygon (4 corners) centred on [lat]/[lng], using [radius]
+  // metres as the half-edge. Each vertex is [latitude, longitude].
+  List<List<double>> _squarePolygon(double lat, double lng, double radius) {
+    final dLat = radius / 111320.0;
+    final dLng = radius / (111320.0 * math.cos(lat * math.pi / 180.0));
+    return <List<double>>[
+      [lat - dLat, lng - dLng],
+      [lat - dLat, lng + dLng],
+      [lat + dLat, lng + dLng],
+      [lat + dLat, lng - dLng],
+    ];
+  }
+
+  Future<void> _startIssue185() async {
+    _setStatus(185, 'Requesting permissions...');
+    try {
+      await Tracelet.requestLocationAuthorization();
+
+      final lat = double.tryParse(_issue185LatController.text.trim());
+      final lng = double.tryParse(_issue185LngController.text.trim());
+      final radius =
+          double.tryParse(_issue185RadiusController.text.trim()) ?? 150.0;
+      if (lat == null || lng == null) {
+        _setStatus(185, '❌ FAILED: enter valid latitude/longitude first.');
+        return;
+      }
+
+      await Tracelet.ready(
+        const Config(
+          app: AppConfig(startOnBoot: true, stopOnTerminate: false),
+          android: AndroidConfig(geofenceModeHighAccuracy: true),
+        ),
+      );
+
+      _issue185EventCount = 0;
+      await _issue185Sub?.cancel();
+      _issue185Sub = Tracelet.onGeofence((event) {
+        _issue185EventCount++;
+        _setStatus(
+          185,
+          '✅ Geofence ${event.action.name.toUpperCase()} #$_issue185EventCount '
+          '@ ${event.location.coords.latitude.toStringAsFixed(5)}, '
+          '${event.location.coords.longitude.toStringAsFixed(5)}',
+        );
+      });
+
+      await Tracelet.removeGeofences();
+      await Tracelet.addGeofence(
+        Geofence(
+          identifier: 'ISSUE_185_ZONE',
+          latitude: lat,
+          longitude: lng,
+          radius: radius,
+          vertices: _issue185Polygon
+              ? _squarePolygon(lat, lng, radius)
+              : const <List<double>>[],
+        ),
+      );
+
+      await Tracelet.startGeofences();
+      setState(() => _isIssue185Tracking = true);
+      _setStatus(
+        185,
+        '🟢 High-accuracy geofencing active '
+        '(${_issue185Polygon ? 'POLYGON' : 'CIRCLE'}, startOnBoot=true).\n'
+        '1) Mock-location: cross IN/OUT of the zone → expect ENTER/EXIT.\n'
+        '2) REBOOT the device (a real reboot, not adb broadcast).\n'
+        '3) WITHOUT reopening the app, cross the zone again with the mock app.\n'
+        'Fixed → ENTER/EXIT fire after reboot. Bug → nothing fires after reboot.\n'
+        '(Samsung: set battery usage to Unrestricted.)',
+      );
+    } catch (e) {
+      _setStatus(185, '❌ FAILED: $e');
+    }
+  }
+
+  Future<void> _stopIssue185() async {
+    await _issue185Sub?.cancel();
+    _issue185Sub = null;
+    try {
+      await Tracelet.stop();
+    } catch (_) {}
+    if (mounted) {
+      setState(() => _isIssue185Tracking = false);
+      _setStatus(185, 'Stopped.');
+    }
+  }
+
+  // After a reboot the app is killed, so the in-app onGeofence callback above
+  // cannot fire — transitions are handled HEADLESSLY. Tracelet persists every
+  // transition to its SQLite log store, so reopening and reading the log proves
+  // the headless geofence events fired while the UI was dead.
+  Future<void> _viewIssue185Logs() async {
+    try {
+      final log = await Tracelet.getLog();
+      final relevant = const LineSplitter()
+          .convert(log)
+          .where(
+            (l) =>
+                l.toLowerCase().contains('geofence') ||
+                l.contains('ENTER') ||
+                l.contains('EXIT') ||
+                l.toLowerCase().contains('boot') ||
+                l.toLowerCase().contains('proximity'),
+          )
+          .toList();
+      final body = relevant.isEmpty
+          ? 'No geofence/boot lines in the persisted log yet.\n\n'
+                'Cross the zone (mock location) — after a reboot too — then reopen '
+                'and tap this again. Headless transitions are written here even '
+                'when the UI is dead.'
+          : relevant.reversed.take(80).toList().reversed.join('\n');
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('#185 — persisted log (geofence/boot)'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: SingleChildScrollView(
+              child: SelectableText(
+                body,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      _setStatus(185, '❌ FAILED reading log: $e');
     }
   }
 
@@ -2100,6 +2287,138 @@ class _IssuesPageState extends State<IssuesPage> {
                       ),
                       label: Text(
                         _isIssue162Tracking ? 'Stop' : 'Start tracking',
+                      ),
+                    ),
+                  ],
+                ),
+                _buildIssueCard(
+                  issueNumber: 185,
+                  title: 'Geofence dead after reboot (high-accuracy)',
+                  description:
+                      'Reproduces ccsframes/tracelet_demo: geofenceModeHighAccuracy '
+                      '+ startOnBoot. High-accuracy mode suppresses OS-level geofence '
+                      'events and detects transitions purely from the location stream. '
+                      'The boot/task-removal path used to skip wiring that stream, so '
+                      'after a reboot NO enter/exit fired. Tap "Use My Location" to drop '
+                      'the zone where you are, pick Circle or Polygon, then test with a '
+                      'mock-location app before AND after a real reboot. Radius doubles '
+                      'as the polygon half-edge.',
+                  actions: [
+                    SizedBox(
+                      width: double.infinity,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextField(
+                                  controller: _issue185LatController,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Latitude',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                        decimal: true,
+                                        signed: true,
+                                      ),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: TextField(
+                                  controller: _issue185LngController,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Longitude',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                        decimal: true,
+                                        signed: true,
+                                      ),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              SizedBox(
+                                width: 90,
+                                child: TextField(
+                                  controller: _issue185RadiusController,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Radius',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                  keyboardType: TextInputType.number,
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: [
+                              OutlinedButton.icon(
+                                onPressed: _isIssue185Tracking
+                                    ? null
+                                    : _useIssue185CurrentLocation,
+                                icon: const Icon(Icons.gps_fixed),
+                                label: const Text('Use My Location'),
+                              ),
+                              SegmentedButton<bool>(
+                                segments: const [
+                                  ButtonSegment(
+                                    value: false,
+                                    icon: Icon(Icons.circle_outlined),
+                                    label: Text('Circle'),
+                                  ),
+                                  ButtonSegment(
+                                    value: true,
+                                    icon: Icon(Icons.pentagon_outlined),
+                                    label: Text('Polygon'),
+                                  ),
+                                ],
+                                selected: {_issue185Polygon},
+                                onSelectionChanged: _isIssue185Tracking
+                                    ? null
+                                    : (s) => setState(
+                                        () => _issue185Polygon = s.first,
+                                      ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: [
+                              FilledButton.icon(
+                                onPressed: _isIssue185Tracking
+                                    ? null
+                                    : _startIssue185,
+                                icon: const Icon(Icons.my_location),
+                                label: const Text('Start Geofencing'),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: _isIssue185Tracking
+                                    ? _stopIssue185
+                                    : null,
+                                icon: const Icon(Icons.stop),
+                                label: const Text('Stop'),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: _viewIssue185Logs,
+                                icon: const Icon(Icons.receipt_long),
+                                label: const Text('View Logs'),
+                              ),
+                            ],
+                          ),
+                        ],
                       ),
                     ),
                   ],

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1432,12 +1432,15 @@ class _IssuesPageState extends State<IssuesPage> {
   bool _issue185Polygon = false;
   StreamSubscription? _issue185Sub;
   int _issue185EventCount = 0;
-  final TextEditingController _issue185LatController =
-      TextEditingController(text: '21.189504');
-  final TextEditingController _issue185LngController =
-      TextEditingController(text: '72.789831');
-  final TextEditingController _issue185RadiusController =
-      TextEditingController(text: '150');
+  final TextEditingController _issue185LatController = TextEditingController(
+    text: '21.189504',
+  );
+  final TextEditingController _issue185LngController = TextEditingController(
+    text: '72.789831',
+  );
+  final TextEditingController _issue185RadiusController = TextEditingController(
+    text: '150',
+  );
 
   Future<void> _toggleIssue162() async {
     if (_isIssue162Tracking) {

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1614,33 +1614,36 @@ class _IssuesPageState extends State<IssuesPage> {
 
   // After a reboot the app is killed, so the in-app onGeofence callback above
   // cannot fire — transitions are handled HEADLESSLY. Tracelet persists every
-  // transition to its SQLite log store, so reopening and reading the log proves
-  // the headless geofence events fired while the UI was dead.
+  // geofence transition to the DB as a location row with event == 'geofence',
+  // so reopening and reading them back proves the headless events fired while
+  // the UI was dead.
   Future<void> _viewIssue185Logs() async {
     try {
-      final log = await Tracelet.getLog();
-      final relevant = const LineSplitter()
-          .convert(log)
-          .where(
-            (l) =>
-                l.toLowerCase().contains('geofence') ||
-                l.contains('ENTER') ||
-                l.contains('EXIT') ||
-                l.toLowerCase().contains('boot') ||
-                l.toLowerCase().contains('proximity'),
-          )
+      final locations = await Tracelet.getLocations();
+      final geofenceHits = locations
+          .where((l) => (l.event ?? '').toLowerCase().contains('geofence'))
           .toList();
-      final body = relevant.isEmpty
-          ? 'No geofence/boot lines in the persisted log yet.\n\n'
+      final body = geofenceHits.isEmpty
+          ? 'No geofence events persisted yet.\n\n'
                 'Cross the zone (mock location) — after a reboot too — then reopen '
-                'and tap this again. Headless transitions are written here even '
-                'when the UI is dead.'
-          : relevant.reversed.take(80).toList().reversed.join('\n');
+                'and tap this again. Headless ENTER/EXIT are written to the DB even '
+                'when the UI is dead.\n\n'
+                '(Tip: `adb logcat | grep -i geofence` shows them live as '
+                '"[Headless] geofence: … action: ENTER/EXIT".)'
+          : geofenceHits.reversed
+                .take(80)
+                .map(
+                  (l) =>
+                      '[${l.timestamp}] ${l.event} '
+                      '@ ${l.coords.latitude.toStringAsFixed(5)}, '
+                      '${l.coords.longitude.toStringAsFixed(5)}',
+                )
+                .join('\n');
       if (!mounted) return;
       await showDialog<void>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: const Text('#185 — persisted log (geofence/boot)'),
+          title: Text('#185 — persisted geofence events (${geofenceHits.length})'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
@@ -2417,7 +2420,7 @@ class _IssuesPageState extends State<IssuesPage> {
                               OutlinedButton.icon(
                                 onPressed: _viewIssue185Logs,
                                 icon: const Icon(Icons.receipt_long),
-                                label: const Text('View Logs'),
+                                label: const Text('View Events'),
                               ),
                             ],
                           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3018,7 +3018,7 @@ class _DashboardPageState extends State<DashboardPage>
     try {
       await tl.Tracelet.setConfig(
         const tl.Config(
-          geofence: tl.GeofenceConfig(geofenceModeHighAccuracy: true),
+          android: tl.AndroidConfig(geofenceModeHighAccuracy: true),
         ),
       );
       final state = await tl.Tracelet.startGeofences();

--- a/packages/tracelet/lib/src/models/config.dart
+++ b/packages/tracelet/lib/src/models/config.dart
@@ -1760,7 +1760,6 @@ class MotionConfig {
 class GeofenceConfig {
   /// Creates a new [GeofenceConfig] with optional overrides.
   const GeofenceConfig({
-    this.geofenceModeHighAccuracy = false,
     this.geofenceInitialTriggerEntry = true,
     this.geofenceInitialTrigger = true,
     this.geofenceProximityRadius = 1000,
@@ -1769,10 +1768,6 @@ class GeofenceConfig {
   /// Creates a [GeofenceConfig] from a map.
   factory GeofenceConfig.fromMap(Map<String, Object?> map) {
     return GeofenceConfig(
-      geofenceModeHighAccuracy: ensureBool(
-        map['geofenceModeHighAccuracy'],
-        fallback: false,
-      ),
       geofenceInitialTriggerEntry: ensureBool(
         map['geofenceInitialTriggerEntry'],
         fallback: true,
@@ -1787,10 +1782,6 @@ class GeofenceConfig {
       ),
     );
   }
-
-  /// Enable high-accuracy location tracking during geofence monitoring (Android only).
-  /// Defaults to `false`.
-  final bool geofenceModeHighAccuracy;
 
   /// Fire enter trigger immediately upon registration if device is already inside the geofence.
   /// Defaults to `true`.
@@ -1808,7 +1799,6 @@ class GeofenceConfig {
   /// Serializes to a map.
   Map<String, Object?> toMap() {
     return <String, Object?>{
-      'geofenceModeHighAccuracy': geofenceModeHighAccuracy,
       'geofenceInitialTriggerEntry': geofenceInitialTriggerEntry,
       'geofenceInitialTrigger': geofenceInitialTrigger,
       'geofenceProximityRadius': geofenceProximityRadius,
@@ -1817,7 +1807,6 @@ class GeofenceConfig {
 
   /// Converts to Pigeon [TlGeofenceConfig].
   TlGeofenceConfig toTlConfig() => TlGeofenceConfig(
-    geofenceModeHighAccuracy: geofenceModeHighAccuracy,
     geofenceInitialTriggerEntry: geofenceInitialTriggerEntry,
     geofenceProximityRadius: geofenceProximityRadius,
     geofenceInitialTrigger: geofenceInitialTrigger,
@@ -1828,14 +1817,12 @@ class GeofenceConfig {
       identical(this, other) ||
       other is GeofenceConfig &&
           runtimeType == other.runtimeType &&
-          geofenceModeHighAccuracy == other.geofenceModeHighAccuracy &&
           geofenceInitialTriggerEntry == other.geofenceInitialTriggerEntry &&
           geofenceInitialTrigger == other.geofenceInitialTrigger &&
           geofenceProximityRadius == other.geofenceProximityRadius;
 
   @override
   int get hashCode => Object.hash(
-    geofenceModeHighAccuracy,
     geofenceInitialTriggerEntry,
     geofenceInitialTrigger,
     geofenceProximityRadius,

--- a/packages/tracelet/test/models_test.dart
+++ b/packages/tracelet/test/models_test.dart
@@ -47,10 +47,7 @@ void main() {
           batchSync: true,
         ),
         motion: MotionConfig(stopTimeout: 10, isMoving: true),
-        geofence: GeofenceConfig(
-          geofenceInitialTriggerEntry: false,
-          geofenceModeHighAccuracy: true,
-        ),
+        geofence: GeofenceConfig(geofenceInitialTriggerEntry: false),
         logger: LoggerConfig(logMaxDays: 7, debug: true),
       );
 
@@ -70,7 +67,6 @@ void main() {
       expect(restored.motion.stopTimeout, 10);
       expect(restored.motion.isMoving, true);
       expect(restored.geofence.geofenceInitialTriggerEntry, false);
-      expect(restored.geofence.geofenceModeHighAccuracy, true);
       expect(restored.logger.logLevel, LogLevel.info);
       expect(restored.logger.logMaxDays, 7);
       expect(restored.logger.debug, true);

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
@@ -1265,7 +1265,6 @@ data class TlMotionConfig (
 
 /** Generated class from Pigeon that represents data sent in messages. */
 data class TlGeofenceConfig (
-  val geofenceModeHighAccuracy: Boolean,
   val geofenceInitialTriggerEntry: Boolean,
   val geofenceProximityRadius: Long,
   val geofenceInitialTrigger: Boolean
@@ -1273,16 +1272,14 @@ data class TlGeofenceConfig (
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): TlGeofenceConfig {
-      val geofenceModeHighAccuracy = pigeonVar_list[0] as Boolean
-      val geofenceInitialTriggerEntry = pigeonVar_list[1] as Boolean
-      val geofenceProximityRadius = pigeonVar_list[2] as Long
-      val geofenceInitialTrigger = pigeonVar_list[3] as Boolean
-      return TlGeofenceConfig(geofenceModeHighAccuracy, geofenceInitialTriggerEntry, geofenceProximityRadius, geofenceInitialTrigger)
+      val geofenceInitialTriggerEntry = pigeonVar_list[0] as Boolean
+      val geofenceProximityRadius = pigeonVar_list[1] as Long
+      val geofenceInitialTrigger = pigeonVar_list[2] as Boolean
+      return TlGeofenceConfig(geofenceInitialTriggerEntry, geofenceProximityRadius, geofenceInitialTrigger)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
-      geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
@@ -1296,12 +1293,11 @@ data class TlGeofenceConfig (
       return true
     }
     val other = other as TlGeofenceConfig
-    return TraceletApiPigeonUtils.deepEquals(this.geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && TraceletApiPigeonUtils.deepEquals(this.geofenceProximityRadius, other.geofenceProximityRadius) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTrigger, other.geofenceInitialTrigger)
+    return TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && TraceletApiPigeonUtils.deepEquals(this.geofenceProximityRadius, other.geofenceProximityRadius) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTrigger, other.geofenceInitialTrigger)
   }
 
   override fun hashCode(): Int {
     var result = javaClass.hashCode()
-    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceModeHighAccuracy)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceInitialTriggerEntry)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceProximityRadius)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceInitialTrigger)

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -281,7 +281,6 @@ class TraceletHostApiImpl(
             put("speedWakeConfirmCount", c.motion.speedWakeConfirmCount)
         })
         put("geofence", buildMap {
-            put("geofenceModeHighAccuracy", c.geofence.geofenceModeHighAccuracy)
             put("geofenceInitialTriggerEntry", c.geofence.geofenceInitialTriggerEntry)
             put("geofenceProximityRadius", c.geofence.geofenceProximityRadius)
             put("geofenceInitialTrigger", c.geofence.geofenceInitialTrigger)

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletStartupProvider.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletStartupProvider.kt
@@ -39,6 +39,24 @@ class TraceletStartupProvider : ContentProvider() {
                     HeadlessTaskService(c, ConfigManager.getInstance(c))
                 }
             }
+            // Wire the headless EVENT bridge too. Without this, a cold boot
+            // (BootReceiver → LocationService, no Flutter engine) leaves
+            // eventSenderFactory null, so LocationService.startBootTracking falls
+            // back to a no-op ListenerEventSender and background location / motion
+            // / geofence events (incl. geofenceModeHighAccuracy enter/exit) are
+            // silently dropped instead of reaching the registered headless task.
+            // Mirrors TraceletAndroidPlugin.onAttachedToEngine; overridden by the
+            // richer main-engine path when the app is later opened.
+            if (TraceletBootstrap.eventSenderFactory == null) {
+                TraceletBootstrap.eventSenderFactory = { c ->
+                    val dispatcher = EventDispatcher()
+                    val h = HeadlessTaskService(c, ConfigManager.getInstance(c))
+                    dispatcher.headlessFallback = { name, data ->
+                        if (h.isRegistered()) h.dispatchEvent(name, data)
+                    }
+                    dispatcher
+                }
+            }
             val sdk = TraceletSdk.getInstance(ctx)
             if (sdk.dartSyncInterceptor == null) {
                 sdk.dartSyncInterceptor = HeadlessSyncInterceptor(ctx)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
@@ -1222,7 +1222,6 @@ struct TlMotionConfig: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct TlGeofenceConfig: Hashable {
-  var geofenceModeHighAccuracy: Bool
   var geofenceInitialTriggerEntry: Bool
   var geofenceProximityRadius: Int64
   var geofenceInitialTrigger: Bool
@@ -1230,13 +1229,11 @@ struct TlGeofenceConfig: Hashable {
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> TlGeofenceConfig? {
-    let geofenceModeHighAccuracy = pigeonVar_list[0] as! Bool
-    let geofenceInitialTriggerEntry = pigeonVar_list[1] as! Bool
-    let geofenceProximityRadius = pigeonVar_list[2] as! Int64
-    let geofenceInitialTrigger = pigeonVar_list[3] as! Bool
+    let geofenceInitialTriggerEntry = pigeonVar_list[0] as! Bool
+    let geofenceProximityRadius = pigeonVar_list[1] as! Int64
+    let geofenceInitialTrigger = pigeonVar_list[2] as! Bool
 
     return TlGeofenceConfig(
-      geofenceModeHighAccuracy: geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry: geofenceInitialTriggerEntry,
       geofenceProximityRadius: geofenceProximityRadius,
       geofenceInitialTrigger: geofenceInitialTrigger
@@ -1244,7 +1241,6 @@ struct TlGeofenceConfig: Hashable {
   }
   func toList() -> [Any?] {
     return [
-      geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
@@ -1254,12 +1250,11 @@ struct TlGeofenceConfig: Hashable {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsTraceletApi(lhs.geofenceModeHighAccuracy, rhs.geofenceModeHighAccuracy) && deepEqualsTraceletApi(lhs.geofenceInitialTriggerEntry, rhs.geofenceInitialTriggerEntry) && deepEqualsTraceletApi(lhs.geofenceProximityRadius, rhs.geofenceProximityRadius) && deepEqualsTraceletApi(lhs.geofenceInitialTrigger, rhs.geofenceInitialTrigger)
+    return deepEqualsTraceletApi(lhs.geofenceInitialTriggerEntry, rhs.geofenceInitialTriggerEntry) && deepEqualsTraceletApi(lhs.geofenceProximityRadius, rhs.geofenceProximityRadius) && deepEqualsTraceletApi(lhs.geofenceInitialTrigger, rhs.geofenceInitialTrigger)
   }
 
   func hash(into hasher: inout Hasher) {
     hasher.combine("TlGeofenceConfig")
-    deepHashTraceletApi(value: geofenceModeHighAccuracy, hasher: &hasher)
     deepHashTraceletApi(value: geofenceInitialTriggerEntry, hasher: &hasher)
     deepHashTraceletApi(value: geofenceProximityRadius, hasher: &hasher)
     deepHashTraceletApi(value: geofenceInitialTrigger, hasher: &hasher)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
@@ -140,7 +140,6 @@ class TraceletHostApiImpl: TraceletHostApi {
         dict["speedWakeConfirmCount"] = c.motion.speedWakeConfirmCount
 
         // Geofence
-        dict["geofenceModeHighAccuracy"] = c.geofence.geofenceModeHighAccuracy
         dict["geofenceInitialTriggerEntry"] = c.geofence.geofenceInitialTriggerEntry
         dict["geofenceProximityRadius"] = c.geofence.geofenceProximityRadius
         dict["geofenceInitialTrigger"] = c.geofence.geofenceInitialTrigger

--- a/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
+++ b/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
@@ -1370,13 +1370,10 @@ class TlMotionConfig {
 
 class TlGeofenceConfig {
   TlGeofenceConfig({
-    required this.geofenceModeHighAccuracy,
     required this.geofenceInitialTriggerEntry,
     required this.geofenceProximityRadius,
     required this.geofenceInitialTrigger,
   });
-
-  bool geofenceModeHighAccuracy;
 
   bool geofenceInitialTriggerEntry;
 
@@ -1386,7 +1383,6 @@ class TlGeofenceConfig {
 
   List<Object?> _toList() {
     return <Object?>[
-      geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
@@ -1400,10 +1396,9 @@ class TlGeofenceConfig {
   static TlGeofenceConfig decode(Object result) {
     result as List<Object?>;
     return TlGeofenceConfig(
-      geofenceModeHighAccuracy: result[0]! as bool,
-      geofenceInitialTriggerEntry: result[1]! as bool,
-      geofenceProximityRadius: result[2]! as int,
-      geofenceInitialTrigger: result[3]! as bool,
+      geofenceInitialTriggerEntry: result[0]! as bool,
+      geofenceProximityRadius: result[1]! as int,
+      geofenceInitialTrigger: result[2]! as bool,
     );
   }
 
@@ -1417,10 +1412,6 @@ class TlGeofenceConfig {
       return true;
     }
     return _deepEquals(
-          geofenceModeHighAccuracy,
-          other.geofenceModeHighAccuracy,
-        ) &&
-        _deepEquals(
           geofenceInitialTriggerEntry,
           other.geofenceInitialTriggerEntry,
         ) &&

--- a/packages/tracelet_platform_interface/lib/src/method_channel_tracelet.dart
+++ b/packages/tracelet_platform_interface/lib/src/method_channel_tracelet.dart
@@ -738,7 +738,6 @@ class MethodChannelTracelet extends TraceletPlatform {
   };
 
   Map<String, Object?> _geofenceToMap(TlGeofenceConfig c) => {
-    'geofenceModeHighAccuracy': c.geofenceModeHighAccuracy,
     'geofenceInitialTriggerEntry': c.geofenceInitialTriggerEntry,
     'geofenceProximityRadius': c.geofenceProximityRadius,
   };

--- a/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
+++ b/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
@@ -372,12 +372,10 @@ class TlMotionConfig {
 
 class TlGeofenceConfig {
   TlGeofenceConfig({
-    required this.geofenceModeHighAccuracy,
     required this.geofenceInitialTriggerEntry,
     required this.geofenceProximityRadius,
     required this.geofenceInitialTrigger,
   });
-  final bool geofenceModeHighAccuracy;
   final bool geofenceInitialTriggerEntry;
   final int geofenceProximityRadius;
   final bool geofenceInitialTrigger;

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -433,9 +433,13 @@ class TraceletSdk private constructor(private val context: Context) {
                     }
                     val useForeground = configManager.isForegroundServiceEnabled()
                     if (useForeground) {
-                        LocationService.switchToStationaryGeofences(locationEngine, stateManager)
+                        LocationService.switchToStationaryGeofences(locationEngine, stateManager, configManager)
                     } else {
-                        locationEngine.stop()
+                        if (configManager.getGeofenceModeHighAccuracy()) {
+                            locationEngine.start()
+                        } else {
+                            locationEngine.stop()
+                        }
                         stateManager.trackingMode = TrackingMode.GEOFENCES
                     }
                     // Dispatch motionchange event so Flutter UI updates _isMoving

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
@@ -219,6 +219,7 @@ class GeofenceManager(
         } catch (e: Exception) {
             TraceletLog.error("Failed to clear geofences from Rust DB", e)
         }
+        invalidateGeofenceCache()
         return unregisterAllGeofences()
     }
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/model/TraceletConfig.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/model/TraceletConfig.kt
@@ -456,21 +456,19 @@ data class MotionConfig(
 }
 
 data class GeofenceConfig(
-    val geofenceModeHighAccuracy: Boolean = false,
     val geofenceInitialTriggerEntry: Boolean = true,
     val geofenceInitialTrigger: Boolean = true,
     val geofenceProximityRadius: Int = 1000
 ) {
     companion object { 
         fun fromMap(m: Map<String, Any?>) = GeofenceConfig(
-            geofenceModeHighAccuracy = m["geofenceModeHighAccuracy"] as? Boolean ?: false,
             geofenceInitialTriggerEntry = m["geofenceInitialTriggerEntry"] as? Boolean ?: true,
             geofenceInitialTrigger = m["geofenceInitialTrigger"] as? Boolean ?: true,
             geofenceProximityRadius = (m["geofenceProximityRadius"] as? Number)?.toInt() ?: 1000
         )
     }
     fun toMap(): Map<String, Any?> = mapOf(
-        "geofenceModeHighAccuracy" to geofenceModeHighAccuracy, "geofenceInitialTriggerEntry" to geofenceInitialTriggerEntry,
+        "geofenceInitialTriggerEntry" to geofenceInitialTriggerEntry,
         "geofenceInitialTrigger" to geofenceInitialTrigger, "geofenceProximityRadius" to geofenceProximityRadius
     )
 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinator.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinator.kt
@@ -127,9 +127,13 @@ class SmartMotionCoordinator(
                 logger.info("SmartMotionCoordinator: Switching to STATIONARY_GEOFENCES")
                 val useForeground = configManager.isForegroundServiceEnabled()
                 if (useForeground) {
-                    LocationService.switchToStationaryGeofences(locationEngine, stateManager)
+                    LocationService.switchToStationaryGeofences(locationEngine, stateManager, configManager)
                 } else {
-                    locationEngine.stop()
+                    if (configManager.getGeofenceModeHighAccuracy()) {
+                        locationEngine.start()
+                    } else {
+                        locationEngine.stop()
+                    }
                 }
                 stateManager.isMoving = false
                 motionDetector.onManualPaceChange(false)

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -201,9 +201,17 @@ class LocationService : Service(), DefaultLifecycleObserver {
         /**
          * Switches to stationary geofences mode.
          */
-        fun switchToStationaryGeofences(engine: com.ikolvi.tracelet.sdk.location.LocationEngine, state: StateManager) {
+        fun switchToStationaryGeofences(
+            engine: com.ikolvi.tracelet.sdk.location.LocationEngine,
+            state: StateManager,
+            config: com.ikolvi.tracelet.sdk.ConfigManager
+        ) {
             stopStationaryTimer()
-            engine.stop()
+            if (config.getGeofenceModeHighAccuracy()) {
+                engine.start()
+            } else {
+                engine.stop()
+            }
             // Mark state as stationary so motion change events fire correctly
             state.isMoving = false
             state.trackingMode = com.ikolvi.tracelet.sdk.model.TrackingMode.GEOFENCES
@@ -786,7 +794,7 @@ class LocationService : Service(), DefaultLifecycleObserver {
                                 }
                             }
                             override fun switchToStationaryGeofences() {
-                                LocationService.switchToStationaryGeofences(engine, state)
+                                LocationService.switchToStationaryGeofences(engine, state, config)
                                 if (state.isMoving) {
                                     state.isMoving = false
                                     val locMap = engine.getLastLocation()?.let { engine.enrichLocation(it, "motionchange") } ?: mapOf("is_moving" to false)
@@ -804,7 +812,7 @@ class LocationService : Service(), DefaultLifecycleObserver {
                     // the appropriate stationary tracking mode.
                     if (state.speedMotionState == com.ikolvi.tracelet.sdk.model.SpeedMotionState.STATIONARY) {
                         when (config.getStationaryTrackingMode()) {
-                            com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state)
+                            com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state, config)
                             else -> LocationService.switchToStationaryPeriodic(engine, config, state)
                         }
                         TraceletLog.debug("Restored stationary mode from persisted speed state")
@@ -920,7 +928,7 @@ class LocationService : Service(), DefaultLifecycleObserver {
                             LocationService.switchToContinuous(engine, state)
                         } else {
                             when (config.getStationaryTrackingMode()) {
-                                com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state)
+                                com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state, config)
                                 else -> LocationService.switchToStationaryPeriodic(engine, config, state)
                             }
                         }
@@ -946,29 +954,29 @@ class LocationService : Service(), DefaultLifecycleObserver {
             // Geofence mode: re-register persisted geofences with Play Services
             // and restore the static BroadcastReceiver reference so transition
             // events are not silently dropped after process death.
+            val geoManager = sdk.geofenceManager
             if (trackingMode == TrackingMode.GEOFENCES) {
-                val geoManager = GeofenceManager(ctx, config, eventSender)
                 geoManager.reRegisterAll()
-                GeofenceBroadcastReceiver.geofenceManager = geoManager
-
-                // Wire the location stream into proximity evaluation. Without this,
-                // geofenceModeHighAccuracy — which suppresses OS-level geofence
-                // transitions and relies entirely on per-location proximity checks
-                // (see GeofenceManager.handleGeofenceEvent / evaluateHighAccuracyProximity)
-                // — produces NO enter/exit events after a reboot or task removal:
-                // the foreground service and engine run, but transitions never fire.
-                // Mirrors TraceletSdk.startGeofences().
-                if (config.getGeofenceModeHighAccuracy()) {
-                    geoManager.clearHighAccuracyState()
-                }
-                bootLocationEngine?.onLocationUpdate = { lat, lng ->
-                    geoManager.updateProximity(lat, lng)
-                    if (config.getGeofenceModeHighAccuracy()) {
-                        geoManager.evaluateHighAccuracyProximity(lat, lng)
-                    }
-                }
-                TraceletLog.debug("Geofence registrations restored after boot/task-removal (proximity stream wired)")
             }
+            GeofenceBroadcastReceiver.geofenceManager = geoManager
+
+            // Wire the location stream into proximity evaluation. Without this,
+            // geofenceModeHighAccuracy — which suppresses OS-level geofence
+            // transitions and relies entirely on per-location proximity checks
+            // (see GeofenceManager.handleGeofenceEvent / evaluateHighAccuracyProximity)
+            // — produces NO enter/exit events after a reboot or task removal:
+            // the foreground service and engine run, but transitions never fire.
+            // Mirrors TraceletSdk.startGeofences() and TraceletSdk.start().
+            if (config.getGeofenceModeHighAccuracy()) {
+                geoManager.clearHighAccuracyState()
+            }
+            bootLocationEngine?.onLocationUpdate = { lat, lng ->
+                geoManager.updateProximity(lat, lng)
+                if (config.getGeofenceModeHighAccuracy()) {
+                    geoManager.evaluateHighAccuracyProximity(lat, lng)
+                }
+            }
+            TraceletLog.debug("Geofence registrations restored after boot/task-removal (proximity stream wired)")
         }
 
     /**

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/ConfigManagerSectionFlatteningTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/ConfigManagerSectionFlatteningTest.kt
@@ -666,7 +666,6 @@ internal class ConfigManagerSectionFlatteningTest {
                 "isMoving" to false
             ),
             "geofence" to mapOf<String, Any?>(
-                "geofenceModeHighAccuracy" to false,
                 "geofenceInitialTriggerEntry" to true,
                 "geofenceProximityRadius" to 1000,
                 "geofenceInitialTrigger" to true

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/OemConfigOverrideTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/OemConfigOverrideTest.kt
@@ -67,9 +67,9 @@ class OemConfigOverrideTest {
         configManager.setConfig(mapOf(
             "android" to mapOf(
                 "foregroundService" to mapOf("enabled" to false),
-                "periodicUseForegroundService" to true
-            ),
-            "geofence" to mapOf("geofenceModeHighAccuracy" to true)
+                "periodicUseForegroundService" to true,
+                "geofenceModeHighAccuracy" to true
+            )
         ))
 
         assertFalse(configManager.isForegroundServiceEnabled())

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerProximityTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerProximityTest.kt
@@ -1,0 +1,94 @@
+package com.ikolvi.tracelet.sdk.geofence
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.ConfigManager
+import com.ikolvi.tracelet.sdk.ListenerEventSender
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import uniffi.tracelet_core.DatabaseManager
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the geofenceModeHighAccuracy "proximity" path — the software-based
+ * ENTER/EXIT detection that runs off the live location stream
+ * (LocationEngine.onLocationUpdate → evaluateHighAccuracyProximity). This is the
+ * path the boot/headless flow relies on (issue #185): OS-level geofence events
+ * are suppressed in high-accuracy mode, so transitions come ONLY from here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GeofenceManagerProximityTest {
+
+    private lateinit var context: Context
+    private lateinit var config: ConfigManager
+    private lateinit var db: DatabaseManager
+    private lateinit var geoManager: GeofenceManager
+    private val captured = mutableListOf<Map<String, Any?>>()
+
+    private val centerLat = 10.787929
+    private val centerLng = 76.684183
+    private val radius = 150.0
+
+    @Before
+    fun setUp() {
+        org.robolectric.shadows.ShadowLog.stream = System.out
+        context = ApplicationProvider.getApplicationContext()
+        config = ConfigManager.getInstance(context)
+        config.setConfig(mapOf("geofenceModeHighAccuracy" to true))
+
+        val dbPath = context.filesDir.resolve("test_geofence_proximity.db").absolutePath
+        db = DatabaseManager(dbPath)
+        db.setEncryptionKey("")
+        db.clearGeofences()
+        db.insertGeofence("ISSUE_185_ZONE", centerLat, centerLng, radius, null, null)
+
+        geoManager = GeofenceManager(context, config, ListenerEventSender(), db)
+        geoManager.onGeofenceEvent = { captured.add(it) }
+        geoManager.clearHighAccuracyState()
+    }
+
+    @After
+    fun tearDown() {
+        ConfigManager.resetInstance()
+        context.filesDir.resolve("test_geofence_proximity.db").delete()
+    }
+
+    private fun lastAction(): String? {
+        val gf = captured.lastOrNull()?.get("geofence") as? Map<*, *>
+        return gf?.get("action") as? String
+    }
+
+    private fun enterCount(): Int = captured.count {
+        ((it["geofence"] as? Map<*, *>)?.get("action") as? String) == "ENTER"
+    }
+
+    @Test
+    fun `high-accuracy proximity fires ENTER then EXIT crossing the boundary`() {
+        // ~1.1 km north — establishes the "outside" baseline, no event.
+        geoManager.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        assertTrue(enterCount() == 0, "Should not ENTER while outside the zone")
+
+        // Move to the centre → crosses inside → ENTER.
+        geoManager.evaluateHighAccuracyProximity(centerLat, centerLng)
+        assertEquals("ENTER", lastAction(), "Crossing inside should fire ENTER")
+
+        // Move ~1.1 km away → EXIT.
+        geoManager.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        assertEquals("EXIT", lastAction(), "Crossing back outside should fire EXIT")
+    }
+
+    @Test
+    fun `staying inside does not re-fire ENTER`() {
+        geoManager.evaluateHighAccuracyProximity(centerLat, centerLng) // ENTER
+        val afterFirst = enterCount()
+        // ~11 m away — still well inside the 150 m radius.
+        geoManager.evaluateHighAccuracyProximity(centerLat + 0.0001, centerLng)
+        assertEquals(afterFirst, enterCount(), "Staying inside must not re-fire ENTER")
+    }
+}


### PR DESCRIPTION
## Follow-up to #186 — makes high-accuracy geofencing actually deliver events after reboot

#186 wired the proximity callback in the boot path, but reboot geofencing still showed nothing. Root cause was deeper and three-layered. All fixed here.

### Root causes
1. **Proximity stream not wired in boot path** — `geofenceModeHighAccuracy` suppresses OS-level geofence transitions and relies entirely on `LocationEngine.onLocationUpdate → evaluateHighAccuracyProximity`. The boot/task-removal path never set that callback. Now wired using the shared `sdk.geofenceManager`.
2. **`switchToStationaryGeofences()` called `engine.stop()`** — killing the GPS stream high-accuracy geofencing depends on. Now keeps the engine running when high-accuracy is enabled.
3. **Headless event bridge missing on cold boot** — on a cold boot (`BootReceiver → LocationService`, no Flutter engine), `TraceletBootstrap.eventSenderFactory` was null, so events fell into a no-op `ListenerEventSender` (the "No event sender factory" warning). `TraceletStartupProvider` (a ContentProvider that runs at process start) previously wired only the **sync** bridge; it now also wires the **event** bridge, mirroring `TraceletAndroidPlugin.onAttachedToEngine`.

### Verified on device
Post-reboot logcat shows the proximity path firing (geofence event coords match the live location stream, OS duplicates suppressed):
```
[Headless] location: lat=10.78765210, lng=76.68292037
[Headless] geofence: { coords:{10.7876521,76.68292037}, action: ENTER }   ← proximity path
...
[Headless] geofence: { action: EXIT }
```

### Cleanup
Removes the duplicate `geofenceModeHighAccuracy` from `GeofenceConfig` (it lives in `AndroidConfig`); regenerates pigeon.

### Tests
- **`GeofenceManagerProximityTest`** (new) — high-accuracy proximity fires ENTER then EXIT across the boundary, and does not re-fire ENTER while inside. (2 tests)
- `LocationServiceSmartBootTest` already asserts `onLocationUpdate` is wired after a high-accuracy geofence boot.
- Full SDK unit suite + 121 Dart model tests pass.

### Example
#185 card adds **Use My Location**, **Circle/Polygon** shape toggle, and a **View Events** button that reads persisted `event=='geofence'` rows so headless transitions are visible after reopening.

iOS already wires the event bridge in its relaunch path (`autoResumeTracking`).

Relates to #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
