### PR TITLE
fix(core): persist resolved address into the DB-sourced sync payload (#187)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ website/app/ta/
 website/app/ru/
 .supermemory/
 example/ios/build_out.txt
+my_log.txt

--- a/example/integration_test/geofence_start_mode_test.dart
+++ b/example/integration_test/geofence_start_mode_test.dart
@@ -31,12 +31,8 @@ void main() {
         // 1) Initialize Tracelet with high-accuracy geofence mode
         await Tracelet.ready(
           const Config(
-            android: AndroidConfig(
-              geofenceModeHighAccuracy: true,
-            ),
-            geofence: GeofenceConfig(
-              geofenceProximityRadius: 10000,
-            ),
+            android: AndroidConfig(geofenceModeHighAccuracy: true),
+            geofence: GeofenceConfig(geofenceProximityRadius: 10000),
             geo: GeoConfig(distanceFilter: 0),
             logger: LoggerConfig(debug: true, logLevel: LogLevel.verbose),
           ),

--- a/example/integration_test/geofence_start_mode_test.dart
+++ b/example/integration_test/geofence_start_mode_test.dart
@@ -31,9 +31,11 @@ void main() {
         // 1) Initialize Tracelet with high-accuracy geofence mode
         await Tracelet.ready(
           const Config(
+            android: AndroidConfig(
+              geofenceModeHighAccuracy: true,
+            ),
             geofence: GeofenceConfig(
               geofenceProximityRadius: 10000,
-              geofenceModeHighAccuracy: true,
             ),
             geo: GeoConfig(distanceFilter: 0),
             logger: LoggerConfig(debug: true, logLevel: LogLevel.verbose),

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1643,7 +1643,9 @@ class _IssuesPageState extends State<IssuesPage> {
       await showDialog<void>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: Text('#185 — persisted geofence events (${geofenceHits.length})'),
+          title: Text(
+            '#185 — persisted geofence events (${geofenceHits.length})',
+          ),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:crypto/crypto.dart';
@@ -59,6 +60,7 @@ class _IssuesPageState extends State<IssuesPage> {
     154,
     159,
     162,
+    185,
   ];
 
   bool _isIssue134Tracking = false;
@@ -103,6 +105,10 @@ class _IssuesPageState extends State<IssuesPage> {
     _issue155Sub?.cancel();
     _issue157Sub?.cancel();
     _issue162Sub?.cancel();
+    _issue185Sub?.cancel();
+    _issue185LatController.dispose();
+    _issue185LngController.dispose();
+    _issue185RadiusController.dispose();
     super.dispose();
   }
 
@@ -1421,6 +1427,18 @@ class _IssuesPageState extends State<IssuesPage> {
   StreamSubscription? _issue162Sub;
   String _issue162Details = '';
 
+  // ==== ISSUE 185: high-accuracy geofence transitions after reboot ====
+  bool _isIssue185Tracking = false;
+  bool _issue185Polygon = false;
+  StreamSubscription? _issue185Sub;
+  int _issue185EventCount = 0;
+  final TextEditingController _issue185LatController =
+      TextEditingController(text: '21.189504');
+  final TextEditingController _issue185LngController =
+      TextEditingController(text: '72.789831');
+  final TextEditingController _issue185RadiusController =
+      TextEditingController(text: '150');
+
   Future<void> _toggleIssue162() async {
     if (_isIssue162Tracking) {
       await Tracelet.stop();
@@ -1470,6 +1488,175 @@ class _IssuesPageState extends State<IssuesPage> {
       });
     } catch (e) {
       _setStatus(162, '❌ FAILED: $e');
+    }
+  }
+
+  // ==== ISSUE 185: high-accuracy geofence transitions after reboot ====
+  // Reproduces ccsframes/tracelet_demo: geofenceModeHighAccuracy + startOnBoot.
+  // High-accuracy mode suppresses OS-level geofence events and detects
+  // transitions purely from the location stream. The boot/task-removal path
+  // used to skip wiring that stream, so after a reboot NO enter/exit fired.
+  // Fills the lat/lng fields from the device's current GPS fix, so you can drop
+  // a geofence on where you are standing instead of typing coordinates.
+  Future<void> _useIssue185CurrentLocation() async {
+    _setStatus(185, 'Getting current position...');
+    try {
+      await Tracelet.requestLocationAuthorization();
+      final loc = await Tracelet.getCurrentPosition(
+        desiredAccuracy: DesiredAccuracy.high,
+        samples: 2,
+      );
+      setState(() {
+        _issue185LatController.text = loc.coords.latitude.toStringAsFixed(6);
+        _issue185LngController.text = loc.coords.longitude.toStringAsFixed(6);
+      });
+      _setStatus(
+        185,
+        '📍 Current location filled '
+        '(${_issue185LatController.text}, ${_issue185LngController.text}). '
+        'Now tap "Start Geofencing".',
+      );
+    } catch (e) {
+      _setStatus(185, '❌ FAILED getting position: $e');
+    }
+  }
+
+  // Builds a square polygon (4 corners) centred on [lat]/[lng], using [radius]
+  // metres as the half-edge. Each vertex is [latitude, longitude].
+  List<List<double>> _squarePolygon(double lat, double lng, double radius) {
+    final dLat = radius / 111320.0;
+    final dLng = radius / (111320.0 * math.cos(lat * math.pi / 180.0));
+    return <List<double>>[
+      [lat - dLat, lng - dLng],
+      [lat - dLat, lng + dLng],
+      [lat + dLat, lng + dLng],
+      [lat + dLat, lng - dLng],
+    ];
+  }
+
+  Future<void> _startIssue185() async {
+    _setStatus(185, 'Requesting permissions...');
+    try {
+      await Tracelet.requestLocationAuthorization();
+
+      final lat = double.tryParse(_issue185LatController.text.trim());
+      final lng = double.tryParse(_issue185LngController.text.trim());
+      final radius =
+          double.tryParse(_issue185RadiusController.text.trim()) ?? 150.0;
+      if (lat == null || lng == null) {
+        _setStatus(185, '❌ FAILED: enter valid latitude/longitude first.');
+        return;
+      }
+
+      await Tracelet.ready(
+        const Config(
+          app: AppConfig(startOnBoot: true, stopOnTerminate: false),
+          android: AndroidConfig(geofenceModeHighAccuracy: true),
+        ),
+      );
+
+      _issue185EventCount = 0;
+      await _issue185Sub?.cancel();
+      _issue185Sub = Tracelet.onGeofence((event) {
+        _issue185EventCount++;
+        _setStatus(
+          185,
+          '✅ Geofence ${event.action.name.toUpperCase()} #$_issue185EventCount '
+          '@ ${event.location.coords.latitude.toStringAsFixed(5)}, '
+          '${event.location.coords.longitude.toStringAsFixed(5)}',
+        );
+      });
+
+      await Tracelet.removeGeofences();
+      await Tracelet.addGeofence(
+        Geofence(
+          identifier: 'ISSUE_185_ZONE',
+          latitude: lat,
+          longitude: lng,
+          radius: radius,
+          vertices: _issue185Polygon
+              ? _squarePolygon(lat, lng, radius)
+              : const <List<double>>[],
+        ),
+      );
+
+      await Tracelet.startGeofences();
+      setState(() => _isIssue185Tracking = true);
+      _setStatus(
+        185,
+        '🟢 High-accuracy geofencing active '
+        '(${_issue185Polygon ? 'POLYGON' : 'CIRCLE'}, startOnBoot=true).\n'
+        '1) Mock-location: cross IN/OUT of the zone → expect ENTER/EXIT.\n'
+        '2) REBOOT the device (a real reboot, not adb broadcast).\n'
+        '3) WITHOUT reopening the app, cross the zone again with the mock app.\n'
+        'Fixed → ENTER/EXIT fire after reboot. Bug → nothing fires after reboot.\n'
+        '(Samsung: set battery usage to Unrestricted.)',
+      );
+    } catch (e) {
+      _setStatus(185, '❌ FAILED: $e');
+    }
+  }
+
+  Future<void> _stopIssue185() async {
+    await _issue185Sub?.cancel();
+    _issue185Sub = null;
+    try {
+      await Tracelet.stop();
+    } catch (_) {}
+    if (mounted) {
+      setState(() => _isIssue185Tracking = false);
+      _setStatus(185, 'Stopped.');
+    }
+  }
+
+  // After a reboot the app is killed, so the in-app onGeofence callback above
+  // cannot fire — transitions are handled HEADLESSLY. Tracelet persists every
+  // transition to its SQLite log store, so reopening and reading the log proves
+  // the headless geofence events fired while the UI was dead.
+  Future<void> _viewIssue185Logs() async {
+    try {
+      final log = await Tracelet.getLog();
+      final relevant = const LineSplitter()
+          .convert(log)
+          .where(
+            (l) =>
+                l.toLowerCase().contains('geofence') ||
+                l.contains('ENTER') ||
+                l.contains('EXIT') ||
+                l.toLowerCase().contains('boot') ||
+                l.toLowerCase().contains('proximity'),
+          )
+          .toList();
+      final body = relevant.isEmpty
+          ? 'No geofence/boot lines in the persisted log yet.\n\n'
+                'Cross the zone (mock location) — after a reboot too — then reopen '
+                'and tap this again. Headless transitions are written here even '
+                'when the UI is dead.'
+          : relevant.reversed.take(80).toList().reversed.join('\n');
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('#185 — persisted log (geofence/boot)'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: SingleChildScrollView(
+              child: SelectableText(
+                body,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      _setStatus(185, '❌ FAILED reading log: $e');
     }
   }
 
@@ -2100,6 +2287,138 @@ class _IssuesPageState extends State<IssuesPage> {
                       ),
                       label: Text(
                         _isIssue162Tracking ? 'Stop' : 'Start tracking',
+                      ),
+                    ),
+                  ],
+                ),
+                _buildIssueCard(
+                  issueNumber: 185,
+                  title: 'Geofence dead after reboot (high-accuracy)',
+                  description:
+                      'Reproduces ccsframes/tracelet_demo: geofenceModeHighAccuracy '
+                      '+ startOnBoot. High-accuracy mode suppresses OS-level geofence '
+                      'events and detects transitions purely from the location stream. '
+                      'The boot/task-removal path used to skip wiring that stream, so '
+                      'after a reboot NO enter/exit fired. Tap "Use My Location" to drop '
+                      'the zone where you are, pick Circle or Polygon, then test with a '
+                      'mock-location app before AND after a real reboot. Radius doubles '
+                      'as the polygon half-edge.',
+                  actions: [
+                    SizedBox(
+                      width: double.infinity,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: TextField(
+                                  controller: _issue185LatController,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Latitude',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                        decimal: true,
+                                        signed: true,
+                                      ),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: TextField(
+                                  controller: _issue185LngController,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Longitude',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                        decimal: true,
+                                        signed: true,
+                                      ),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              SizedBox(
+                                width: 90,
+                                child: TextField(
+                                  controller: _issue185RadiusController,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Radius',
+                                    border: OutlineInputBorder(),
+                                    isDense: true,
+                                  ),
+                                  keyboardType: TextInputType.number,
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: [
+                              OutlinedButton.icon(
+                                onPressed: _isIssue185Tracking
+                                    ? null
+                                    : _useIssue185CurrentLocation,
+                                icon: const Icon(Icons.gps_fixed),
+                                label: const Text('Use My Location'),
+                              ),
+                              SegmentedButton<bool>(
+                                segments: const [
+                                  ButtonSegment(
+                                    value: false,
+                                    icon: Icon(Icons.circle_outlined),
+                                    label: Text('Circle'),
+                                  ),
+                                  ButtonSegment(
+                                    value: true,
+                                    icon: Icon(Icons.pentagon_outlined),
+                                    label: Text('Polygon'),
+                                  ),
+                                ],
+                                selected: {_issue185Polygon},
+                                onSelectionChanged: _isIssue185Tracking
+                                    ? null
+                                    : (s) => setState(
+                                        () => _issue185Polygon = s.first,
+                                      ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: [
+                              FilledButton.icon(
+                                onPressed: _isIssue185Tracking
+                                    ? null
+                                    : _startIssue185,
+                                icon: const Icon(Icons.my_location),
+                                label: const Text('Start Geofencing'),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: _isIssue185Tracking
+                                    ? _stopIssue185
+                                    : null,
+                                icon: const Icon(Icons.stop),
+                                label: const Text('Stop'),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: _viewIssue185Logs,
+                                icon: const Icon(Icons.receipt_long),
+                                label: const Text('View Logs'),
+                              ),
+                            ],
+                          ),
+                        ],
                       ),
                     ),
                   ],

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1432,12 +1432,15 @@ class _IssuesPageState extends State<IssuesPage> {
   bool _issue185Polygon = false;
   StreamSubscription? _issue185Sub;
   int _issue185EventCount = 0;
-  final TextEditingController _issue185LatController =
-      TextEditingController(text: '21.189504');
-  final TextEditingController _issue185LngController =
-      TextEditingController(text: '72.789831');
-  final TextEditingController _issue185RadiusController =
-      TextEditingController(text: '150');
+  final TextEditingController _issue185LatController = TextEditingController(
+    text: '21.189504',
+  );
+  final TextEditingController _issue185LngController = TextEditingController(
+    text: '72.789831',
+  );
+  final TextEditingController _issue185RadiusController = TextEditingController(
+    text: '150',
+  );
 
   Future<void> _toggleIssue162() async {
     if (_isIssue162Tracking) {

--- a/example/lib/issues_page.dart
+++ b/example/lib/issues_page.dart
@@ -1614,33 +1614,36 @@ class _IssuesPageState extends State<IssuesPage> {
 
   // After a reboot the app is killed, so the in-app onGeofence callback above
   // cannot fire — transitions are handled HEADLESSLY. Tracelet persists every
-  // transition to its SQLite log store, so reopening and reading the log proves
-  // the headless geofence events fired while the UI was dead.
+  // geofence transition to the DB as a location row with event == 'geofence',
+  // so reopening and reading them back proves the headless events fired while
+  // the UI was dead.
   Future<void> _viewIssue185Logs() async {
     try {
-      final log = await Tracelet.getLog();
-      final relevant = const LineSplitter()
-          .convert(log)
-          .where(
-            (l) =>
-                l.toLowerCase().contains('geofence') ||
-                l.contains('ENTER') ||
-                l.contains('EXIT') ||
-                l.toLowerCase().contains('boot') ||
-                l.toLowerCase().contains('proximity'),
-          )
+      final locations = await Tracelet.getLocations();
+      final geofenceHits = locations
+          .where((l) => (l.event ?? '').toLowerCase().contains('geofence'))
           .toList();
-      final body = relevant.isEmpty
-          ? 'No geofence/boot lines in the persisted log yet.\n\n'
+      final body = geofenceHits.isEmpty
+          ? 'No geofence events persisted yet.\n\n'
                 'Cross the zone (mock location) — after a reboot too — then reopen '
-                'and tap this again. Headless transitions are written here even '
-                'when the UI is dead.'
-          : relevant.reversed.take(80).toList().reversed.join('\n');
+                'and tap this again. Headless ENTER/EXIT are written to the DB even '
+                'when the UI is dead.\n\n'
+                '(Tip: `adb logcat | grep -i geofence` shows them live as '
+                '"[Headless] geofence: … action: ENTER/EXIT".)'
+          : geofenceHits.reversed
+                .take(80)
+                .map(
+                  (l) =>
+                      '[${l.timestamp}] ${l.event} '
+                      '@ ${l.coords.latitude.toStringAsFixed(5)}, '
+                      '${l.coords.longitude.toStringAsFixed(5)}',
+                )
+                .join('\n');
       if (!mounted) return;
       await showDialog<void>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: const Text('#185 — persisted log (geofence/boot)'),
+          title: Text('#185 — persisted geofence events (${geofenceHits.length})'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
@@ -2417,7 +2420,7 @@ class _IssuesPageState extends State<IssuesPage> {
                               OutlinedButton.icon(
                                 onPressed: _viewIssue185Logs,
                                 icon: const Icon(Icons.receipt_long),
-                                label: const Text('View Logs'),
+                                label: const Text('View Events'),
                               ),
                             ],
                           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3018,7 +3018,7 @@ class _DashboardPageState extends State<DashboardPage>
     try {
       await tl.Tracelet.setConfig(
         const tl.Config(
-          geofence: tl.GeofenceConfig(geofenceModeHighAccuracy: true),
+          android: tl.AndroidConfig(geofenceModeHighAccuracy: true),
         ),
       );
       final state = await tl.Tracelet.startGeofences();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -205,16 +205,23 @@ class _DashboardPageState extends State<DashboardPage>
     try {
       final state = await tl.Tracelet.getState();
       if (state.enabled) {
-        // We're already tracking, bypass initialization and hook up the UI
+        // Tracking was active (persisted state says enabled), but on a fresh
+        // process the NATIVE runtime is not `ready()` yet — getState() reads
+        // persisted state, it does not initialize the engine. We MUST call
+        // ready() again here, otherwise a later start()/changePace() throws
+        // NOT_READY ("Call ready() before start()"). ready() is idempotent and
+        // does not stop active tracking. (#187 repro: stop `flutter run`, run
+        // again, press start → NOT_READY.)
         _subscribeEvents();
+        final readyState = await tl.Tracelet.ready(_buildConfig());
         setState(() {
           _isReady = true;
-          _isTracking = state.enabled;
-          _isMoving = state.isMoving;
-          _isPeriodicMode = state.trackingMode == tl.TrackingMode.periodic;
-          _pluginState = state;
+          _isTracking = readyState.enabled;
+          _isMoving = readyState.isMoving;
+          _isPeriodicMode = readyState.trackingMode == tl.TrackingMode.periodic;
+          _pluginState = readyState;
         });
-        _addLog('RESTORE', 'Restored active tracking state from background');
+        _addLog('RESTORE', 'Restored active tracking state + re-ran ready()');
 
         // Grab the most recent location to populate the map/UI immediately
         final locs = await tl.Tracelet.getLocations();
@@ -377,13 +384,7 @@ class _DashboardPageState extends State<DashboardPage>
         // is visible live, independent of the DB-sourced sync batch.
         final addr = loc.address;
         final addrTag = addr != null
-            ? '  addr=[${[
-                addr.street,
-                addr.city,
-                addr.state,
-                addr.postalCode,
-                addr.country,
-              ].where((e) => e != null && e.isNotEmpty).join(', ')}]'
+            ? '  addr=[${[addr.street, addr.city, addr.state, addr.postalCode, addr.country].where((e) => e != null && e.isNotEmpty).join(', ')}]'
             : '';
         _addLog(
           tag,
@@ -571,6 +572,78 @@ class _DashboardPageState extends State<DashboardPage>
   // ── Lifecycle ───────────────────────────────────────────────────────────
 
   /// Initialize with the *full-featured* config showcasing all new features.
+  /// The canonical Tracelet configuration for this demo. Used by BOTH the
+  /// initial `ready()` and the restore path, so a re-launched app re-establishes
+  /// the native runtime instead of assuming it's still ready (see #187 repro:
+  /// `flutter run` again → start() failed with NOT_READY because the restore
+  /// path set `_isReady = true` without ever calling `ready()`).
+  tl.Config _buildConfig() {
+    return tl.Config(
+      geo: const tl.GeoConfig(
+        distanceFilter: 0,
+        resolveAddress: true,
+        filter: tl.LocationFilter(
+          useKalmanFilter: true,
+          mockDetectionLevel: 2, // 2 = HEURISTIC
+        ),
+        // ── Battery budget (auto-adjusts tracking to save battery) ──
+        batteryBudgetPerHour: 3, // 3% max drain per hour
+      ),
+      app: const tl.AppConfig(
+        stopOnTerminate: false,
+        startOnBoot: true,
+        heartbeatInterval: 10,
+      ),
+      android: tl.AndroidConfig(
+        periodicUseForegroundService: true, // KEEP NOTIFICATION ALIVE
+        locationUpdateInterval: 2000, // 2s
+        deferTime: 1000, // 10s — batches ~5 locations every 10s
+        foregroundService: _isAndroid
+            ? const tl.ForegroundServiceConfig(
+                notificationTitle: '📍 Tracelet Demo Active',
+                notificationText:
+                    'Smart Notifications — disappears when app is open!',
+                channelId: 'tracelet_demo_channel',
+                channelName: 'Tracelet Demo Background',
+                notificationPriority: tl.NotificationPriority.high,
+                showNotificationOnPauseOnly:
+                    true, // ✨ Smart Visibility — hide while app is foregrounded
+              )
+            : const tl.ForegroundServiceConfig(enabled: false),
+        scheduleUseAlarmManager: _isAndroid, // Android-only: exact alarms
+      ),
+      ios: tl.IosConfig(
+        activityType: _isAndroid
+            ? tl.LocationActivityType.other
+            : tl.LocationActivityType.otherNavigation,
+        preventSuspend: !_isAndroid, // iOS-only: silent-audio keep-alive
+      ),
+      motion: const tl.MotionConfig(
+        stopTimeout: 1, // 1 minute for fast stop-timeout testing
+        motionDetectionMode: tl.MotionDetectionMode.smart,
+        shakeThreshold: 2, // prevent ultra-sensitive motion triggering
+        speedStationaryDelay: 30, // Make it quicker for demo testing
+        stationaryPeriodicInterval: 60, // Quick checks when stationary
+      ),
+      http: tl.HttpConfig(
+        url:
+            tl.Tracelet.activeConfig.http.url ??
+            'http://192.168.20.103:8099/locations',
+        autoSyncDelay: 5000,
+      ),
+      audit: const tl.AuditConfig(enabled: true),
+      security: const tl.SecurityConfig(encryptDatabase: true),
+      persistence: const tl.PersistenceConfig(
+        maxDaysToPersist: 7,
+        maxRecordsToPersist: 5000,
+      ),
+      logger: const tl.LoggerConfig(
+        logLevel: tl.LogLevel.verbose,
+        debug: true,
+      ),
+    );
+  }
+
   Future<void> _initialize() async {
     try {
       _subscribeEvents();
@@ -623,79 +696,7 @@ class _DashboardPageState extends State<DashboardPage>
         );
       }
 
-      final state = await tl.Tracelet.ready(
-        tl.Config(
-          geo: const tl.GeoConfig(
-            distanceFilter: 0,
-            resolveAddress: true,
-            filter: tl.LocationFilter(
-              useKalmanFilter: true,
-              mockDetectionLevel: 2, // 2 = HEURISTIC
-            ),
-            // ── Battery budget (auto-adjusts tracking to save battery) ──
-            batteryBudgetPerHour: 3, // 3% max drain per hour
-          ),
-          app: const tl.AppConfig(
-            stopOnTerminate: false,
-            startOnBoot: true,
-            heartbeatInterval: 10,
-          ),
-          // ── Issue #74 fix verification ──
-          // Custom Android config with distinctive notification and deferTime.
-          // Before the fix, these values were silently ignored and defaults
-          // were used instead. After the fix, the notification should show
-          // the custom title/text and deferTime should be 60s.
-          android: tl.AndroidConfig(
-            periodicUseForegroundService: true, // KEEP NOTIFICATION ALIVE
-            locationUpdateInterval: 2000, // 2s
-            deferTime: 1000, // 10s — batches ~5 locations every 10s
-            foregroundService: _isAndroid
-                ? const tl.ForegroundServiceConfig(
-                    notificationTitle: '📍 Tracelet Demo Active',
-                    notificationText:
-                        'Smart Notifications — disappears when app is open!',
-                    channelId: 'tracelet_demo_channel',
-                    channelName: 'Tracelet Demo Background',
-                    notificationPriority: tl.NotificationPriority.high,
-                    showNotificationOnPauseOnly:
-                        true, // ✨ New Feature: Smart Visibility — hide while app is foregrounded
-                  )
-                : const tl.ForegroundServiceConfig(enabled: false),
-            scheduleUseAlarmManager: _isAndroid, // Android-only: exact alarms
-          ),
-          ios: tl.IosConfig(
-            activityType: _isAndroid
-                ? tl.LocationActivityType.other
-                : tl.LocationActivityType.otherNavigation,
-            preventSuspend: !_isAndroid, // iOS-only: silent-audio keep-alive
-          ),
-          motion: const tl.MotionConfig(
-            stopTimeout: 1, // 1 minute for fast stop-timeout testing
-            motionDetectionMode: tl.MotionDetectionMode.smart,
-            shakeThreshold:
-                2, // Increased to 2.0 to prevent ultra-sensitive motion triggering
-            speedStationaryDelay: 30, // Make it quicker for demo testing
-            stationaryPeriodicInterval: 60, // Quick checks when stationary
-          ),
-          http: tl.HttpConfig(
-            url:
-                tl.Tracelet.activeConfig.http.url ??
-                'http://192.168.20.103:8099/locations',
-            // ── New features ──
-            autoSyncDelay: 5000,
-          ),
-          audit: const tl.AuditConfig(enabled: true),
-          security: const tl.SecurityConfig(encryptDatabase: true),
-          persistence: const tl.PersistenceConfig(
-            maxDaysToPersist: 7,
-            maxRecordsToPersist: 5000,
-          ),
-          logger: const tl.LoggerConfig(
-            logLevel: tl.LogLevel.verbose,
-            debug: true,
-          ),
-        ),
-      );
+      final state = await tl.Tracelet.ready(_buildConfig());
 
       // Verify the new RouteContext feature
       await tl.Tracelet.setRouteContext(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -373,11 +373,23 @@ class _DashboardPageState extends State<DashboardPage>
             ? ' [${loc.locationSource.toUpperCase()}]'
             : '';
         final reducedTag = loc.reducedAccuracy ? ' [REDUCED]' : '';
+        // #187: surface the reverse-geocoded address (resolveAddress: true) so it
+        // is visible live, independent of the DB-sourced sync batch.
+        final addr = loc.address;
+        final addrTag = addr != null
+            ? '  addr=[${[
+                addr.street,
+                addr.city,
+                addr.state,
+                addr.postalCode,
+                addr.country,
+              ].where((e) => e != null && e.isNotEmpty).join(', ')}]'
+            : '';
         _addLog(
           tag,
           '${loc.coords.latitude.toStringAsFixed(6)}, ${loc.coords.longitude.toStringAsFixed(6)}  '
           'acc=${loc.coords.accuracy.toStringAsFixed(1)}m  spd=${loc.coords.speed.toStringAsFixed(1)}m/s  '
-          'odo=${loc.odometer.toStringAsFixed(0)}m$mockTag$heuristicsInfo$srcTag$reducedTag',
+          'odo=${loc.odometer.toStringAsFixed(0)}m$mockTag$heuristicsInfo$srcTag$reducedTag$addrTag',
         );
       }),
     );
@@ -615,6 +627,7 @@ class _DashboardPageState extends State<DashboardPage>
         tl.Config(
           geo: const tl.GeoConfig(
             distanceFilter: 0,
+            resolveAddress: true,
             filter: tl.LocationFilter(
               useKalmanFilter: true,
               mockDetectionLevel: 2, // 2 = HEURISTIC

--- a/packages/tracelet/lib/src/models/config.dart
+++ b/packages/tracelet/lib/src/models/config.dart
@@ -1760,7 +1760,6 @@ class MotionConfig {
 class GeofenceConfig {
   /// Creates a new [GeofenceConfig] with optional overrides.
   const GeofenceConfig({
-    this.geofenceModeHighAccuracy = false,
     this.geofenceInitialTriggerEntry = true,
     this.geofenceInitialTrigger = true,
     this.geofenceProximityRadius = 1000,
@@ -1769,10 +1768,6 @@ class GeofenceConfig {
   /// Creates a [GeofenceConfig] from a map.
   factory GeofenceConfig.fromMap(Map<String, Object?> map) {
     return GeofenceConfig(
-      geofenceModeHighAccuracy: ensureBool(
-        map['geofenceModeHighAccuracy'],
-        fallback: false,
-      ),
       geofenceInitialTriggerEntry: ensureBool(
         map['geofenceInitialTriggerEntry'],
         fallback: true,
@@ -1787,10 +1782,6 @@ class GeofenceConfig {
       ),
     );
   }
-
-  /// Enable high-accuracy location tracking during geofence monitoring (Android only).
-  /// Defaults to `false`.
-  final bool geofenceModeHighAccuracy;
 
   /// Fire enter trigger immediately upon registration if device is already inside the geofence.
   /// Defaults to `true`.
@@ -1808,7 +1799,6 @@ class GeofenceConfig {
   /// Serializes to a map.
   Map<String, Object?> toMap() {
     return <String, Object?>{
-      'geofenceModeHighAccuracy': geofenceModeHighAccuracy,
       'geofenceInitialTriggerEntry': geofenceInitialTriggerEntry,
       'geofenceInitialTrigger': geofenceInitialTrigger,
       'geofenceProximityRadius': geofenceProximityRadius,
@@ -1817,7 +1807,6 @@ class GeofenceConfig {
 
   /// Converts to Pigeon [TlGeofenceConfig].
   TlGeofenceConfig toTlConfig() => TlGeofenceConfig(
-    geofenceModeHighAccuracy: geofenceModeHighAccuracy,
     geofenceInitialTriggerEntry: geofenceInitialTriggerEntry,
     geofenceProximityRadius: geofenceProximityRadius,
     geofenceInitialTrigger: geofenceInitialTrigger,
@@ -1828,14 +1817,12 @@ class GeofenceConfig {
       identical(this, other) ||
       other is GeofenceConfig &&
           runtimeType == other.runtimeType &&
-          geofenceModeHighAccuracy == other.geofenceModeHighAccuracy &&
           geofenceInitialTriggerEntry == other.geofenceInitialTriggerEntry &&
           geofenceInitialTrigger == other.geofenceInitialTrigger &&
           geofenceProximityRadius == other.geofenceProximityRadius;
 
   @override
   int get hashCode => Object.hash(
-    geofenceModeHighAccuracy,
     geofenceInitialTriggerEntry,
     geofenceInitialTrigger,
     geofenceProximityRadius,

--- a/packages/tracelet/test/models_test.dart
+++ b/packages/tracelet/test/models_test.dart
@@ -47,10 +47,7 @@ void main() {
           batchSync: true,
         ),
         motion: MotionConfig(stopTimeout: 10, isMoving: true),
-        geofence: GeofenceConfig(
-          geofenceInitialTriggerEntry: false,
-          geofenceModeHighAccuracy: true,
-        ),
+        geofence: GeofenceConfig(geofenceInitialTriggerEntry: false),
         logger: LoggerConfig(logMaxDays: 7, debug: true),
       );
 
@@ -70,7 +67,6 @@ void main() {
       expect(restored.motion.stopTimeout, 10);
       expect(restored.motion.isMoving, true);
       expect(restored.geofence.geofenceInitialTriggerEntry, false);
-      expect(restored.geofence.geofenceModeHighAccuracy, true);
       expect(restored.logger.logLevel, LogLevel.info);
       expect(restored.logger.logMaxDays, 7);
       expect(restored.logger.debug, true);

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
@@ -1265,7 +1265,6 @@ data class TlMotionConfig (
 
 /** Generated class from Pigeon that represents data sent in messages. */
 data class TlGeofenceConfig (
-  val geofenceModeHighAccuracy: Boolean,
   val geofenceInitialTriggerEntry: Boolean,
   val geofenceProximityRadius: Long,
   val geofenceInitialTrigger: Boolean
@@ -1273,16 +1272,14 @@ data class TlGeofenceConfig (
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): TlGeofenceConfig {
-      val geofenceModeHighAccuracy = pigeonVar_list[0] as Boolean
-      val geofenceInitialTriggerEntry = pigeonVar_list[1] as Boolean
-      val geofenceProximityRadius = pigeonVar_list[2] as Long
-      val geofenceInitialTrigger = pigeonVar_list[3] as Boolean
-      return TlGeofenceConfig(geofenceModeHighAccuracy, geofenceInitialTriggerEntry, geofenceProximityRadius, geofenceInitialTrigger)
+      val geofenceInitialTriggerEntry = pigeonVar_list[0] as Boolean
+      val geofenceProximityRadius = pigeonVar_list[1] as Long
+      val geofenceInitialTrigger = pigeonVar_list[2] as Boolean
+      return TlGeofenceConfig(geofenceInitialTriggerEntry, geofenceProximityRadius, geofenceInitialTrigger)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
-      geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
@@ -1296,12 +1293,11 @@ data class TlGeofenceConfig (
       return true
     }
     val other = other as TlGeofenceConfig
-    return TraceletApiPigeonUtils.deepEquals(this.geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && TraceletApiPigeonUtils.deepEquals(this.geofenceProximityRadius, other.geofenceProximityRadius) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTrigger, other.geofenceInitialTrigger)
+    return TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && TraceletApiPigeonUtils.deepEquals(this.geofenceProximityRadius, other.geofenceProximityRadius) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTrigger, other.geofenceInitialTrigger)
   }
 
   override fun hashCode(): Int {
     var result = javaClass.hashCode()
-    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceModeHighAccuracy)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceInitialTriggerEntry)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceProximityRadius)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceInitialTrigger)

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -281,7 +281,6 @@ class TraceletHostApiImpl(
             put("speedWakeConfirmCount", c.motion.speedWakeConfirmCount)
         })
         put("geofence", buildMap {
-            put("geofenceModeHighAccuracy", c.geofence.geofenceModeHighAccuracy)
             put("geofenceInitialTriggerEntry", c.geofence.geofenceInitialTriggerEntry)
             put("geofenceProximityRadius", c.geofence.geofenceProximityRadius)
             put("geofenceInitialTrigger", c.geofence.geofenceInitialTrigger)

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletStartupProvider.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletStartupProvider.kt
@@ -39,6 +39,24 @@ class TraceletStartupProvider : ContentProvider() {
                     HeadlessTaskService(c, ConfigManager.getInstance(c))
                 }
             }
+            // Wire the headless EVENT bridge too. Without this, a cold boot
+            // (BootReceiver → LocationService, no Flutter engine) leaves
+            // eventSenderFactory null, so LocationService.startBootTracking falls
+            // back to a no-op ListenerEventSender and background location / motion
+            // / geofence events (incl. geofenceModeHighAccuracy enter/exit) are
+            // silently dropped instead of reaching the registered headless task.
+            // Mirrors TraceletAndroidPlugin.onAttachedToEngine; overridden by the
+            // richer main-engine path when the app is later opened.
+            if (TraceletBootstrap.eventSenderFactory == null) {
+                TraceletBootstrap.eventSenderFactory = { c ->
+                    val dispatcher = EventDispatcher()
+                    val h = HeadlessTaskService(c, ConfigManager.getInstance(c))
+                    dispatcher.headlessFallback = { name, data ->
+                        if (h.isRegistered()) h.dispatchEvent(name, data)
+                    }
+                    dispatcher
+                }
+            }
             val sdk = TraceletSdk.getInstance(ctx)
             if (sdk.dartSyncInterceptor == null) {
                 sdk.dartSyncInterceptor = HeadlessSyncInterceptor(ctx)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
@@ -1222,7 +1222,6 @@ struct TlMotionConfig: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct TlGeofenceConfig: Hashable {
-  var geofenceModeHighAccuracy: Bool
   var geofenceInitialTriggerEntry: Bool
   var geofenceProximityRadius: Int64
   var geofenceInitialTrigger: Bool
@@ -1230,13 +1229,11 @@ struct TlGeofenceConfig: Hashable {
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> TlGeofenceConfig? {
-    let geofenceModeHighAccuracy = pigeonVar_list[0] as! Bool
-    let geofenceInitialTriggerEntry = pigeonVar_list[1] as! Bool
-    let geofenceProximityRadius = pigeonVar_list[2] as! Int64
-    let geofenceInitialTrigger = pigeonVar_list[3] as! Bool
+    let geofenceInitialTriggerEntry = pigeonVar_list[0] as! Bool
+    let geofenceProximityRadius = pigeonVar_list[1] as! Int64
+    let geofenceInitialTrigger = pigeonVar_list[2] as! Bool
 
     return TlGeofenceConfig(
-      geofenceModeHighAccuracy: geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry: geofenceInitialTriggerEntry,
       geofenceProximityRadius: geofenceProximityRadius,
       geofenceInitialTrigger: geofenceInitialTrigger
@@ -1244,7 +1241,6 @@ struct TlGeofenceConfig: Hashable {
   }
   func toList() -> [Any?] {
     return [
-      geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
@@ -1254,12 +1250,11 @@ struct TlGeofenceConfig: Hashable {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsTraceletApi(lhs.geofenceModeHighAccuracy, rhs.geofenceModeHighAccuracy) && deepEqualsTraceletApi(lhs.geofenceInitialTriggerEntry, rhs.geofenceInitialTriggerEntry) && deepEqualsTraceletApi(lhs.geofenceProximityRadius, rhs.geofenceProximityRadius) && deepEqualsTraceletApi(lhs.geofenceInitialTrigger, rhs.geofenceInitialTrigger)
+    return deepEqualsTraceletApi(lhs.geofenceInitialTriggerEntry, rhs.geofenceInitialTriggerEntry) && deepEqualsTraceletApi(lhs.geofenceProximityRadius, rhs.geofenceProximityRadius) && deepEqualsTraceletApi(lhs.geofenceInitialTrigger, rhs.geofenceInitialTrigger)
   }
 
   func hash(into hasher: inout Hasher) {
     hasher.combine("TlGeofenceConfig")
-    deepHashTraceletApi(value: geofenceModeHighAccuracy, hasher: &hasher)
     deepHashTraceletApi(value: geofenceInitialTriggerEntry, hasher: &hasher)
     deepHashTraceletApi(value: geofenceProximityRadius, hasher: &hasher)
     deepHashTraceletApi(value: geofenceInitialTrigger, hasher: &hasher)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
@@ -140,7 +140,6 @@ class TraceletHostApiImpl: TraceletHostApi {
         dict["speedWakeConfirmCount"] = c.motion.speedWakeConfirmCount
 
         // Geofence
-        dict["geofenceModeHighAccuracy"] = c.geofence.geofenceModeHighAccuracy
         dict["geofenceInitialTriggerEntry"] = c.geofence.geofenceInitialTriggerEntry
         dict["geofenceProximityRadius"] = c.geofence.geofenceProximityRadius
         dict["geofenceInitialTrigger"] = c.geofence.geofenceInitialTrigger

--- a/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
+++ b/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
@@ -1370,13 +1370,10 @@ class TlMotionConfig {
 
 class TlGeofenceConfig {
   TlGeofenceConfig({
-    required this.geofenceModeHighAccuracy,
     required this.geofenceInitialTriggerEntry,
     required this.geofenceProximityRadius,
     required this.geofenceInitialTrigger,
   });
-
-  bool geofenceModeHighAccuracy;
 
   bool geofenceInitialTriggerEntry;
 
@@ -1386,7 +1383,6 @@ class TlGeofenceConfig {
 
   List<Object?> _toList() {
     return <Object?>[
-      geofenceModeHighAccuracy,
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
@@ -1400,10 +1396,9 @@ class TlGeofenceConfig {
   static TlGeofenceConfig decode(Object result) {
     result as List<Object?>;
     return TlGeofenceConfig(
-      geofenceModeHighAccuracy: result[0]! as bool,
-      geofenceInitialTriggerEntry: result[1]! as bool,
-      geofenceProximityRadius: result[2]! as int,
-      geofenceInitialTrigger: result[3]! as bool,
+      geofenceInitialTriggerEntry: result[0]! as bool,
+      geofenceProximityRadius: result[1]! as int,
+      geofenceInitialTrigger: result[2]! as bool,
     );
   }
 
@@ -1417,10 +1412,6 @@ class TlGeofenceConfig {
       return true;
     }
     return _deepEquals(
-          geofenceModeHighAccuracy,
-          other.geofenceModeHighAccuracy,
-        ) &&
-        _deepEquals(
           geofenceInitialTriggerEntry,
           other.geofenceInitialTriggerEntry,
         ) &&

--- a/packages/tracelet_platform_interface/lib/src/method_channel_tracelet.dart
+++ b/packages/tracelet_platform_interface/lib/src/method_channel_tracelet.dart
@@ -738,7 +738,6 @@ class MethodChannelTracelet extends TraceletPlatform {
   };
 
   Map<String, Object?> _geofenceToMap(TlGeofenceConfig c) => {
-    'geofenceModeHighAccuracy': c.geofenceModeHighAccuracy,
     'geofenceInitialTriggerEntry': c.geofenceInitialTriggerEntry,
     'geofenceProximityRadius': c.geofenceProximityRadius,
   };

--- a/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
+++ b/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
@@ -372,12 +372,10 @@ class TlMotionConfig {
 
 class TlGeofenceConfig {
   TlGeofenceConfig({
-    required this.geofenceModeHighAccuracy,
     required this.geofenceInitialTriggerEntry,
     required this.geofenceProximityRadius,
     required this.geofenceInitialTrigger,
   });
-  final bool geofenceModeHighAccuracy;
   final bool geofenceInitialTriggerEntry;
   final int geofenceProximityRadius;
   final bool geofenceInitialTrigger;

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -1228,6 +1228,7 @@ class TraceletSdk private constructor(private val context: Context) {
             odometer = odometer,
             eventType = record.eventType,
             eventPayload = record.eventPayload,
+            address = record.address,
         )
     }
 
@@ -1339,6 +1340,10 @@ class TraceletSdk private constructor(private val context: Context) {
         val eventType = (params["event"] as? String) ?: "location"
         val eventPayload: String? = (params["event_payload"] as? String)
             ?: (params["geofence"] as? Map<*, *>)?.let { org.json.JSONObject(it as Map<String, Any?>).toString() }
+        // #187: persist the reverse-geocoded address (added by resolveAddress) so
+        // it survives into the DB-sourced sync payload, not just the live event.
+        val address: String? = (params["address"] as? String)
+            ?: (params["address"] as? Map<*, *>)?.let { org.json.JSONObject(it as Map<String, Any?>).toString() }
         
         // Prevent duplicate insertions of the exact same GPS fix (e.g. from PeriodicLocationWorker)
         if (eventType == "location" && timestamp != null && timestamp == lastInsertedTimestamp) {
@@ -1390,7 +1395,7 @@ class TraceletSdk private constructor(private val context: Context) {
         }
 
         return try {
-            val newRowId = db.insertLocation(uuid, lat, lng, acc, speed, heading, altitude, isMock, isMoving, activity, routeContext, timestamp, eventType, eventPayload)
+            val newRowId = db.insertLocation(uuid, lat, lng, acc, speed, heading, altitude, isMock, isMoving, activity, routeContext, timestamp, eventType, eventPayload, address)
             // Notify the sync plugin so it can trigger auto-sync
             (syncProvider as? com.ikolvi.tracelet.sdk.location.LocationDataSink)?.insertLocation(params)
             newRowId.toString()

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -433,9 +433,13 @@ class TraceletSdk private constructor(private val context: Context) {
                     }
                     val useForeground = configManager.isForegroundServiceEnabled()
                     if (useForeground) {
-                        LocationService.switchToStationaryGeofences(locationEngine, stateManager)
+                        LocationService.switchToStationaryGeofences(locationEngine, stateManager, configManager)
                     } else {
-                        locationEngine.stop()
+                        if (configManager.getGeofenceModeHighAccuracy()) {
+                            locationEngine.start()
+                        } else {
+                            locationEngine.stop()
+                        }
                         stateManager.trackingMode = TrackingMode.GEOFENCES
                     }
                     // Dispatch motionchange event so Flutter UI updates _isMoving

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
@@ -219,6 +219,7 @@ class GeofenceManager(
         } catch (e: Exception) {
             TraceletLog.error("Failed to clear geofences from Rust DB", e)
         }
+        invalidateGeofenceCache()
         return unregisterAllGeofences()
     }
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationMapper.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationMapper.kt
@@ -42,6 +42,7 @@ object LocationMapper {
         odometer: Double,
         eventType: String = "location",
         eventPayload: String? = null,
+        address: String? = null,
     ): Map<String, Any?> {
         val map = mutableMapOf<String, Any?>(
             "uuid" to (uuid ?: id.toString()),
@@ -75,7 +76,18 @@ object LocationMapper {
                 // ignore
             }
         }
-        
+
+        // #187: surface the persisted reverse-geocoded address into the same
+        // nested shape used by the live onLocation event, so it appears in
+        // getLocations() and the sync payload.
+        if (!address.isNullOrBlank()) {
+            try {
+                map["address"] = jsonToKotlin(JSONObject(address))
+            } catch (e: Exception) {
+                // ignore malformed address JSON
+            }
+        }
+
         applyRouteContext(map, routeContext)
         return map
     }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/model/TraceletConfig.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/model/TraceletConfig.kt
@@ -456,21 +456,19 @@ data class MotionConfig(
 }
 
 data class GeofenceConfig(
-    val geofenceModeHighAccuracy: Boolean = false,
     val geofenceInitialTriggerEntry: Boolean = true,
     val geofenceInitialTrigger: Boolean = true,
     val geofenceProximityRadius: Int = 1000
 ) {
     companion object { 
         fun fromMap(m: Map<String, Any?>) = GeofenceConfig(
-            geofenceModeHighAccuracy = m["geofenceModeHighAccuracy"] as? Boolean ?: false,
             geofenceInitialTriggerEntry = m["geofenceInitialTriggerEntry"] as? Boolean ?: true,
             geofenceInitialTrigger = m["geofenceInitialTrigger"] as? Boolean ?: true,
             geofenceProximityRadius = (m["geofenceProximityRadius"] as? Number)?.toInt() ?: 1000
         )
     }
     fun toMap(): Map<String, Any?> = mapOf(
-        "geofenceModeHighAccuracy" to geofenceModeHighAccuracy, "geofenceInitialTriggerEntry" to geofenceInitialTriggerEntry,
+        "geofenceInitialTriggerEntry" to geofenceInitialTriggerEntry,
         "geofenceInitialTrigger" to geofenceInitialTrigger, "geofenceProximityRadius" to geofenceProximityRadius
     )
 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinator.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinator.kt
@@ -127,9 +127,13 @@ class SmartMotionCoordinator(
                 logger.info("SmartMotionCoordinator: Switching to STATIONARY_GEOFENCES")
                 val useForeground = configManager.isForegroundServiceEnabled()
                 if (useForeground) {
-                    LocationService.switchToStationaryGeofences(locationEngine, stateManager)
+                    LocationService.switchToStationaryGeofences(locationEngine, stateManager, configManager)
                 } else {
-                    locationEngine.stop()
+                    if (configManager.getGeofenceModeHighAccuracy()) {
+                        locationEngine.start()
+                    } else {
+                        locationEngine.stop()
+                    }
                 }
                 stateManager.isMoving = false
                 motionDetector.onManualPaceChange(false)

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -201,9 +201,17 @@ class LocationService : Service(), DefaultLifecycleObserver {
         /**
          * Switches to stationary geofences mode.
          */
-        fun switchToStationaryGeofences(engine: com.ikolvi.tracelet.sdk.location.LocationEngine, state: StateManager) {
+        fun switchToStationaryGeofences(
+            engine: com.ikolvi.tracelet.sdk.location.LocationEngine,
+            state: StateManager,
+            config: com.ikolvi.tracelet.sdk.ConfigManager
+        ) {
             stopStationaryTimer()
-            engine.stop()
+            if (config.getGeofenceModeHighAccuracy()) {
+                engine.start()
+            } else {
+                engine.stop()
+            }
             // Mark state as stationary so motion change events fire correctly
             state.isMoving = false
             state.trackingMode = com.ikolvi.tracelet.sdk.model.TrackingMode.GEOFENCES
@@ -786,7 +794,7 @@ class LocationService : Service(), DefaultLifecycleObserver {
                                 }
                             }
                             override fun switchToStationaryGeofences() {
-                                LocationService.switchToStationaryGeofences(engine, state)
+                                LocationService.switchToStationaryGeofences(engine, state, config)
                                 if (state.isMoving) {
                                     state.isMoving = false
                                     val locMap = engine.getLastLocation()?.let { engine.enrichLocation(it, "motionchange") } ?: mapOf("is_moving" to false)
@@ -804,7 +812,7 @@ class LocationService : Service(), DefaultLifecycleObserver {
                     // the appropriate stationary tracking mode.
                     if (state.speedMotionState == com.ikolvi.tracelet.sdk.model.SpeedMotionState.STATIONARY) {
                         when (config.getStationaryTrackingMode()) {
-                            com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state)
+                            com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state, config)
                             else -> LocationService.switchToStationaryPeriodic(engine, config, state)
                         }
                         TraceletLog.debug("Restored stationary mode from persisted speed state")
@@ -920,7 +928,7 @@ class LocationService : Service(), DefaultLifecycleObserver {
                             LocationService.switchToContinuous(engine, state)
                         } else {
                             when (config.getStationaryTrackingMode()) {
-                                com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state)
+                                com.ikolvi.tracelet.sdk.model.StationaryTrackingMode.GEOFENCES -> LocationService.switchToStationaryGeofences(engine, state, config)
                                 else -> LocationService.switchToStationaryPeriodic(engine, config, state)
                             }
                         }
@@ -946,29 +954,29 @@ class LocationService : Service(), DefaultLifecycleObserver {
             // Geofence mode: re-register persisted geofences with Play Services
             // and restore the static BroadcastReceiver reference so transition
             // events are not silently dropped after process death.
+            val geoManager = sdk.geofenceManager
             if (trackingMode == TrackingMode.GEOFENCES) {
-                val geoManager = GeofenceManager(ctx, config, eventSender)
                 geoManager.reRegisterAll()
-                GeofenceBroadcastReceiver.geofenceManager = geoManager
-
-                // Wire the location stream into proximity evaluation. Without this,
-                // geofenceModeHighAccuracy — which suppresses OS-level geofence
-                // transitions and relies entirely on per-location proximity checks
-                // (see GeofenceManager.handleGeofenceEvent / evaluateHighAccuracyProximity)
-                // — produces NO enter/exit events after a reboot or task removal:
-                // the foreground service and engine run, but transitions never fire.
-                // Mirrors TraceletSdk.startGeofences().
-                if (config.getGeofenceModeHighAccuracy()) {
-                    geoManager.clearHighAccuracyState()
-                }
-                bootLocationEngine?.onLocationUpdate = { lat, lng ->
-                    geoManager.updateProximity(lat, lng)
-                    if (config.getGeofenceModeHighAccuracy()) {
-                        geoManager.evaluateHighAccuracyProximity(lat, lng)
-                    }
-                }
-                TraceletLog.debug("Geofence registrations restored after boot/task-removal (proximity stream wired)")
             }
+            GeofenceBroadcastReceiver.geofenceManager = geoManager
+
+            // Wire the location stream into proximity evaluation. Without this,
+            // geofenceModeHighAccuracy — which suppresses OS-level geofence
+            // transitions and relies entirely on per-location proximity checks
+            // (see GeofenceManager.handleGeofenceEvent / evaluateHighAccuracyProximity)
+            // — produces NO enter/exit events after a reboot or task removal:
+            // the foreground service and engine run, but transitions never fire.
+            // Mirrors TraceletSdk.startGeofences() and TraceletSdk.start().
+            if (config.getGeofenceModeHighAccuracy()) {
+                geoManager.clearHighAccuracyState()
+            }
+            bootLocationEngine?.onLocationUpdate = { lat, lng ->
+                geoManager.updateProximity(lat, lng)
+                if (config.getGeofenceModeHighAccuracy()) {
+                    geoManager.evaluateHighAccuracyProximity(lat, lng)
+                }
+            }
+            TraceletLog.debug("Geofence registrations restored after boot/task-removal (proximity stream wired)")
         }
 
     /**

--- a/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
@@ -1038,7 +1038,7 @@ external fun uniffi_tracelet_core_fn_method_databasemanager_insert_audit_trail(`
 ): Unit
 external fun uniffi_tracelet_core_fn_method_databasemanager_insert_geofence(`ptr`: Long,`identifier`: RustBuffer.ByValue,`lat`: Double,`lng`: Double,`radius`: Double,`vertices`: RustBuffer.ByValue,`extras`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
-external fun uniffi_tracelet_core_fn_method_databasemanager_insert_location(`ptr`: Long,`uuid`: RustBuffer.ByValue,`lat`: Double,`lng`: Double,`acc`: Double,`speed`: Double,`heading`: Double,`altitude`: Double,`isMock`: Byte,`isMoving`: Byte,`activity`: RustBuffer.ByValue,`routeContext`: RustBuffer.ByValue,`timestampOverride`: RustBuffer.ByValue,`eventType`: RustBuffer.ByValue,`eventPayload`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+external fun uniffi_tracelet_core_fn_method_databasemanager_insert_location(`ptr`: Long,`uuid`: RustBuffer.ByValue,`lat`: Double,`lng`: Double,`acc`: Double,`speed`: Double,`heading`: Double,`altitude`: Double,`isMock`: Byte,`isMoving`: Byte,`activity`: RustBuffer.ByValue,`routeContext`: RustBuffer.ByValue,`timestampOverride`: RustBuffer.ByValue,`eventType`: RustBuffer.ByValue,`eventPayload`: RustBuffer.ByValue,`address`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Long
 external fun uniffi_tracelet_core_fn_method_databasemanager_insert_log(`ptr`: Long,`level`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,`source`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -1451,7 +1451,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_tracelet_core_checksum_method_databasemanager_insert_geofence() != 35448.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tracelet_core_checksum_method_databasemanager_insert_location() != 14450.toShort()) {
+    if (lib.uniffi_tracelet_core_checksum_method_databasemanager_insert_location() != 41177.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_method_databasemanager_insert_log() != 43891.toShort()) {
@@ -3089,7 +3089,7 @@ public interface DatabaseManagerInterface {
     /**
      * Inserts a new location record into the database.
      */
-    fun `insertLocation`(`uuid`: kotlin.String?, `lat`: kotlin.Double, `lng`: kotlin.Double, `acc`: kotlin.Double, `speed`: kotlin.Double, `heading`: kotlin.Double, `altitude`: kotlin.Double, `isMock`: kotlin.Boolean, `isMoving`: kotlin.Boolean, `activity`: kotlin.String, `routeContext`: kotlin.String?, `timestampOverride`: kotlin.String?, `eventType`: kotlin.String?, `eventPayload`: kotlin.String?): kotlin.Long
+    fun `insertLocation`(`uuid`: kotlin.String?, `lat`: kotlin.Double, `lng`: kotlin.Double, `acc`: kotlin.Double, `speed`: kotlin.Double, `heading`: kotlin.Double, `altitude`: kotlin.Double, `isMock`: kotlin.Boolean, `isMoving`: kotlin.Boolean, `activity`: kotlin.String, `routeContext`: kotlin.String?, `timestampOverride`: kotlin.String?, `eventType`: kotlin.String?, `eventPayload`: kotlin.String?, `address`: kotlin.String?): kotlin.Long
     
     /**
      * Inserts a log entry into the database.
@@ -3600,13 +3600,13 @@ open class DatabaseManager: Disposable, AutoCloseable, DatabaseManagerInterface
     /**
      * Inserts a new location record into the database.
      */
-    @Throws(TraceletException::class)override fun `insertLocation`(`uuid`: kotlin.String?, `lat`: kotlin.Double, `lng`: kotlin.Double, `acc`: kotlin.Double, `speed`: kotlin.Double, `heading`: kotlin.Double, `altitude`: kotlin.Double, `isMock`: kotlin.Boolean, `isMoving`: kotlin.Boolean, `activity`: kotlin.String, `routeContext`: kotlin.String?, `timestampOverride`: kotlin.String?, `eventType`: kotlin.String?, `eventPayload`: kotlin.String?): kotlin.Long {
+    @Throws(TraceletException::class)override fun `insertLocation`(`uuid`: kotlin.String?, `lat`: kotlin.Double, `lng`: kotlin.Double, `acc`: kotlin.Double, `speed`: kotlin.Double, `heading`: kotlin.Double, `altitude`: kotlin.Double, `isMock`: kotlin.Boolean, `isMoving`: kotlin.Boolean, `activity`: kotlin.String, `routeContext`: kotlin.String?, `timestampOverride`: kotlin.String?, `eventType`: kotlin.String?, `eventPayload`: kotlin.String?, `address`: kotlin.String?): kotlin.Long {
             return FfiConverterLong.lift(
     callWithHandle {
     uniffiRustCallWithError(TraceletException) { _status ->
     UniffiLib.uniffi_tracelet_core_fn_method_databasemanager_insert_location(
         it,
-        FfiConverterOptionalString.lower(`uuid`),FfiConverterDouble.lower(`lat`),FfiConverterDouble.lower(`lng`),FfiConverterDouble.lower(`acc`),FfiConverterDouble.lower(`speed`),FfiConverterDouble.lower(`heading`),FfiConverterDouble.lower(`altitude`),FfiConverterBoolean.lower(`isMock`),FfiConverterBoolean.lower(`isMoving`),FfiConverterString.lower(`activity`),FfiConverterOptionalString.lower(`routeContext`),FfiConverterOptionalString.lower(`timestampOverride`),FfiConverterOptionalString.lower(`eventType`),FfiConverterOptionalString.lower(`eventPayload`),_status)
+        FfiConverterOptionalString.lower(`uuid`),FfiConverterDouble.lower(`lat`),FfiConverterDouble.lower(`lng`),FfiConverterDouble.lower(`acc`),FfiConverterDouble.lower(`speed`),FfiConverterDouble.lower(`heading`),FfiConverterDouble.lower(`altitude`),FfiConverterBoolean.lower(`isMock`),FfiConverterBoolean.lower(`isMoving`),FfiConverterString.lower(`activity`),FfiConverterOptionalString.lower(`routeContext`),FfiConverterOptionalString.lower(`timestampOverride`),FfiConverterOptionalString.lower(`eventType`),FfiConverterOptionalString.lower(`eventPayload`),FfiConverterOptionalString.lower(`address`),_status)
 }
     }
     )
@@ -8578,6 +8578,13 @@ data class DbLocationRecord (
      * and action). `None` for plain location records.
      */
     var `eventPayload`: kotlin.String?
+    , 
+    /**
+     * Optional reverse-geocoded address as a JSON object string (e.g.
+     * `{"street":..,"city":..,"state":..,"postalCode":..,"country":..}`).
+     * Populated when `resolveAddress` is enabled (#187). `None` otherwise.
+     */
+    var `address`: kotlin.String?
     
 ){
     
@@ -8609,6 +8616,7 @@ public object FfiConverterTypeDbLocationRecord: FfiConverterRustBuffer<DbLocatio
             FfiConverterOptionalString.read(buf),
             FfiConverterString.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
         )
     }
 
@@ -8627,7 +8635,8 @@ public object FfiConverterTypeDbLocationRecord: FfiConverterRustBuffer<DbLocatio
             FfiConverterString.allocationSize(value.`activity`) +
             FfiConverterOptionalString.allocationSize(value.`routeContext`) +
             FfiConverterString.allocationSize(value.`eventType`) +
-            FfiConverterOptionalString.allocationSize(value.`eventPayload`)
+            FfiConverterOptionalString.allocationSize(value.`eventPayload`) +
+            FfiConverterOptionalString.allocationSize(value.`address`)
     )
 
     override fun write(value: DbLocationRecord, buf: ByteBuffer) {
@@ -8646,6 +8655,7 @@ public object FfiConverterTypeDbLocationRecord: FfiConverterRustBuffer<DbLocatio
             FfiConverterOptionalString.write(value.`routeContext`, buf)
             FfiConverterString.write(value.`eventType`, buf)
             FfiConverterOptionalString.write(value.`eventPayload`, buf)
+            FfiConverterOptionalString.write(value.`address`, buf)
     }
 }
 

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/ConfigManagerSectionFlatteningTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/ConfigManagerSectionFlatteningTest.kt
@@ -666,7 +666,6 @@ internal class ConfigManagerSectionFlatteningTest {
                 "isMoving" to false
             ),
             "geofence" to mapOf<String, Any?>(
-                "geofenceModeHighAccuracy" to false,
                 "geofenceInitialTriggerEntry" to true,
                 "geofenceProximityRadius" to 1000,
                 "geofenceInitialTrigger" to true

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/OemConfigOverrideTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/OemConfigOverrideTest.kt
@@ -67,9 +67,9 @@ class OemConfigOverrideTest {
         configManager.setConfig(mapOf(
             "android" to mapOf(
                 "foregroundService" to mapOf("enabled" to false),
-                "periodicUseForegroundService" to true
-            ),
-            "geofence" to mapOf("geofenceModeHighAccuracy" to true)
+                "periodicUseForegroundService" to true,
+                "geofenceModeHighAccuracy" to true
+            )
         ))
 
         assertFalse(configManager.isForegroundServiceEnabled())

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerProximityTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerProximityTest.kt
@@ -1,0 +1,94 @@
+package com.ikolvi.tracelet.sdk.geofence
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.ConfigManager
+import com.ikolvi.tracelet.sdk.ListenerEventSender
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import uniffi.tracelet_core.DatabaseManager
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the geofenceModeHighAccuracy "proximity" path — the software-based
+ * ENTER/EXIT detection that runs off the live location stream
+ * (LocationEngine.onLocationUpdate → evaluateHighAccuracyProximity). This is the
+ * path the boot/headless flow relies on (issue #185): OS-level geofence events
+ * are suppressed in high-accuracy mode, so transitions come ONLY from here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GeofenceManagerProximityTest {
+
+    private lateinit var context: Context
+    private lateinit var config: ConfigManager
+    private lateinit var db: DatabaseManager
+    private lateinit var geoManager: GeofenceManager
+    private val captured = mutableListOf<Map<String, Any?>>()
+
+    private val centerLat = 10.787929
+    private val centerLng = 76.684183
+    private val radius = 150.0
+
+    @Before
+    fun setUp() {
+        org.robolectric.shadows.ShadowLog.stream = System.out
+        context = ApplicationProvider.getApplicationContext()
+        config = ConfigManager.getInstance(context)
+        config.setConfig(mapOf("geofenceModeHighAccuracy" to true))
+
+        val dbPath = context.filesDir.resolve("test_geofence_proximity.db").absolutePath
+        db = DatabaseManager(dbPath)
+        db.setEncryptionKey("")
+        db.clearGeofences()
+        db.insertGeofence("ISSUE_185_ZONE", centerLat, centerLng, radius, null, null)
+
+        geoManager = GeofenceManager(context, config, ListenerEventSender(), db)
+        geoManager.onGeofenceEvent = { captured.add(it) }
+        geoManager.clearHighAccuracyState()
+    }
+
+    @After
+    fun tearDown() {
+        ConfigManager.resetInstance()
+        context.filesDir.resolve("test_geofence_proximity.db").delete()
+    }
+
+    private fun lastAction(): String? {
+        val gf = captured.lastOrNull()?.get("geofence") as? Map<*, *>
+        return gf?.get("action") as? String
+    }
+
+    private fun enterCount(): Int = captured.count {
+        ((it["geofence"] as? Map<*, *>)?.get("action") as? String) == "ENTER"
+    }
+
+    @Test
+    fun `high-accuracy proximity fires ENTER then EXIT crossing the boundary`() {
+        // ~1.1 km north — establishes the "outside" baseline, no event.
+        geoManager.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        assertTrue(enterCount() == 0, "Should not ENTER while outside the zone")
+
+        // Move to the centre → crosses inside → ENTER.
+        geoManager.evaluateHighAccuracyProximity(centerLat, centerLng)
+        assertEquals("ENTER", lastAction(), "Crossing inside should fire ENTER")
+
+        // Move ~1.1 km away → EXIT.
+        geoManager.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        assertEquals("EXIT", lastAction(), "Crossing back outside should fire EXIT")
+    }
+
+    @Test
+    fun `staying inside does not re-fire ENTER`() {
+        geoManager.evaluateHighAccuracyProximity(centerLat, centerLng) // ENTER
+        val afterFirst = enterCount()
+        // ~11 m away — still well inside the 150 m radius.
+        geoManager.evaluateHighAccuracyProximity(centerLat + 0.0001, centerLng)
+        assertEquals(afterFirst, enterCount(), "Staying inside must not re-fire ENTER")
+    }
+}

--- a/sdk/ios/Sources/TraceletSDK/LocationMapper.swift
+++ b/sdk/ios/Sources/TraceletSDK/LocationMapper.swift
@@ -34,7 +34,8 @@ public enum LocationMapper {
         isMoving: Bool,
         odometer: Double,
         eventType: String? = nil,
-        eventPayload: String? = nil
+        eventPayload: String? = nil,
+        address: String? = nil
     ) -> [String: Any] {
         var map: [String: Any] = [
             "uuid": uuid ?? String(id),
@@ -67,7 +68,15 @@ public enum LocationMapper {
                 map[eventType] = json
             }
         }
-        
+
+        // #187: surface the persisted reverse-geocoded address into the same
+        // nested shape used by the live onLocation event.
+        if let address = address,
+           let data = address.data(using: .utf8),
+           let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] {
+            map["address"] = json
+        }
+
         applyRouteContext(&map, routeContext)
         return map
     }

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -906,7 +906,8 @@ public final class TraceletSdk {
             isMoving: record.isMoving,
             odometer: locationEngine.getOdometer(),
             eventType: record.eventType,
-            eventPayload: record.eventPayload
+            eventPayload: record.eventPayload,
+            address: record.address
         )
     }
 
@@ -1035,6 +1036,16 @@ public final class TraceletSdk {
                 eventPayload = jsonString
             }
         }
+
+        // #187: persist the reverse-geocoded address (added by resolveAddress) so
+        // it survives into the DB-sourced sync payload, not just the live event.
+        var address: String? = params["address"] as? String
+        if address == nil, let addressData = params["address"] as? [String: Any] {
+            if let jsonData = try? JSONSerialization.data(withJSONObject: addressData, options: []),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                address = jsonString
+            }
+        }
         
         // Prevent duplicate insertions of the exact same GPS fix
         if eventType == "location", let ts = timestamp, ts == lastInsertedTimestamp {
@@ -1092,7 +1103,8 @@ public final class TraceletSdk {
                 routeContext: routeContext,
                 timestampOverride: timestamp,
                 eventType: eventType,
-                eventPayload: eventPayload
+                eventPayload: eventPayload,
+                address: address
             )
             // Notify the sync plugin so it can trigger auto-sync
             if let sink = syncProvider as? LocationDataSink {

--- a/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
@@ -1183,7 +1183,7 @@ public protocol DatabaseManagerProtocol: AnyObject, Sendable {
     /**
      * Inserts a new location record into the database.
      */
-    func insertLocation(uuid: String?, lat: Double, lng: Double, acc: Double, speed: Double, heading: Double, altitude: Double, isMock: Bool, isMoving: Bool, activity: String, routeContext: String?, timestampOverride: String?, eventType: String?, eventPayload: String?) throws  -> Int64
+    func insertLocation(uuid: String?, lat: Double, lng: Double, acc: Double, speed: Double, heading: Double, altitude: Double, isMock: Bool, isMoving: Bool, activity: String, routeContext: String?, timestampOverride: String?, eventType: String?, eventPayload: String?, address: String?) throws  -> Int64
     
     /**
      * Inserts a log entry into the database.
@@ -1538,7 +1538,7 @@ open func insertGeofence(identifier: String, lat: Double, lng: Double, radius: D
     /**
      * Inserts a new location record into the database.
      */
-open func insertLocation(uuid: String?, lat: Double, lng: Double, acc: Double, speed: Double, heading: Double, altitude: Double, isMock: Bool, isMoving: Bool, activity: String, routeContext: String?, timestampOverride: String?, eventType: String?, eventPayload: String?)throws  -> Int64  {
+open func insertLocation(uuid: String?, lat: Double, lng: Double, acc: Double, speed: Double, heading: Double, altitude: Double, isMock: Bool, isMoving: Bool, activity: String, routeContext: String?, timestampOverride: String?, eventType: String?, eventPayload: String?, address: String?)throws  -> Int64  {
     return try  FfiConverterInt64.lift(try rustCallWithError(FfiConverterTypeTraceletError_lift) {
     uniffi_tracelet_core_fn_method_databasemanager_insert_location(
             self.uniffiCloneHandle(),
@@ -1555,7 +1555,8 @@ open func insertLocation(uuid: String?, lat: Double, lng: Double, acc: Double, s
         FfiConverterOptionString.lower(routeContext),
         FfiConverterOptionString.lower(timestampOverride),
         FfiConverterOptionString.lower(eventType),
-        FfiConverterOptionString.lower(eventPayload),$0
+        FfiConverterOptionString.lower(eventPayload),
+        FfiConverterOptionString.lower(address),$0
     )
 })
 }
@@ -5023,6 +5024,12 @@ public struct DbLocationRecord: Equatable, Hashable {
      * and action). `None` for plain location records.
      */
     public var eventPayload: String?
+    /**
+     * Optional reverse-geocoded address as a JSON object string (e.g.
+     * `{"street":..,"city":..,"state":..,"postalCode":..,"country":..}`).
+     * Populated when `resolveAddress` is enabled (#187). `None` otherwise.
+     */
+    public var address: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -5033,7 +5040,12 @@ public struct DbLocationRecord: Equatable, Hashable {
         /**
          * Optional JSON payload with event-specific data (e.g. geofence identifier
          * and action). `None` for plain location records.
-         */eventPayload: String?) {
+         */eventPayload: String?, 
+        /**
+         * Optional reverse-geocoded address as a JSON object string (e.g.
+         * `{"street":..,"city":..,"state":..,"postalCode":..,"country":..}`).
+         * Populated when `resolveAddress` is enabled (#187). `None` otherwise.
+         */address: String?) {
         self.id = id
         self.uuid = uuid
         self.timestamp = timestamp
@@ -5049,6 +5061,7 @@ public struct DbLocationRecord: Equatable, Hashable {
         self.routeContext = routeContext
         self.eventType = eventType
         self.eventPayload = eventPayload
+        self.address = address
     }
 
     
@@ -5081,7 +5094,8 @@ public struct FfiConverterTypeDbLocationRecord: FfiConverterRustBuffer {
                 activity: FfiConverterString.read(from: &buf), 
                 routeContext: FfiConverterOptionString.read(from: &buf), 
                 eventType: FfiConverterString.read(from: &buf), 
-                eventPayload: FfiConverterOptionString.read(from: &buf)
+                eventPayload: FfiConverterOptionString.read(from: &buf), 
+                address: FfiConverterOptionString.read(from: &buf)
         )
     }
 
@@ -5101,6 +5115,7 @@ public struct FfiConverterTypeDbLocationRecord: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.routeContext, into: &buf)
         FfiConverterString.write(value.eventType, into: &buf)
         FfiConverterOptionString.write(value.eventPayload, into: &buf)
+        FfiConverterOptionString.write(value.address, into: &buf)
     }
 }
 
@@ -9333,7 +9348,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_tracelet_core_checksum_method_databasemanager_insert_geofence() != 35448) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_tracelet_core_checksum_method_databasemanager_insert_location() != 14450) {
+    if (uniffi_tracelet_core_checksum_method_databasemanager_insert_location() != 41177) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_method_databasemanager_insert_log() != 43891) {

--- a/sdk/ios/Sources/TraceletSDK/tracelet_coreFFI.h
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_coreFFI.h
@@ -658,7 +658,7 @@ void uniffi_tracelet_core_fn_method_databasemanager_insert_geofence(uint64_t ptr
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_TRACELET_CORE_FN_METHOD_DATABASEMANAGER_INSERT_LOCATION
 #define UNIFFI_FFIDEF_UNIFFI_TRACELET_CORE_FN_METHOD_DATABASEMANAGER_INSERT_LOCATION
-int64_t uniffi_tracelet_core_fn_method_databasemanager_insert_location(uint64_t ptr, RustBuffer uuid, double lat, double lng, double acc, double speed, double heading, double altitude, int8_t is_mock, int8_t is_moving, RustBuffer activity, RustBuffer route_context, RustBuffer timestamp_override, RustBuffer event_type, RustBuffer event_payload, RustCallStatus *_Nonnull out_status
+int64_t uniffi_tracelet_core_fn_method_databasemanager_insert_location(uint64_t ptr, RustBuffer uuid, double lat, double lng, double acc, double speed, double heading, double altitude, int8_t is_mock, int8_t is_moving, RustBuffer activity, RustBuffer route_context, RustBuffer timestamp_override, RustBuffer event_type, RustBuffer event_payload, RustBuffer address, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_TRACELET_CORE_FN_METHOD_DATABASEMANAGER_INSERT_LOG

--- a/sdk/rust-core/core/src/database/mod.rs
+++ b/sdk/rust-core/core/src/database/mod.rs
@@ -51,6 +51,10 @@ pub struct DbLocationRecord {
     /// Optional JSON payload with event-specific data (e.g. geofence identifier
     /// and action). `None` for plain location records.
     pub event_payload: Option<String>,
+    /// Optional reverse-geocoded address as a JSON object string (e.g.
+    /// `{"street":..,"city":..,"state":..,"postalCode":..,"country":..}`).
+    /// Populated when `resolveAddress` is enabled (#187). `None` otherwise.
+    pub address: Option<String>,
 }
 
 #[derive(Debug, Clone, uniffi::Record)]
@@ -114,7 +118,8 @@ impl DatabaseManager {
                 activity TEXT NOT NULL,
                 encrypted_payload BLOB,
                 route_context TEXT,
-                timestamp_ms INTEGER DEFAULT 0
+                timestamp_ms INTEGER DEFAULT 0,
+                address TEXT
             )",
             [],
         ).map_err(|e| TraceletError::Database(e.to_string()))?;
@@ -219,6 +224,9 @@ impl DatabaseManager {
         // offline queue and surfaced to sync builders tagged by type.
         let _ = conn.execute("ALTER TABLE location_events ADD COLUMN event_type TEXT DEFAULT 'location'", []);
         let _ = conn.execute("ALTER TABLE location_events ADD COLUMN event_payload TEXT", []);
+        // #187: persist reverse-geocoded address (JSON) so it survives into the
+        // DB-sourced sync payload, not just the live onLocation event.
+        let _ = conn.execute("ALTER TABLE location_events ADD COLUMN address TEXT", []);
 
         Ok(Self {
             conn: Mutex::new(conn),
@@ -283,7 +291,7 @@ impl DatabaseManager {
     }
 
     /// Inserts a new location record into the database.
-    pub fn insert_location(&self, uuid: Option<String>, lat: f64, lng: f64, acc: f64, speed: f64, heading: f64, altitude: f64, is_mock: bool, is_moving: bool, activity: &str, route_context: Option<String>, timestamp_override: Option<String>, event_type: Option<String>, event_payload: Option<String>) -> Result<i64, TraceletError> {
+    pub fn insert_location(&self, uuid: Option<String>, lat: f64, lng: f64, acc: f64, speed: f64, heading: f64, altitude: f64, is_mock: bool, is_moving: bool, activity: &str, route_context: Option<String>, timestamp_override: Option<String>, event_type: Option<String>, event_payload: Option<String>, address: Option<String>) -> Result<i64, TraceletError> {
         let conn = self.conn.lock().unwrap();
 
         let (timestamp, timestamp_ms) = if let Some(override_ts) = timestamp_override {
@@ -314,12 +322,15 @@ impl DatabaseManager {
                 "is_mock": is_mock,
                 "is_moving": is_moving,
                 "activity": activity,
-                "route_context": route_context
+                "route_context": route_context,
+                "address": address
             });
             if let Some(payload) = self.encrypt_payload(record.to_string().as_bytes()) {
+                // address is coordinate-level PII — under encryption it lives only
+                // inside the encrypted payload, so the plaintext column stays NULL.
                 conn.execute(
-                    "INSERT INTO location_events (uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, timestamp_ms, event_type, event_payload)
-                     VALUES (?1, ?2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, '', ?3, ?4, ?5, ?6, ?7)",
+                    "INSERT INTO location_events (uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, timestamp_ms, event_type, event_payload, address)
+                     VALUES (?1, ?2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, '', ?3, ?4, ?5, ?6, ?7, NULL)",
                     params![uuid, timestamp, payload, route_context, timestamp_ms, event_type, event_payload],
                 ).map_err(|e| TraceletError::Database(e.to_string()))?;
                 return Ok(conn.last_insert_rowid());
@@ -328,9 +339,9 @@ impl DatabaseManager {
 
         // Fallback or unencrypted
         conn.execute(
-            "INSERT INTO location_events (uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, timestamp_ms, event_type, event_payload)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL, ?12, ?13, ?14, ?15)",
-            params![uuid, timestamp, lat, lng, acc, speed, heading, altitude, if is_mock { 1 } else { 0 }, if is_moving { 1 } else { 0 }, activity, route_context, timestamp_ms, event_type, event_payload],
+            "INSERT INTO location_events (uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, timestamp_ms, event_type, event_payload, address)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL, ?12, ?13, ?14, ?15, ?16)",
+            params![uuid, timestamp, lat, lng, acc, speed, heading, altitude, if is_mock { 1 } else { 0 }, if is_moving { 1 } else { 0 }, activity, route_context, timestamp_ms, event_type, event_payload, address],
         ).map_err(|e| TraceletError::Database(e.to_string()))?;
 
         Ok(conn.last_insert_rowid())
@@ -341,7 +352,7 @@ impl DatabaseManager {
         use rusqlite::types::Value;
         let conn = self.conn.lock().unwrap();
         
-        let mut sql = "SELECT id, uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, event_type, event_payload FROM location_events WHERE 1=1".to_string();
+        let mut sql = "SELECT id, uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, event_type, event_payload, address FROM location_events WHERE 1=1".to_string();
         let mut params: Vec<Value> = Vec::new();
         
         // No limit specified → return ALL matching rows (-1 = no LIMIT, handled
@@ -399,6 +410,7 @@ impl DatabaseManager {
             let mut route_context: Option<String> = row.get(13).unwrap_or(None);
             let event_type: String = row.get::<_, Option<String>>(14).unwrap_or(None).unwrap_or_else(|| "location".to_string());
             let event_payload: Option<String> = row.get(15).unwrap_or(None);
+            let mut address: Option<String> = row.get(16).unwrap_or(None);
 
             if let Some(payload_bytes) = encrypted_payload {
                 if let Some(plaintext) = self.decrypt_payload(&payload_bytes) {
@@ -413,10 +425,12 @@ impl DatabaseManager {
                         if let Some(is_moving) = json.get("is_moving").and_then(|v| v.as_bool()) { is_moving_val = if is_moving { 1 } else { 0 }; }
                         if let Some(activity) = json.get("activity").and_then(|v| v.as_str()) { activity_val = activity.to_string(); }
                         if let Some(rc) = json.get("route_context").and_then(|v| v.as_str()) { route_context = Some(rc.to_string()); }
+                        // address lives in the encrypted payload (PII); plaintext column is NULL.
+                        if let Some(a) = json.get("address").and_then(|v| v.as_str()) { address = Some(a.to_string()); }
                     }
                 }
             }
-            
+
             Ok(DbLocationRecord {
                 id: row.get(0)?,
                 uuid: row.get(1).unwrap_or(None),
@@ -433,6 +447,7 @@ impl DatabaseManager {
                 route_context,
                 event_type,
                 event_payload,
+                address,
             })
         }).map_err(|e| TraceletError::Database(e.to_string()))?;
 
@@ -464,7 +479,7 @@ impl DatabaseManager {
     /// Gets the total count of locations persisted in the database.
     pub fn get_location_for_audit(&self, uuid: &str) -> Result<Option<DbLocationRecord>, TraceletError> {
         let conn = self.conn.lock().unwrap();
-        let sql = "SELECT id, uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, event_type, event_payload FROM location_events WHERE uuid = ?1 LIMIT 1";
+        let sql = "SELECT id, uuid, timestamp, latitude, longitude, accuracy, speed, heading, altitude, is_mock, is_moving, activity, encrypted_payload, route_context, event_type, event_payload, address FROM location_events WHERE uuid = ?1 LIMIT 1";
         
         let mut stmt = conn.prepare(sql).map_err(|e| TraceletError::Database(e.to_string()))?;
         
@@ -483,6 +498,7 @@ impl DatabaseManager {
             let mut route_context: Option<String> = row.get(13).unwrap_or(None);
             let event_type: String = row.get::<_, Option<String>>(14).unwrap_or(None).unwrap_or_else(|| "location".to_string());
             let event_payload: Option<String> = row.get(15).unwrap_or(None);
+            let mut address: Option<String> = row.get(16).unwrap_or(None);
 
             if let Some(payload_bytes) = encrypted_payload {
                 if let Some(plaintext) = self.decrypt_payload(&payload_bytes) {
@@ -497,6 +513,7 @@ impl DatabaseManager {
                         if let Some(is_moving) = json.get("is_moving").and_then(|v| v.as_bool()) { is_moving_val = if is_moving { 1 } else { 0 }; }
                         if let Some(activity) = json.get("activity").and_then(|v| v.as_str()) { activity_val = activity.to_string(); }
                         if let Some(rc) = json.get("route_context").and_then(|v| v.as_str()) { route_context = Some(rc.to_string()); }
+                        if let Some(a) = json.get("address").and_then(|v| v.as_str()) { address = Some(a.to_string()); }
                     }
                 }
             }
@@ -517,6 +534,7 @@ impl DatabaseManager {
                 route_context,
                 event_type,
                 event_payload,
+                address,
             })
         }).map_err(|e| TraceletError::Database(e.to_string()))?;
 
@@ -880,7 +898,7 @@ mod tests {
         // Ensure no key is set
         db.set_encryption_key("");
         
-        db.insert_location(None, 37.7749, -122.4194, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
+        db.insert_location(None, 37.7749, -122.4194, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
         
         let locations = db.get_locations_batch(None).unwrap();
         assert_eq!(locations.len(), 1);
@@ -898,7 +916,7 @@ mod tests {
         let test_key = "my_super_secret_encryption_key_!";
         db.set_encryption_key(test_key);
         
-        db.insert_location(None, 40.7128, -74.0060, 5.0, 0.0, 0.0, 10.0, true, true, "running", None, None, None, None).unwrap();
+        db.insert_location(None, 40.7128, -74.0060, 5.0, 0.0, 0.0, 10.0, true, true, "running", None, None, None, None, None).unwrap();
         
         let locations = db.get_locations_batch(None).unwrap();
         assert_eq!(locations.len(), 1);
@@ -915,12 +933,12 @@ mod tests {
         
         // Insert unencrypted
         db.set_encryption_key("");
-        db.insert_location(None, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, false, false, "unencrypted", None, None, None, None).unwrap();
+        db.insert_location(None, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, false, false, "unencrypted", None, None, None, None, None).unwrap();
         
         // Turn encryption ON
         let test_key = "another_secret_key_1234567890!!!";
         db.set_encryption_key(test_key);
-        db.insert_location(None, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, false, false, "encrypted", None, None, None, None).unwrap();
+        db.insert_location(None, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, false, false, "encrypted", None, None, None, None, None).unwrap();
         
         let locations = db.get_locations_batch(Some(LocationQuery {
             start_time_ms: None,
@@ -1082,8 +1100,8 @@ mod tests {
     #[test]
     fn test_insert_location_returns_id() {
         let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
-        let id1 = db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
-        let id2 = db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
+        let id1 = db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
+        let id2 = db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
         assert_eq!(id1, 1);
         assert_eq!(id2, 2);
     }
@@ -1097,9 +1115,9 @@ mod tests {
         let t2 = chrono::Utc.timestamp_millis_opt(1704106800000).unwrap().to_rfc3339();
         let t3 = chrono::Utc.timestamp_millis_opt(1704110400000).unwrap().to_rfc3339();
         
-        db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, Some(t1.clone()), None, None).unwrap();
-        db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, Some(t2.clone()), None, None).unwrap();
-        db.insert_location(None, 3.0, 3.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, Some(t3.clone()), None, None).unwrap();
+        db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, Some(t1.clone()), None, None, None).unwrap();
+        db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, Some(t2.clone()), None, None, None).unwrap();
+        db.insert_location(None, 3.0, 3.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, Some(t3.clone()), None, None, None).unwrap();
 
         // Query between t2 and t3
         let query = LocationQuery {
@@ -1121,7 +1139,7 @@ mod tests {
         let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
         
         for i in 1..=5 {
-            db.insert_location(None, i as f64, i as f64, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
+            db.insert_location(None, i as f64, i as f64, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
         }
 
         // Test limit and offset
@@ -1158,7 +1176,7 @@ mod tests {
         // query (limit = None) and with an explicit None-limit query.
         let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
         for i in 1..=1500 {
-            db.insert_location(None, i as f64, i as f64, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
+            db.insert_location(None, i as f64, i as f64, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
         }
 
         // No query at all.
@@ -1189,8 +1207,8 @@ mod tests {
     fn test_delete_locations() {
         let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
         
-        let id1 = db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
-        db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
+        let id1 = db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
+        db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
         
         assert_eq!(db.get_locations_count().unwrap(), 2);
         
@@ -1205,9 +1223,9 @@ mod tests {
     fn test_delete_synced_locations() {
         let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
         
-        db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
-        let id2 = db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
-        let id3 = db.insert_location(None, 3.0, 3.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None).unwrap();
+        db.insert_location(None, 1.0, 1.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
+        let id2 = db.insert_location(None, 2.0, 2.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
+        let id3 = db.insert_location(None, 3.0, 3.0, 10.0, 1.5, 90.0, 15.0, false, false, "walking", None, None, None, None, None).unwrap();
         
         assert_eq!(db.get_locations_count().unwrap(), 3);
         
@@ -1224,7 +1242,7 @@ mod tests {
         let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
         let payload = r#"{"identifier":"home","action":"ENTER"}"#.to_string();
         db.insert_location(Some("gf-1".into()), 1.0, 2.0, 10.0, 0.0, 0.0, 0.0, false, false, "still",
-                           None, None, Some("geofence".into()), Some(payload.clone())).unwrap();
+                           None, None, Some("geofence".into()), Some(payload.clone()), None).unwrap();
         let rows = db.get_locations_batch(None).unwrap();
         let gf = rows.iter().find(|r| r.uuid.as_deref() == Some("gf-1")).expect("row");
         assert_eq!(gf.event_type, "geofence");
@@ -1232,9 +1250,45 @@ mod tests {
 
         // A default location insert still reads back as 'location'.
         db.insert_location(Some("loc-1".into()), 1.0, 2.0, 5.0, 0.0, 0.0, 0.0, false, true, "walking",
-                           None, None, None, None).unwrap();
+                           None, None, None, None, None).unwrap();
         let loc = db.get_locations_batch(None).unwrap();
         let l = loc.iter().find(|r| r.uuid.as_deref() == Some("loc-1")).unwrap();
         assert_eq!(l.event_type, "location");
+    }
+
+    #[test]
+    fn test_address_round_trips_through_insert_and_read() {
+        // #187: a resolved address must survive persistence into the DB-sourced
+        // sync payload, not just the live onLocation event.
+        let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
+        let address = "{\"city\":\"Palakkad\",\"state\":\"Kerala\",\"country\":\"India\"}";
+        db.insert_location(Some("addr-1".into()), 10.78, 76.68, 20.0, 0.1, 0.0, 11.0,
+            false, false, "unknown", None, None, None, None, Some(address.to_string())).unwrap();
+
+        let rows = db.get_locations_batch(None).unwrap();
+        let r = rows.iter().find(|r| r.uuid.as_deref() == Some("addr-1")).expect("row");
+        assert_eq!(r.address.as_deref(), Some(address), "address must round-trip");
+
+        // A location inserted without an address reads back as None.
+        db.insert_location(Some("addr-2".into()), 10.78, 76.68, 20.0, 0.1, 0.0, 11.0,
+            false, false, "unknown", None, None, None, None, None).unwrap();
+        let r2 = db.get_locations_batch(None).unwrap();
+        let l2 = r2.iter().find(|r| r.uuid.as_deref() == Some("addr-2")).unwrap();
+        assert_eq!(l2.address, None, "no address → None");
+    }
+
+    #[test]
+    fn test_address_round_trips_under_encryption() {
+        // Under encryption the address lives in the encrypted payload (PII), and
+        // must still decrypt back on read.
+        let db = DatabaseManager::new(":memory:").expect("Failed to create in-memory db");
+        db.set_encryption_key("test-key-187");
+        let address = "{\"city\":\"Palakkad\"}";
+        db.insert_location(Some("enc-addr".into()), 10.78, 76.68, 20.0, 0.0, 0.0, 0.0,
+            false, false, "unknown", None, None, None, None, Some(address.to_string())).unwrap();
+
+        let rows = db.get_locations_batch(None).unwrap();
+        let r = rows.iter().find(|r| r.uuid.as_deref() == Some("enc-addr")).expect("row");
+        assert_eq!(r.address.as_deref(), Some(address), "encrypted address must round-trip");
     }
 }

--- a/sdk/rust-core/core/src/event_dispatcher/mod.rs
+++ b/sdk/rust-core/core/src/event_dispatcher/mod.rs
@@ -31,7 +31,7 @@ impl EventDispatcher {
         let route_context = self.state.get_route_context();
 
         // 2. Persist to Database
-        if let Err(e) = self.db.insert_location(uuid, lat, lng, accuracy, speed, heading, altitude, is_mock, is_moving, &activity, route_context, timestamp, None, None) {
+        if let Err(e) = self.db.insert_location(uuid, lat, lng, accuracy, speed, heading, altitude, is_mock, is_moving, &activity, route_context, timestamp, None, None, None) {
             crate::logger::error(&format!("[Rust Core] ❌ Failed to insert location into database: {}", e));
             return false;
         }


### PR DESCRIPTION
## Problem (#187)
With `resolveAddress: true`, the SDK reverse-geocodes and *logs* the address, but it never appears in the location payload delivered to `requestSyncBody` or the HTTP body.

## Root cause (both platforms — shared Rust DB)
The address was attached to the in-memory enriched map (Android `mutableEnriched["address"]`, iOS `finalMap["address"]`), so it reached the **live `onLocation`** event (Pigeon `TlLocation.address`). But it was **dropped at the DB layer**:
- `insert_location(...)` had no address parameter.
- `location_events` had no address column; `DbLocationRecord` had no address field.

The sync payload (`requestSyncBody` + HTTP) is built from the DB, so the address never made it through.

## Fix — dedicated `address` column (mirrors `route_context`)
- **Rust** (`database/mod.rs`): `address TEXT` column + additive migration; `insert_location` takes `address: Option<String>`; stored as a plaintext column when unencrypted, or **inside the encrypted payload (PII-safe)** under encryption; read back in `get_locations_batch` + `get_location_for_audit`; added to `DbLocationRecord`. Raw-location persist in `event_dispatcher` passes `None`.
- **Android & iOS**: extract `address` (JSON) in the `insertLocation` persist path and thread it through; `LocationMapper.buildLocationMap` re-nests it as `address` so `getLocations()` and the sync payload carry the **same nested shape** as the live event.
- uniffi bindings regenerated for both platforms.

## Tests / verification
- Rust: `test_address_round_trips_through_insert_and_read` (plaintext + absent→None) and `test_address_round_trips_under_encryption`.
- `cargo test` 59 + 3 pass; Android SDK unit tests + example APK build; **iOS SDK BUILD SUCCEEDED**.

## Notes
- Migration is additive (`ALTER TABLE … ADD COLUMN address TEXT`) — safe for existing DBs; old rows read back `address = null`.
- Stacks on #189 (unmerged) — merge that first; this branch will then show only its own diff.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
