### PR TITLE
chore(ci): dart format example/lib/main.dart (fix main CI)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -637,10 +637,7 @@ class _DashboardPageState extends State<DashboardPage>
         maxDaysToPersist: 7,
         maxRecordsToPersist: 5000,
       ),
-      logger: const tl.LoggerConfig(
-        logLevel: tl.LogLevel.verbose,
-        debug: true,
-      ),
+      logger: const tl.LoggerConfig(logLevel: tl.LogLevel.verbose, debug: true),
     );
   }
 


### PR DESCRIPTION
The **Analyze & Format** job on `main` is red after #190 merged.

`melos run format` (`dart format --set-exit-if-changed`) flagged `example/lib/main.dart`: a multi-line `LoggerConfig(...)` in the new `_buildConfig()` helper fits on one line, so the formatter rewrites it.

One-line formatting-only change — no behavior change. `dart format` now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)