### PR TITLE
chore(release): prepare for patch release 3.3.4

### DIFF
--- a/TraceletSDK.podspec
+++ b/TraceletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TraceletSDK'
-  s.version = '3.3.3'
+  s.version = '3.3.4'
   s.summary          = 'Production-grade background geolocation SDK for iOS.'
   s.description      = <<-DESC
     TraceletSDK provides battery-conscious background geolocation with motion detection,

--- a/bump_version.py
+++ b/bump_version.py
@@ -1,0 +1,113 @@
+import os
+
+version_from = "3.3.3"
+version_to = "3.3.4"
+
+# 1. Bump version strings
+exact_replacements = [
+    ('sdk/android/gradle.properties', f'SDK_VERSION={version_from}', f'SDK_VERSION={version_to}'),
+    ('TraceletSDK.podspec', f"s.version = '{version_from}'", f"s.version = '{version_to}'"),
+    ('sdk/ios/TraceletSDK.podspec', f"s.version = '{version_from}'", f"s.version = '{version_to}'"),
+    ('packages/tracelet_platform_interface/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_android/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_ios/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_web/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_sync/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_supabase/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_firebase/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    ('packages/tracelet_doctor/pubspec.yaml', f'version: {version_from}', f'version: {version_to}'),
+    
+    ('packages/tracelet_android/pubspec.yaml', f'tracelet_platform_interface: ^{version_from}', f'tracelet_platform_interface: ^{version_to}'),
+    ('packages/tracelet_ios/pubspec.yaml', f'tracelet_platform_interface: ^{version_from}', f'tracelet_platform_interface: ^{version_to}'),
+    ('packages/tracelet_web/pubspec.yaml', f'tracelet_platform_interface: ^{version_from}', f'tracelet_platform_interface: ^{version_to}'),
+    
+    ('packages/tracelet/pubspec.yaml', f'tracelet_platform_interface: ^{version_from}', f'tracelet_platform_interface: ^{version_to}'),
+    ('packages/tracelet/pubspec.yaml', f'tracelet_android: ^{version_from}', f'tracelet_android: ^{version_to}'),
+    ('packages/tracelet/pubspec.yaml', f'tracelet_ios: ^{version_from}', f'tracelet_ios: ^{version_to}'),
+    ('packages/tracelet/pubspec.yaml', f'tracelet_web: ^{version_from}', f'tracelet_web: ^{version_to}'),
+    
+    ('packages/tracelet_sync/pubspec.yaml', f'tracelet: ^{version_from}', f'tracelet: ^{version_to}'),
+    
+    ('packages/tracelet_supabase/pubspec.yaml', f'tracelet: ^{version_from}', f'tracelet: ^{version_to}'),
+    ('packages/tracelet_supabase/pubspec.yaml', f'tracelet_sync: ^{version_from}', f'tracelet_sync: ^{version_to}'),
+    
+    ('packages/tracelet_firebase/pubspec.yaml', f'tracelet: ^{version_from}', f'tracelet: ^{version_to}'),
+    ('packages/tracelet_firebase/pubspec.yaml', f'tracelet_sync: ^{version_from}', f'tracelet_sync: ^{version_to}'),
+    
+    ('packages/tracelet_doctor/pubspec.yaml', f'tracelet: ^{version_from}', f'tracelet: ^{version_to}'),
+    
+    ('packages/tracelet_android/android/build.gradle', f'implementation("com.ikolvi:tracelet-sdk:{version_from}")', f'implementation("com.ikolvi:tracelet-sdk:{version_to}")'),
+    ('packages/tracelet_android/android/build.gradle', f'api("com.ikolvi:tracelet-sdk:{version_from}")', f'api("com.ikolvi:tracelet-sdk:{version_to}")'),
+    
+    ('packages/tracelet_ios/ios/tracelet_ios.podspec', f"s.version = '{version_from}'", f"s.version = '{version_to}'"),
+    ('packages/tracelet_ios/ios/tracelet_ios.podspec', f"s.dependency 'TraceletSDK', '{version_from}'", f"s.dependency 'TraceletSDK', '{version_to}'"),
+    
+    ('packages/tracelet_sync/android/build.gradle.kts', f'compileOnly("com.ikolvi:tracelet-sdk:{version_from}")', f'compileOnly("com.ikolvi:tracelet-sdk:{version_to}")'),
+    ('packages/tracelet_sync/android/build.gradle.kts', f'implementation("com.ikolvi:tracelet-sync-sdk:{version_from}")', f'implementation("com.ikolvi:tracelet-sync-sdk:{version_to}")'),
+    
+    ('packages/tracelet_sync/ios/tracelet_sync.podspec', f"s.version = '{version_from}'", f"s.version = '{version_to}'"),
+    ('packages/tracelet_sync/ios/tracelet_sync.podspec', f"s.dependency 'TraceletSDK', '{version_from}'", f"s.dependency 'TraceletSDK', '{version_to}'"),
+]
+
+for file_path, old_str, new_str in exact_replacements:
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as f:
+            content = f.read()
+        if old_str in content:
+            content = content.replace(old_str, new_str)
+            with open(file_path, 'w') as f:
+                f.write(content)
+            print(f"Updated {file_path}")
+        else:
+            print(f"Warning: '{old_str}' not found in {file_path}")
+    else:
+        print(f"Warning: File {file_path} does not exist.")
+
+# 2. Update Changelogs
+changelogs = [
+    'sdk/android/CHANGELOG.md',
+    'sdk/ios/CHANGELOG.md',
+    'packages/tracelet_android/CHANGELOG.md',
+    'packages/tracelet_ios/CHANGELOG.md',
+    'packages/tracelet/CHANGELOG.md',
+]
+generic_changelogs = [
+    'packages/tracelet_platform_interface/CHANGELOG.md',
+    'packages/tracelet_web/CHANGELOG.md',
+    'packages/tracelet_sync/CHANGELOG.md',
+    'packages/tracelet_supabase/CHANGELOG.md',
+    'packages/tracelet_firebase/CHANGELOG.md',
+    'packages/tracelet_doctor/CHANGELOG.md',
+]
+
+changelog_addition = f"""## {version_to}
+
+**FIX**: resolve battery and extras DB persistence (#175)
+
+"""
+generic_addition = f"""## {version_to}
+
+**CHORE**: bump version.
+
+"""
+
+for cl in changelogs:
+    if os.path.exists(cl):
+        with open(cl, 'r') as f:
+            content = f.read()
+        if f"## {version_to}" not in content:
+            content = changelog_addition + content
+            with open(cl, 'w') as f:
+                f.write(content)
+            print(f"Added entry to {cl}")
+
+for cl in generic_changelogs:
+    if os.path.exists(cl):
+        with open(cl, 'r') as f:
+            content = f.read()
+        if f"## {version_to}" not in content:
+            content = generic_addition + content
+            with open(cl, 'w') as f:
+                f.write(content)
+            print(f"Added entry to {cl}")

--- a/packages/tracelet/CHANGELOG.md
+++ b/packages/tracelet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**FIX**: resolve battery and extras DB persistence (#175)
+
 ## 3.3.3
 
  - **FIX**(android): deliver headless geofence events after reboot in high-accuracy mode ([#185](https://github.com/Ikolvi/Tracelet/issues/185)). ([b197dc5f](https://github.com/Ikolvi/Tracelet/commit/b197dc5f0e4b5f081590e806b27a6eb52a4ed253))

--- a/packages/tracelet/pubspec.yaml
+++ b/packages/tracelet/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Production-grade background geolocation for Flutter. Battery-conscious
   tracking, geofencing, SQLite persistence, HTTP sync, and headless
   execution for iOS & Android.
-version: 3.3.3
+version: 3.3.4
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -30,10 +30,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.3.3
-  tracelet_android: ^3.3.3
-  tracelet_ios: ^3.3.3
-  tracelet_web: ^3.3.3
+  tracelet_platform_interface: ^3.3.4
+  tracelet_android: ^3.3.4
+  tracelet_ios: ^3.3.4
+  tracelet_web: ^3.3.4
   collection: ^1.19.1
   meta: ^1.18.0
 

--- a/packages/tracelet_android/CHANGELOG.md
+++ b/packages/tracelet_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**FIX**: resolve battery and extras DB persistence (#175)
+
 ## 3.3.3
 
  - **FIX**(android): deliver headless geofence events after reboot in high-accuracy mode ([#185](https://github.com/Ikolvi/Tracelet/issues/185)). ([b197dc5f](https://github.com/Ikolvi/Tracelet/commit/b197dc5f0e4b5f081590e806b27a6eb52a4ed253))

--- a/packages/tracelet_android/android/build.gradle
+++ b/packages/tracelet_android/android/build.gradle
@@ -48,7 +48,7 @@ android {
         // Tracelet SDK — standalone geolocation engine
         // Resolved from Maven Central when published, substituted with local
         // module via includeBuild during development.
-        api("com.ikolvi:tracelet-sdk:3.3.3")
+        api("com.ikolvi:tracelet-sdk:3.3.4")
 
         // Testing
         // Real org.json so ConfigManager's JSON persistence works under unit

--- a/packages/tracelet_android/pubspec.yaml
+++ b/packages/tracelet_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_android
 description: Android implementation of the Tracelet background geolocation plugin.
-version: 3.3.3
+version: 3.3.4
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.3.3
+  tracelet_platform_interface: ^3.3.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_doctor/CHANGELOG.md
+++ b/packages/tracelet_doctor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**CHORE**: bump version.
+
 ## 3.3.3
 
  - Update a dependency to the latest release.

--- a/packages/tracelet_doctor/pubspec.yaml
+++ b/packages/tracelet_doctor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Drop-in diagnostic overlay widget for Tracelet. Visualizes permissions,
   battery health, OEM compatibility, sensor availability, and tracking
   state with actionable fix suggestions.
-version: 3.3.3
+version: 3.3.4
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -29,7 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.3.3
+  tracelet: ^3.3.4
   share_plus: ^13.1.0
 
 dev_dependencies:

--- a/packages/tracelet_firebase/CHANGELOG.md
+++ b/packages/tracelet_firebase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**CHORE**: bump version.
+
 ## 3.3.3
 
  - Update a dependency to the latest release.

--- a/packages/tracelet_firebase/pubspec.yaml
+++ b/packages/tracelet_firebase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_firebase
 description: >-
   Firebase adapter for Tracelet. Automatically configures native HTTP sync to push locations directly to the Firebase RTDB and manages background auth token refresh.
-version: 3.3.3
+version: 3.3.4
 topics:
   - firebase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.3.3
-  tracelet_sync: ^3.3.3
+  tracelet: ^3.3.4
+  tracelet_sync: ^3.3.4
   firebase_auth: ^6.5.2
   firebase_core: ^4.10.0
 

--- a/packages/tracelet_ios/CHANGELOG.md
+++ b/packages/tracelet_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**FIX**: resolve battery and extras DB persistence (#175)
+
 ## 3.3.3
 
  - **FIX**(android): deliver headless geofence events after reboot in high-accuracy mode ([#185](https://github.com/Ikolvi/Tracelet/issues/185)). ([b197dc5f](https://github.com/Ikolvi/Tracelet/commit/b197dc5f0e4b5f081590e806b27a6eb52a4ed253))

--- a/packages/tracelet_ios/ios/tracelet_ios.podspec
+++ b/packages/tracelet_ios/ios/tracelet_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tracelet_ios'
-  s.version = '3.3.3'
+  s.version = '3.3.4'
   s.summary          = 'iOS implementation of the Tracelet background geolocation plugin.'
   s.description      = <<-DESC
 Production-grade background geolocation for Flutter. Battery-conscious
@@ -18,7 +18,7 @@ execution for iOS.
   s.source_files = 'tracelet_ios/Sources/tracelet_ios/**/*.{swift,h}'
   s.public_header_files = 'tracelet_ios/Sources/tracelet_ios/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TraceletSDK', '3.3.3'
+  s.dependency 'TraceletSDK', '3.3.4'
   s.platform = :ios, '14.0'
   s.frameworks = 'CoreLocation', 'CoreMotion', 'UIKit', 'BackgroundTasks', 'AVFoundation', 'AudioToolbox', 'Network', 'DeviceCheck'
   s.libraries = 'sqlite3'

--- a/packages/tracelet_ios/pubspec.yaml
+++ b/packages/tracelet_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_ios
 description: iOS implementation of the Tracelet background geolocation plugin.
-version: 3.3.3
+version: 3.3.4
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.3.3
+  tracelet_platform_interface: ^3.3.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_platform_interface/CHANGELOG.md
+++ b/packages/tracelet_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**CHORE**: bump version.
+
 ## 3.3.3
 
  - **FIX**: Correct the pigeon mock stub for `TlGeofenceConfig` to accommodate removed fields and update config tests. ([065b3bbc](https://github.com/Ikolvi/Tracelet/commit/065b3bbc631a367364eba2b666c54120174530cc))

--- a/packages/tracelet_platform_interface/pubspec.yaml
+++ b/packages/tracelet_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracelet_platform_interface
 description: >-
   A common platform interface for the Tracelet background geolocation plugin.
   Used by tracelet_android and tracelet_ios implementations.
-version: 3.3.3
+version: 3.3.4
 topics:
   - location
   - background

--- a/packages/tracelet_supabase/CHANGELOG.md
+++ b/packages/tracelet_supabase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**CHORE**: bump version.
+
 ## 3.3.3
 
  - Update a dependency to the latest release.

--- a/packages/tracelet_supabase/pubspec.yaml
+++ b/packages/tracelet_supabase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_supabase
 description: >-
   Supabase adapter for Tracelet. Automatically configures Tracelet's native HTTP sync to push locations to Supabase and manages background auth token refresh.
-version: 3.3.3
+version: 3.3.4
 topics:
   - supabase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.3.3
-  tracelet_sync: ^3.3.3
+  tracelet: ^3.3.4
+  tracelet_sync: ^3.3.4
   supabase_flutter: '^2.12.4'
 
   meta: ^1.18.0

--- a/packages/tracelet_sync/CHANGELOG.md
+++ b/packages/tracelet_sync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**CHORE**: bump version.
+
 ## 3.3.3
 
  - **FIX**: Centralize HTTP sync event reporting to guarantee exactly one onHttp event emission per sync attempt on all failure paths, resolving silently dropped events for custom builder timeouts and 0-count executions ([#192](https://github.com/Ikolvi/Tracelet/issues/192)). ([065b3bbc](https://github.com/Ikolvi/Tracelet/commit/065b3bbc631a367364eba2b666c54120174530cc))

--- a/packages/tracelet_sync/android/build.gradle.kts
+++ b/packages/tracelet_sync/android/build.gradle.kts
@@ -72,8 +72,8 @@ kotlin {
 }
 
 dependencies {
-    compileOnly("com.ikolvi:tracelet-sdk:3.3.3")
-    implementation("com.ikolvi:tracelet-sync-sdk:3.3.3")
+    compileOnly("com.ikolvi:tracelet-sdk:3.3.4")
+    implementation("com.ikolvi:tracelet-sync-sdk:3.3.4")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
 }

--- a/packages/tracelet_sync/ios/tracelet_sync.podspec
+++ b/packages/tracelet_sync/ios/tracelet_sync.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tracelet_sync'
-  s.version = '3.3.3'
+  s.version = '3.3.4'
   s.summary          = 'iOS implementation of the Tracelet Sync plugin.'
   s.description      = <<-DESC
 A new Flutter plugin project.
@@ -16,7 +16,7 @@ A new Flutter plugin project.
   s.source_files = 'tracelet_sync/Sources/tracelet_sync/**/*.{swift,h}'
   s.public_header_files = 'tracelet_sync/Sources/tracelet_sync/**/*.h', 'tracelet_sync/Sources/tracelet_sync/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TraceletSDK', '3.3.3'
+  s.dependency 'TraceletSDK', '3.3.4'
   s.platform = :ios, '14.0'
   s.vendored_frameworks = 'tracelet_sync/TraceletSyncFFI.xcframework'
 

--- a/packages/tracelet_sync/pubspec.yaml
+++ b/packages/tracelet_sync/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_sync
 description: Offline SQLite persistence and automatic HTTP synchronization engine for Tracelet.
-version: 3.3.3
+version: 3.3.4
 homepage: https://github.com/ikolvi/tracelet
 documentation: https://tracelet.ikolvi.com
 repository: https://github.com/ikolvi/tracelet/tree/main/packages/tracelet_sync
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.3.3
+  tracelet: ^3.3.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_web/CHANGELOG.md
+++ b/packages/tracelet_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**CHORE**: bump version.
+
 ## 3.3.3
 
  - **FIX**: Correct the `geofenceModeHighAccuracy` config mapping in Web plugin to prevent runtime getter errors. ([065b3bbc](https://github.com/Ikolvi/Tracelet/commit/065b3bbc631a367364eba2b666c54120174530cc))

--- a/packages/tracelet_web/pubspec.yaml
+++ b/packages/tracelet_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_web
 description: Web implementation of the Tracelet background geolocation plugin.
-version: 3.3.3
+version: 3.3.4
 topics:
   - location
   - background
@@ -28,7 +28,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  tracelet_platform_interface: ^3.3.3
+  tracelet_platform_interface: ^3.3.4
   web: ^1.1.1
 
 dev_dependencies:

--- a/sdk/android/CHANGELOG.md
+++ b/sdk/android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**FIX**: resolve battery and extras DB persistence (#175)
+
 ## 3.3.0
 
 * **FEAT** (Battery, Android): Motion-gated wakelock — drop the OEM partial wakelock when stationary and re-assert it on movement, via `AndroidConfig.releaseWakelockWhenStationary` (opt-in, default off; gated on the hardware significant-motion wake sensor) ([#162](https://github.com/Ikolvi/Tracelet/issues/162)).

--- a/sdk/android/gradle.properties
+++ b/sdk/android/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 kotlin.code.style=official
 # Native SDK version
-SDK_VERSION=3.3.3
+SDK_VERSION=3.3.4
 
 # ── Maven Central Publishing ─────────────────────────────────────────────────
 # Set these in ~/.gradle/gradle.properties (NOT committed to git) or as

--- a/sdk/ios/CHANGELOG.md
+++ b/sdk/ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4
+
+**FIX**: resolve battery and extras DB persistence (#175)
+
 ## 3.3.0
 
 * **FEAT**: Native runtime for the 3.3.0 behavior engines — TelematicsEngine (driving events), TransportModeClassifier (fused transport mode), and ImpactDetector (crash/fall) wired into the location + accelerometer pipeline. All opt-in / default-off. ([#163](https://github.com/Ikolvi/Tracelet/issues/163), [#164](https://github.com/Ikolvi/Tracelet/issues/164), [#165](https://github.com/Ikolvi/Tracelet/issues/165))

--- a/sdk/ios/TraceletSDK.podspec
+++ b/sdk/ios/TraceletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TraceletSDK'
-  s.version = '3.3.3'
+  s.version = '3.3.4'
   s.summary          = 'Production-grade background geolocation SDK for iOS.'
   s.homepage         = 'https://github.com/Ikolvi/Tracelet/tree/main/sdk/ios'
   s.license          = { :type => 'Apache-2.0', :file => '../../LICENSE' }


### PR DESCRIPTION
Bumps all versions to 3.3.4 across Native SDKs and Flutter packages for publishing.