### PR TITLE
test(#206): Phase 1 — completeness guards for Map↔Pigeon conversions

### DIFF
--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/LocationMappingRegressionTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/LocationMappingRegressionTest.kt
@@ -135,4 +135,34 @@ class LocationMappingRegressionTest {
         val extras = map["extras"] as? Map<String?, Any?>
         assertEquals("sos", extras?.get("alarm"), "extras must be forwarded to the SDK (#175)")
     }
+
+    /**
+     * Phase 1 (#206) completeness guard: every property of the Pigeon
+     * [TlCurrentPositionOptions] must be present in the SDK map after conversion.
+     * With all fields set to sentinels, a forgotten field in `tlOptionsToMap`
+     * (the exact #175/#201 failure mode) makes this fail automatically — and a
+     * newly-added Pigeon field that isn't mapped trips it too.
+     */
+    @Test
+    fun tlOptionsToMap_covers_every_pigeon_field() {
+        val opts = TlCurrentPositionOptions(
+            desiredAccuracy = TlDesiredAccuracy.PASSIVE,
+            timeout = 11,
+            maximumAge = 22,
+            persist = false,
+            samples = 3,
+            extras = mapOf("k" to "v"),
+        )
+        val map = tlOptionsToMap(opts)
+
+        val fields = TlCurrentPositionOptions::class.java.declaredFields
+            .map { it.name }
+            .filterNot { it.startsWith("$") || it == "Companion" || it == "CREATOR" }
+        for (field in fields) {
+            assertTrue(
+                map.containsKey(field),
+                "tlOptionsToMap dropped Pigeon field '$field' (#206) — add it to the converter",
+            )
+        }
+    }
 }

--- a/packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart
+++ b/packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart
@@ -795,6 +795,59 @@ void main() {
       },
     );
 
+    // Phase 1 (#206): completeness guards. Set every option key to a
+    // non-null sentinel and assert no field is null after conversion — a
+    // dropped/forgotten field in `_mapToOptions` surfaces as a null in
+    // `encode()` and fails the test automatically.
+    test('options conversion forwards every field (#206)', () async {
+      await pigeon.getCurrentPosition({
+        'desiredAccuracy': 4, // passive
+        'timeout': 11,
+        'maximumAge': 22,
+        'persist': false,
+        'samples': 3,
+        'extras': {'k': 'v'},
+      });
+      final opts =
+          fakeApi.lastCallArgs('getCurrentPosition')!.first!
+              as TlCurrentPositionOptions;
+      final encoded = opts.encode() as List<Object?>;
+      expect(
+        encoded.where((Object? e) => e == null),
+        isEmpty,
+        reason:
+            'A TlCurrentPositionOptions field is null after conversion — '
+            '_mapToOptions likely dropped a newly-added field (#206).',
+      );
+    });
+
+    test('geofence conversion forwards every field (#206)', () async {
+      await pigeon.addGeofence({
+        'identifier': 'g1',
+        'latitude': 1.0,
+        'longitude': 2.0,
+        'radius': 3.0,
+        'notifyOnEntry': true,
+        'notifyOnExit': true,
+        'notifyOnDwell': true,
+        'loiteringDelay': 5,
+        'extras': {'k': 'v'},
+        'vertices': [
+          [1.0, 2.0],
+        ],
+      });
+      final g =
+          fakeApi.lastCallArgs('addGeofence')!.first! as TlGeofence;
+      final encoded = g.encode() as List<Object?>;
+      expect(
+        encoded.where((Object? e) => e == null),
+        isEmpty,
+        reason:
+            'A TlGeofence field is null after conversion — _mapToGeofence '
+            'likely dropped a newly-added field (#206).',
+      );
+    });
+
     test('getLastKnownLocation() returns location map', () async {
       final loc = await pigeon.getLastKnownLocation();
       expect(loc['uuid'], 'test-uuid-123');


### PR DESCRIPTION
Auto field-count guards that fail when a conversion silently drops a field (the #175/#201 bug class):
- platform-interface: getCurrentPosition options + geofence conversions — encode() must contain no nulls after conversion.
- android: tlOptionsToMap must cover every Pigeon field (via reflection).

Refs #206