### PR TITLE
fix(android): renew foreground-service wakelock to keep continuous tr…

### DIFF
--- a/TraceletSDK.podspec
+++ b/TraceletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TraceletSDK'
-  s.version = '3.5.1'
+  s.version = '3.5.2'
   s.summary          = 'Production-grade background geolocation SDK for iOS.'
   s.description      = <<-DESC
     TraceletSDK provides battery-conscious background geolocation with motion detection,

--- a/bump_version.py
+++ b/bump_version.py
@@ -1,7 +1,7 @@
 import os
 
-version_from = "3.5.0"
-version_to = "3.5.1"
+version_from = "3.5.1"
+version_to = "3.5.2"
 
 # 1. Bump version strings
 exact_replacements = [
@@ -84,13 +84,12 @@ generic_changelogs = [
 
 changelog_addition = f"""## {version_to}
 
-**FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change, which raises crash confidence on phones that have a pressure sensor. Phones without one simply skip this check, with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).
-**DOCS**: Rewrote the Driving & Safety crash/fall confirmation section in plain, beginner-friendly language.
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
 
 """
 generic_addition = f"""## {version_to}
 
-**FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
 
 """
 

--- a/packages/tracelet/CHANGELOG.md
+++ b/packages/tracelet/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change, which raises crash confidence on phones that have a pressure sensor. Phones without one simply skip this check, with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet/pubspec.yaml
+++ b/packages/tracelet/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Production-grade background geolocation for Flutter. Battery-conscious
   tracking, geofencing, SQLite persistence, HTTP sync, and headless
   execution for iOS & Android.
-version: 3.5.1
+version: 3.5.2
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -30,10 +30,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.1
-  tracelet_android: ^3.5.1
-  tracelet_ios: ^3.5.1
-  tracelet_web: ^3.5.1
+  tracelet_platform_interface: ^3.5.2
+  tracelet_android: ^3.5.2
+  tracelet_ios: ^3.5.2
+  tracelet_web: ^3.5.2
   collection: ^1.19.1
   meta: ^1.18.0
 

--- a/packages/tracelet_android/CHANGELOG.md
+++ b/packages/tracelet_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change, which raises crash confidence on phones that have a pressure sensor. Phones without one simply skip this check, with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_android/android/build.gradle
+++ b/packages/tracelet_android/android/build.gradle
@@ -48,7 +48,7 @@ android {
         // Tracelet SDK — standalone geolocation engine
         // Resolved from Maven Central when published, substituted with local
         // module via includeBuild during development.
-        api("com.ikolvi:tracelet-sdk:3.5.1")
+        api("com.ikolvi:tracelet-sdk:3.5.2")
 
         // Testing
         // Real org.json so ConfigManager's JSON persistence works under unit

--- a/packages/tracelet_android/pubspec.yaml
+++ b/packages/tracelet_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_android
 description: Android implementation of the Tracelet background geolocation plugin.
-version: 3.5.1
+version: 3.5.2
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.1
+  tracelet_platform_interface: ^3.5.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_doctor/CHANGELOG.md
+++ b/packages/tracelet_doctor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_doctor/pubspec.yaml
+++ b/packages/tracelet_doctor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Drop-in diagnostic overlay widget for Tracelet. Visualizes permissions,
   battery health, OEM compatibility, sensor availability, and tracking
   state with actionable fix suggestions.
-version: 3.5.1
+version: 3.5.2
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -29,7 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.1
+  tracelet: ^3.5.2
   share_plus: ^13.1.0
 
 dev_dependencies:

--- a/packages/tracelet_firebase/CHANGELOG.md
+++ b/packages/tracelet_firebase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_firebase/pubspec.yaml
+++ b/packages/tracelet_firebase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_firebase
 description: >-
   Firebase adapter for Tracelet. Automatically configures native HTTP sync to push locations directly to the Firebase RTDB and manages background auth token refresh.
-version: 3.5.1
+version: 3.5.2
 topics:
   - firebase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.1
-  tracelet_sync: ^3.5.1
+  tracelet: ^3.5.2
+  tracelet_sync: ^3.5.2
   firebase_auth: ^6.5.2
   firebase_core: ^4.10.0
 
@@ -43,4 +43,4 @@ dev_dependencies:
   flutter_lints: '6.0.0'
   mocktail: ^1.0.5
   plugin_platform_interface: any
-  tracelet_platform_interface: ^3.5.1
+  tracelet_platform_interface: ^3.5.2

--- a/packages/tracelet_ios/CHANGELOG.md
+++ b/packages/tracelet_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change, which raises crash confidence on phones that have a pressure sensor. Phones without one simply skip this check, with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_ios/ios/tracelet_ios.podspec
+++ b/packages/tracelet_ios/ios/tracelet_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tracelet_ios'
-  s.version = '3.5.1'
+  s.version = '3.5.2'
   s.summary          = 'iOS implementation of the Tracelet background geolocation plugin.'
   s.description      = <<-DESC
 Production-grade background geolocation for Flutter. Battery-conscious
@@ -18,7 +18,7 @@ execution for iOS.
   s.source_files = 'tracelet_ios/Sources/tracelet_ios/**/*.{swift,h}'
   s.public_header_files = 'tracelet_ios/Sources/tracelet_ios/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TraceletSDK', '3.5.1'
+  s.dependency 'TraceletSDK', '3.5.2'
   s.platform = :ios, '14.0'
   s.frameworks = 'CoreLocation', 'CoreMotion', 'UIKit', 'BackgroundTasks', 'AVFoundation', 'AudioToolbox', 'Network', 'DeviceCheck'
   s.libraries = 'sqlite3'

--- a/packages/tracelet_ios/pubspec.yaml
+++ b/packages/tracelet_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_ios
 description: iOS implementation of the Tracelet background geolocation plugin.
-version: 3.5.1
+version: 3.5.2
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.1
+  tracelet_platform_interface: ^3.5.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_platform_interface/CHANGELOG.md
+++ b/packages/tracelet_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_platform_interface/pubspec.yaml
+++ b/packages/tracelet_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracelet_platform_interface
 description: >-
   A common platform interface for the Tracelet background geolocation plugin.
   Used by tracelet_android and tracelet_ios implementations.
-version: 3.5.1
+version: 3.5.2
 topics:
   - location
   - background

--- a/packages/tracelet_supabase/CHANGELOG.md
+++ b/packages/tracelet_supabase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_supabase/pubspec.yaml
+++ b/packages/tracelet_supabase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_supabase
 description: >-
   Supabase adapter for Tracelet. Automatically configures Tracelet's native HTTP sync to push locations to Supabase and manages background auth token refresh.
-version: 3.5.1
+version: 3.5.2
 topics:
   - supabase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.1
-  tracelet_sync: ^3.5.1
+  tracelet: ^3.5.2
+  tracelet_sync: ^3.5.2
   supabase_flutter: '^2.12.4'
 
   meta: ^1.18.0

--- a/packages/tracelet_sync/CHANGELOG.md
+++ b/packages/tracelet_sync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_sync/android/build.gradle.kts
+++ b/packages/tracelet_sync/android/build.gradle.kts
@@ -72,8 +72,8 @@ kotlin {
 }
 
 dependencies {
-    compileOnly("com.ikolvi:tracelet-sdk:3.5.1")
-    implementation("com.ikolvi:tracelet-sync-sdk:3.5.1")
+    compileOnly("com.ikolvi:tracelet-sdk:3.5.2")
+    implementation("com.ikolvi:tracelet-sync-sdk:3.5.2")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
 }

--- a/packages/tracelet_sync/ios/tracelet_sync.podspec
+++ b/packages/tracelet_sync/ios/tracelet_sync.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tracelet_sync'
-  s.version = '3.5.1'
+  s.version = '3.5.2'
   s.summary          = 'iOS implementation of the Tracelet Sync plugin.'
   s.description      = <<-DESC
 A new Flutter plugin project.
@@ -16,7 +16,7 @@ A new Flutter plugin project.
   s.source_files = 'tracelet_sync/Sources/tracelet_sync/**/*.{swift,h}'
   s.public_header_files = 'tracelet_sync/Sources/tracelet_sync/**/*.h', 'tracelet_sync/Sources/tracelet_sync/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TraceletSDK', '3.5.1'
+  s.dependency 'TraceletSDK', '3.5.2'
   s.platform = :ios, '14.0'
   s.vendored_frameworks = 'tracelet_sync/TraceletSyncFFI.xcframework'
 

--- a/packages/tracelet_sync/pubspec.yaml
+++ b/packages/tracelet_sync/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_sync
 description: Offline SQLite persistence and automatic HTTP synchronization engine for Tracelet.
-version: 3.5.1
+version: 3.5.2
 homepage: https://github.com/ikolvi/tracelet
 documentation: https://tracelet.ikolvi.com
 repository: https://github.com/ikolvi/tracelet/tree/main/packages/tracelet_sync
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.1
+  tracelet: ^3.5.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_web/CHANGELOG.md
+++ b/packages/tracelet_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change that raises crash confidence on phones with a pressure sensor; phones without one skip it with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/packages/tracelet_web/pubspec.yaml
+++ b/packages/tracelet_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_web
 description: Web implementation of the Tracelet background geolocation plugin.
-version: 3.5.1
+version: 3.5.2
 topics:
   - location
   - background
@@ -28,7 +28,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.1
+  tracelet_platform_interface: ^3.5.2
   web: ^1.1.1
 
 dev_dependencies:

--- a/sdk/android/CHANGELOG.md
+++ b/sdk/android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change, which raises crash confidence on phones that have a pressure sensor. Phones without one simply skip this check, with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/sdk/android/gradle.properties
+++ b/sdk/android/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 kotlin.code.style=official
 # Native SDK version
-SDK_VERSION=3.5.1
+SDK_VERSION=3.5.2
 
 # ── Maven Central Publishing ─────────────────────────────────────────────────
 # Set these in ~/.gradle/gradle.properties (NOT committed to git) or as

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -51,6 +51,24 @@ class LocationService : Service(), DefaultLifecycleObserver {
     companion object {
         private const val TAG = "LocationService"
         private const val NOTIFICATION_ID = 7701
+
+        /**
+         * Auto-expiry safety timeout for the OEM-safe wakelock. Comfortably
+         * exceeds [WAKELOCK_RENEWAL_INTERVAL_MS] so the lock never lapses
+         * between renewals, while still bounding a leaked lock so it eventually
+         * self-releases.
+         */
+        private const val WAKELOCK_TIMEOUT_MS = 15 * 60 * 1000L
+
+        /**
+         * How often the held wakelock is renewed so it never reaches its
+         * auto-expiry timeout while tracking is active. Must be shorter than
+         * [WAKELOCK_TIMEOUT_MS]. Without renewal the lock expired after the
+         * default 10 minutes and aggressive OEMs (Samsung One UI, etc.) let the
+         * CPU enter deep sleep, silently freezing FusedLocationProvider updates
+         * even though the foreground service was still alive (#222).
+         */
+        private const val WAKELOCK_RENEWAL_INTERVAL_MS = 10 * 60 * 1000L
         const val ACTION_START = "com.tracelet.ACTION_START"
         const val ACTION_STOP = "com.tracelet.ACTION_STOP"
         const val ACTION_UPDATE_NOTIFICATION = "com.tracelet.ACTION_UPDATE_NOTIFICATION"
@@ -420,6 +438,11 @@ class LocationService : Service(), DefaultLifecycleObserver {
     private var lastInForeground: Boolean? = null
     private var wakeLock: PowerManager.WakeLock? = null
 
+    // Renews the OEM-safe wakelock before its auto-expiry timeout so continuous
+    // tracking is never silently frozen by CPU deep-sleep on aggressive OEMs.
+    private val wakelockHandler = Handler(Looper.getMainLooper())
+    private var wakelockRenewalRunnable: Runnable? = null
+
     // Callback for notification action button taps dispatched to TraceletEventSender
     var onNotificationAction: ((String) -> Unit)? = null
 
@@ -634,11 +657,44 @@ class LocationService : Service(), DefaultLifecycleObserver {
      * aggressive OEM power managers from suspending our process.
      */
     private fun acquireOemWakelock() {
-        if (wakeLock?.isHeld == true) return
-        wakeLock = OemCompat.acquireOemSafeWakelock(applicationContext)
+        if (wakeLock?.isHeld != true) {
+            wakeLock = OemCompat.acquireOemSafeWakelock(applicationContext, WAKELOCK_TIMEOUT_MS)
+        }
+        scheduleWakelockRenewal()
+    }
+
+    /**
+     * Schedules periodic re-acquisition of the OEM-safe wakelock so its
+     * auto-expiry timeout never lapses while the foreground service is
+     * tracking. The lock keeps a finite timeout as a leak safety-net, but the
+     * renewal guarantees the CPU stays awake for the lifetime of tracking —
+     * preventing the silent location-update freeze on aggressive OEMs (#222).
+     */
+    private fun scheduleWakelockRenewal() {
+        wakelockRenewalRunnable?.let { wakelockHandler.removeCallbacks(it) }
+        val runnable = object : Runnable {
+            override fun run() {
+                // Acquire a fresh lock BEFORE releasing the old one so there is
+                // never a gap during which the CPU could be allowed to sleep.
+                try {
+                    val fresh = OemCompat.acquireOemSafeWakelock(applicationContext, WAKELOCK_TIMEOUT_MS)
+                    val previous = wakeLock
+                    wakeLock = fresh
+                    if (previous?.isHeld == true) previous.release()
+                    TraceletLog.debug("Renewed OEM wakelock")
+                } catch (e: Exception) {
+                    TraceletLog.error("Error renewing OEM wakelock: ${e.message}")
+                }
+                wakelockHandler.postDelayed(this, WAKELOCK_RENEWAL_INTERVAL_MS)
+            }
+        }
+        wakelockRenewalRunnable = runnable
+        wakelockHandler.postDelayed(runnable, WAKELOCK_RENEWAL_INTERVAL_MS)
     }
 
     private fun releaseOemWakelock() {
+        wakelockRenewalRunnable?.let { wakelockHandler.removeCallbacks(it) }
+        wakelockRenewalRunnable = null
         try {
             if (wakeLock?.isHeld == true) {
                 wakeLock?.release()

--- a/sdk/ios/CHANGELOG.md
+++ b/sdk/ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+**FIX**: Android continuous tracking no longer silently stops after a while on aggressive OEMs (Samsung One UI, etc.). The foreground-service wakelock used a fixed 10-minute auto-expiry and was never renewed, so once it lapsed the CPU could deep-sleep and FusedLocationProvider stopped delivering updates with no error or callback. The wakelock is now renewed for the lifetime of tracking ([#222](https://github.com/Ikolvi/Tracelet/issues/222)).
+
 ## 3.5.1
 
 **FEAT**: Crash detection now uses the device barometer as an extra confirmation clue — a serious crash or airbag deployment causes a quick cabin air-pressure change, which raises crash confidence on phones that have a pressure sensor. Phones without one simply skip this check, with no downside ([#173](https://github.com/Ikolvi/Tracelet/issues/173)).

--- a/sdk/ios/TraceletSDK.podspec
+++ b/sdk/ios/TraceletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TraceletSDK'
-  s.version = '3.5.1'
+  s.version = '3.5.2'
   s.summary          = 'Production-grade background geolocation SDK for iOS.'
   s.homepage         = 'https://github.com/Ikolvi/Tracelet/tree/main/sdk/ios'
   s.license          = { :type => 'Apache-2.0', :file => '../../LICENSE' }


### PR DESCRIPTION
…acking alive (#222)

Continuous tracking silently stopped after ~10-60 min on aggressive OEMs (Samsung One UI, etc.). The OEM-safe wakelock was acquired with a fixed 10-minute auto-expiry (regressed in v0.12.0, commit 79d3fbf8, which changed the default from an indefinite acquire to a 10-minute timeout) and was never renewed by LocationService. Once it lapsed, the CPU could enter deep sleep and FusedLocationProvider stopped delivering updates with no error or callback — while the foreground service stayed alive. iOS was unaffected.

LocationService now renews the wakelock every 10 minutes (acquire-fresh- before-release, so there is no sleep gap) for the lifetime of tracking, keeping a finite timeout only as a leak safety-net. Bumps to 3.5.2.

Fixes #222