### PR TITLE
fix: geofence telemetry (#231), setConfig propagation (#230), teardown crash (#227)

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -4,3 +4,7 @@ android.useAndroidX=true
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false
+# Allow slow artifact downloads (e.g. dl.google.com) to complete instead of
+# failing with a socket/connection timeout.
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000

--- a/example/lib/issues/issue_230_card.dart
+++ b/example/lib/issues/issue_230_card.dart
@@ -1,0 +1,121 @@
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #230 — runtime config changes (setConfig) did not propagate to the
+/// active native tracking/sensor loops. Only a few location keys triggered a
+/// restart, and only the LocationEngine was restarted — motion-detector /
+/// speed-manager parameter changes (e.g. switching ACCELEROMETER → SPEED) were
+/// silently ignored until the app was force-killed.
+///
+/// The fix performs a clean stop/start of the whole active pipeline when a
+/// tracking-relevant key changes. This test starts in ACCELEROMETER mode, clears
+/// the native log, switches to SPEED mode via setConfig, then inspects the log
+/// for the stop→start lifecycle that proves the pipeline was rebuilt.
+class Issue230Card extends StatefulWidget {
+  const Issue230Card({super.key});
+
+  @override
+  State<Issue230Card> createState() => _Issue230CardState();
+}
+
+class _Issue230CardState extends State<Issue230Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _test() async {
+    setState(() => _running = true);
+    try {
+      _set('Requesting permissions...');
+      final auth = await Tracelet.requestLocationAuthorization();
+      if (auth != AuthorizationStatus.always &&
+          auth != AuthorizationStatus.whenInUse) {
+        _set('❌ FAILED: location permission denied ($auth).');
+        return;
+      }
+
+      const baseConfig = Config(
+        geo: GeoConfig(
+          desiredAccuracy: DesiredAccuracy.high,
+          distanceFilter: 10,
+        ),
+        motion: MotionConfig(
+          motionDetectionMode: MotionDetectionMode.accelerometer,
+          shakeThreshold: 3.5,
+          isMoving: true,
+        ),
+        logger: LoggerConfig(debug: true, logLevel: LogLevel.verbose),
+      );
+
+      _set('Starting tracking (ACCELEROMETER mode)...');
+      await Tracelet.ready(baseConfig);
+      await Tracelet.start();
+      await Future<void>.delayed(const Duration(seconds: 1));
+
+      // Clear logs to establish a clean baseline for the setConfig assertion.
+      await Tracelet.destroyLog();
+
+      _set('Switching to SPEED mode via setConfig...');
+      final newConfig = baseConfig.copyWith(
+        motion: const MotionConfig(
+          motionDetectionMode: MotionDetectionMode.speed,
+          speedMovingThreshold: 0.8,
+          isMoving: true,
+        ),
+      );
+      await Tracelet.setConfig(newConfig);
+
+      // Give the native pipeline time to tear down and restart.
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      final logs = (await Tracelet.getLog()).toLowerCase();
+      await Tracelet.stop();
+
+      // A correct restart executes a stop→start cycle on the active loops.
+      final hasStop = logs.contains('stop') || logs.contains('destroy');
+      final hasStart =
+          logs.contains('start') || logs.contains('restarting active');
+
+      if (hasStop && hasStart) {
+        _set(
+          '✅ SUCCESS: setConfig propagated! The native pipeline performed a '
+          'stop→start restart to apply the new motion strategy.',
+        );
+      } else {
+        _set(
+          '❌ FAILED: setConfig ignored — no stop/start lifecycle in the native '
+          'log (hasStop=$hasStop, hasStart=$hasStart). Sensors are stale.',
+        );
+      }
+    } catch (e) {
+      _set('❌ FAILED: $e');
+    } finally {
+      try {
+        await Tracelet.stop();
+      } catch (_) {}
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      title: '#230: setConfig ignored by active tracking loops',
+      description:
+          'Starts in ACCELEROMETER mode, clears the native log, switches to '
+          'SPEED mode via setConfig, then asserts the native log shows a '
+          'stop→start restart of the pipeline (previously the motion sensors '
+          'kept running on stale parameters until the app was force-killed).',
+      status: _status,
+      running: _running,
+      onRun: _test,
+    );
+  }
+}

--- a/example/lib/issues/issue_231_card.dart
+++ b/example/lib/issues/issue_231_card.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #231 — geofence transition events were emitted with hardcoded zero
+/// coordinate metrics (accuracy/speed/heading/altitude) and no `battery` key,
+/// so backends received geofence crossings with no usable telemetry.
+///
+/// The fix enriches the geofence payload from the last GPS fix and attaches the
+/// current battery snapshot. This test starts high-accuracy geofencing anchored
+/// at the current location, triggers an ENTER, and asserts the event carries a
+/// real (non-zero) accuracy and a valid battery level.
+class Issue231Card extends StatefulWidget {
+  const Issue231Card({super.key});
+
+  @override
+  State<Issue231Card> createState() => _Issue231CardState();
+}
+
+class _Issue231CardState extends State<Issue231Card> {
+  static const _geofenceId = 'issue-231-here';
+
+  String _status = 'Idle';
+  bool _running = false;
+  StreamSubscription<GeofenceEvent>? _sub;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _test() async {
+    setState(() => _running = true);
+    final completer = Completer<String>();
+    try {
+      _set('Requesting permissions...');
+      final auth = await Tracelet.requestLocationAuthorization();
+      if (auth != AuthorizationStatus.always &&
+          auth != AuthorizationStatus.whenInUse) {
+        _set('❌ FAILED: location permission denied ($auth).');
+        return;
+      }
+
+      _set('Configuring high-accuracy geofencing...');
+      await Tracelet.ready(
+        const Config(
+          geo: GeoConfig(
+            // ignore: avoid_redundant_argument_values
+            desiredAccuracy: DesiredAccuracy.high,
+            distanceFilter: 0,
+          ),
+          geofence: GeofenceConfig(
+            geofenceModeHighAccuracy: true,
+            // ignore: avoid_redundant_argument_values
+            geofenceInitialTriggerEntry: true,
+          ),
+          logger: LoggerConfig(debug: true, logLevel: LogLevel.verbose),
+        ),
+      );
+
+      _set('Acquiring a GPS fix to anchor the geofence...');
+      final here = await Tracelet.getCurrentPosition(
+        desiredAccuracy: DesiredAccuracy.high,
+      );
+
+      _sub?.cancel();
+      _sub = Tracelet.onGeofence((event) {
+        if (event.identifier != _geofenceId) return;
+        final coords = event.location.coords;
+        final battery = event.location.battery;
+        if (event.action == GeofenceAction.enter) {
+          if (coords.accuracy > 0.0 && battery.level >= 0.0) {
+            if (!completer.isCompleted) {
+              completer.complete(
+                '✅ SUCCESS: enriched geofence event! '
+                'accuracy=${coords.accuracy.toStringAsFixed(1)}m, '
+                'speed=${coords.speed.toStringAsFixed(1)}m/s, '
+                'heading=${coords.heading.toStringAsFixed(0)}°, '
+                'battery=${(battery.level * 100).toStringAsFixed(0)}%.',
+              );
+            }
+          } else {
+            if (!completer.isCompleted) {
+              completer.complete(
+                '❌ FAILED: mock values — accuracy=${coords.accuracy}, '
+                'speed=${coords.speed}, battery=${battery.level}.',
+              );
+            }
+          }
+        }
+      });
+
+      _set('Registering geofence at ${here.coords.latitude.toStringAsFixed(5)}, '
+          '${here.coords.longitude.toStringAsFixed(5)}...');
+      await Tracelet.addGeofence(
+        Geofence(
+          identifier: _geofenceId,
+          latitude: here.coords.latitude,
+          longitude: here.coords.longitude,
+          radius: 200,
+        ),
+      );
+
+      await Tracelet.startGeofences();
+      _set('Waiting for ENTER event...');
+
+      final result = await completer.future.timeout(
+        const Duration(seconds: 20),
+        onTimeout: () =>
+            '❌ FAILED: timed out waiting for the geofence ENTER event.',
+      );
+      _set(result);
+    } catch (e) {
+      _set('❌ FAILED: $e');
+    } finally {
+      await _sub?.cancel();
+      _sub = null;
+      try {
+        await Tracelet.removeGeofence(_geofenceId);
+        await Tracelet.stop();
+      } catch (_) {}
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      title: '#231: geofence events missing coords & battery',
+      description:
+          'Starts high-accuracy geofencing anchored at your current location, '
+          'triggers an ENTER, and asserts the event carries a real accuracy and '
+          'a valid battery level (previously hardcoded 0.0 / -1.0). Needs a live '
+          'GPS fix — run outdoors or with a mock location set.',
+      status: _status,
+      running: _running,
+      onRun: _test,
+    );
+  }
+}

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -14,6 +14,8 @@ import 'package:tracelet_example/issues/issue_210_card.dart';
 import 'package:tracelet_example/issues/issue_212_card.dart';
 import 'package:tracelet_example/issues/issue_213_card.dart';
 import 'package:tracelet_example/issues/issue_214_card.dart';
+import 'package:tracelet_example/issues/issue_230_card.dart';
+import 'package:tracelet_example/issues/issue_231_card.dart';
 
 @pragma('vm:entry-point')
 void headlessSyncBodyBuilder136(HeadlessEvent event) {
@@ -1734,6 +1736,8 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                     ),
                   ],
                 ),
+                const Issue231Card(),
+                const Issue230Card(),
                 const Issue185Card(),
                 const Issue198Card(),
                 const Issue201Card(),

--- a/packages/tracelet/lib/src/models/geofence_event.dart
+++ b/packages/tracelet/lib/src/models/geofence_event.dart
@@ -47,11 +47,15 @@ class GeofenceEvent {
     }
 
     // Location: the flat shape wraps the location under 'location'; the
-    // structured payload exposes the coords at the top-level 'coords'.
+    // structured payload (headless/killed-state) exposes the coords at the
+    // top-level 'coords' and the battery at the top-level 'battery' (#231).
     final locationMap =
         safeMap(map['location']) ??
         (map['coords'] != null
-            ? <String, Object?>{'coords': map['coords']}
+            ? <String, Object?>{
+                'coords': map['coords'],
+                if (map['battery'] != null) 'battery': map['battery'],
+              }
             : const <String, Object?>{});
     final extrasRaw = source['extras'];
 

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/EventDispatcherGeofenceActionTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/EventDispatcherGeofenceActionTest.kt
@@ -95,4 +95,44 @@ internal class EventDispatcherGeofenceActionTest {
         )
         assertEquals(TlGeofenceAction.ENTER, event.action)
     }
+
+    /**
+     * #231: the SDK now enriches the geofence payload with real coordinate
+     * metrics and a top-level `battery` map. Pin that both survive the mapping
+     * to the Pigeon [com.ikolvi.tracelet.TlGeofenceEvent] (the foreground path).
+     */
+    @Test
+    fun structuredPayload_enrichedCoordsAndBattery_surviveMapping() {
+        val enriched = mapOf<String, Any?>(
+            "uuid" to "abc-231",
+            "event" to "geofence",
+            "timestamp" to "2026-06-30T00:00:00.000Z",
+            "coords" to mapOf(
+                "latitude" to 12.345,
+                "longitude" to 67.890,
+                "accuracy" to 25.0,
+                "speed" to 3.5,
+                "heading" to 90.0,
+                "altitude" to 100.0,
+            ),
+            "battery" to mapOf(
+                "level" to 0.42,
+                "is_charging" to true,
+            ),
+            "geofence" to mapOf(
+                "identifier" to "office",
+                "action" to "ENTER",
+                "extras" to mapOf("tier" to "gold"),
+            ),
+        )
+
+        val event = EventDispatcher().buildGeofenceEvent(enriched)
+
+        assertEquals(25.0, event.location.coords.accuracy, "accuracy must survive (was 0.0)")
+        assertEquals(3.5, event.location.coords.speed, "speed must survive (was 0.0)")
+        assertEquals(90.0, event.location.coords.heading, "heading must survive (was 0.0)")
+        assertEquals(100.0, event.location.coords.altitude, "altitude must survive (was 0.0)")
+        assertEquals(0.42, event.location.battery.level, "battery level must survive (was -1.0)")
+        assertEquals(true, event.location.battery.isCharging, "battery isCharging must survive")
+    }
 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -501,7 +501,10 @@ class TraceletSdk private constructor(private val context: Context) {
 
         // Geofencing
         geofenceManager = GeofenceManager(
-            context, configManager, eventSender, rustDatabase
+            context, configManager, eventSender, rustDatabase,
+            lastLocationProvider = {
+                if (::locationEngine.isInitialized) locationEngine.getLastGpsLocation() else null
+            },
         ).apply {
             onGeofenceEvent = { eventMap ->
                 insertLocation(eventMap)
@@ -1032,17 +1035,55 @@ class TraceletSdk private constructor(private val context: Context) {
             rustDatabase?.setEncryptionKey("")
         }
 
+        // Keys whose changes require the active native tracking pipeline to be
+        // rebuilt with the new values. Previously only a handful of location
+        // keys were watched and only locationEngine was restarted — motion
+        // detector / speed manager / smart coordinator kept running on stale
+        // parameters until the app was force-killed (#230).
+        val locationKeys = listOf(
+            "desiredAccuracy", "distanceFilter", "locationUpdateInterval",
+            "fastestLocationUpdateInterval", "stationaryRadius", "deferTime",
+            "disableElasticity", "elasticityMultiplier",
+        )
+        val motionKeys = listOf(
+            "motionDetectionMode", "shakeThreshold", "stillThreshold", "stillSampleCount",
+            "stopTimeout", "motionTriggerDelay", "stopDetectionDelay", "disableStopDetection",
+            "stopOnStationary", "triggerActivities", "minimumActivityRecognitionConfidence",
+            "activityRecognitionInterval", "disableMotionActivityUpdates",
+            "speedMovingThreshold", "speedStationaryDelay", "speedWakeConfirmCount",
+            "stationaryTrackingMode", "stationaryPeriodicInterval", "stationaryPeriodicAccuracy",
+        )
+        val needsRestart = (locationKeys + motionKeys).any { key -> oldConfig[key] != merged[key] }
+
         if (stateManager.enabled) {
-            val locationKeys = listOf(
-                "desiredAccuracy", "distanceFilter", "locationUpdateInterval",
-                "fastestLocationUpdateInterval", "stationaryRadius", "deferTime",
-                "disableElasticity", "elasticityMultiplier",
-            )
-            val needsRestart = locationKeys.any { key -> oldConfig[key] != merged[key] }
             if (needsRestart) {
-                locationEngine.stop()
-                locationEngine.start()
+                logger.info("setConfig: tracking-relevant config changed — restarting active pipeline")
+                // Preserve the active tracking mode and motion state across the
+                // clean stop/start so the device doesn't silently revert to a
+                // stationary continuous default.
+                val currentMode = stateManager.trackingMode
+                val wasMoving = stateManager.isMoving
+
+                stop()
+
+                stateManager.enabled = true
+                stateManager.trackingMode = currentMode
+                stateManager.isMoving = wasMoving
+
+                // Rebuild the Rust processor so distanceFilter/elasticity/etc.
+                // changes take effect on the very first fix after restart (#157).
+                if (::locationEngine.isInitialized) locationEngine.rebuildProcessor()
+
+                when (currentMode) {
+                    TrackingMode.CONTINUOUS -> start(isResume = true)
+                    TrackingMode.PERIODIC -> startPeriodic()
+                    TrackingMode.GEOFENCES -> startGeofences()
+                }
             }
+        } else if (needsRestart && ::locationEngine.isInitialized) {
+            // Not actively tracking — still rebuild the processor so the next
+            // start() picks up the new location config without a stale cache.
+            locationEngine.rebuildProcessor()
         }
 
         // Behavior engines (telematics / transport / crash-fall + ML model) are

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -3171,15 +3171,23 @@ class TraceletSdk private constructor(private val context: Context) {
 
         // LocationEngine — keep alive for continuous (0) and geofence (1) modes.
         // Periodic mode (2) has its own WorkManager/AlarmManager lifecycle.
+        //
+        // All subsystems are `lateinit` and are only constructed by initialize().
+        // destroyAll() can run in a process/engine where initialize() never
+        // executed — e.g. a secondary/headless Flutter engine that is the last to
+        // detach (see TraceletAndroidPlugin.onDetachedFromEngine). Touching an
+        // uninitialized lateinit here throws UninitializedPropertyAccessException,
+        // which — being dispatched during engine/activity teardown — surfaces as
+        // a fatal "Unable to destroy activity" (#227). Guard every access.
         if (!(keepAlive && stateManager.trackingMode != TrackingMode.PERIODIC)) {
-            locationEngine.destroy()
+            if (::locationEngine.isInitialized) locationEngine.destroy()
         }
-        motionDetector.stop()
+        if (::motionDetector.isInitialized) motionDetector.stop()
 
         // GeofenceManager — keep alive only in geofence mode (1).
         val keepGeofencesAlive = keepAlive && stateManager.trackingMode == TrackingMode.GEOFENCES
         if (!keepGeofencesAlive) {
-            geofenceManager.destroy()
+            if (::geofenceManager.isInitialized) geofenceManager.destroy()
         }
 
         // HttpSyncManager — MUST survive for location uploads after task
@@ -3193,7 +3201,7 @@ class TraceletSdk private constructor(private val context: Context) {
 
         // ScheduleManager & heartbeat — keep alive for continuity.
         if (!keepAlive) {
-            scheduleManager.stop()
+            if (::scheduleManager.isInitialized) scheduleManager.stop()
             stopHeartbeat()
         }
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
@@ -6,10 +6,13 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.location.Location
+import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.ikolvi.tracelet.sdk.ConfigManager
 import com.ikolvi.tracelet.sdk.TraceletEventSender
+import com.ikolvi.tracelet.sdk.util.BatteryUtils
 import uniffi.tracelet_core.GeofenceEvaluator
 import uniffi.tracelet_core.CoreGeofence
 import uniffi.tracelet_core.Coordinate
@@ -39,6 +42,13 @@ class GeofenceManager(
     private val events: TraceletEventSender,
     private val rustDatabase: uniffi.tracelet_core.DatabaseManager? = null,
     private val geofencingClient: TraceletGeofencingClient = TraceletServices.getInstance(context).getGeofencingClient(context),
+    /**
+     * Provides the most recent GPS fix so geofence transition payloads can be
+     * enriched with real coordinate telemetry (accuracy/speed/heading/altitude)
+     * instead of hardcoded zeros (#231). Wired from [TraceletSdk] to the active
+     * [com.ikolvi.tracelet.sdk.location.LocationEngine].
+     */
+    private val lastLocationProvider: (() -> Location?)? = null,
 ) {
     var onGeofenceEvent: ((Map<String, Any?>) -> Unit)? = null
     companion object {
@@ -290,14 +300,8 @@ class GeofenceManager(
                 "uuid" to java.util.UUID.randomUUID().toString(),
                 "event" to "geofence",
                 "timestamp" to java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US).apply { timeZone = java.util.TimeZone.getTimeZone("UTC") }.format(java.util.Date()),
-                "coords" to mapOf(
-                    "latitude" to latitude,
-                    "longitude" to longitude,
-                    "accuracy" to 0.0,
-                    "speed" to 0.0,
-                    "heading" to 0.0,
-                    "altitude" to 0.0
-                ),
+                "coords" to buildCoords(latitude, longitude),
+                "battery" to currentBattery(),
                 "geofence" to mapOf(
                     "identifier" to identifier,
                     "action" to action,
@@ -360,14 +364,8 @@ class GeofenceManager(
                 "uuid" to java.util.UUID.randomUUID().toString(),
                 "event" to "geofence",
                 "timestamp" to java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US).apply { timeZone = java.util.TimeZone.getTimeZone("UTC") }.format(java.util.Date()),
-                "coords" to mapOf(
-                    "latitude" to latitude,
-                    "longitude" to longitude,
-                    "accuracy" to 0.0,
-                    "speed" to 0.0,
-                    "heading" to 0.0,
-                    "altitude" to 0.0
-                ),
+                "coords" to buildCoords(latitude, longitude),
+                "battery" to currentBattery(),
                 "geofence" to mapOf(
                     "identifier" to t.identifier,
                     "action" to t.action,
@@ -485,6 +483,48 @@ class GeofenceManager(
     // =========================================================================
     // Private methods
     // =========================================================================
+
+    /**
+     * Builds the `coords` payload for a geofence transition event.
+     *
+     * The geofence boundary latitude/longitude come from the triggering event,
+     * but the remaining telemetry (accuracy, speed, heading, altitude and their
+     * per-field accuracies) is sourced from the most recent GPS fix when
+     * available. Previously these were hardcoded to `0.0`, leaving backends
+     * blind to speed/heading/accuracy at the crossing (#231).
+     */
+    private fun buildCoords(latitude: Double, longitude: Double): Map<String, Any?> {
+        val last = lastLocationProvider?.invoke()
+            ?: return mapOf(
+                "latitude" to latitude,
+                "longitude" to longitude,
+                "accuracy" to 0.0,
+                "speed" to 0.0,
+                "heading" to 0.0,
+                "altitude" to 0.0,
+            )
+
+        return buildMap {
+            put("latitude", latitude)
+            put("longitude", longitude)
+            put("accuracy", last.accuracy.toDouble())
+            put("speed", if (last.hasSpeed()) last.speed.toDouble() else 0.0)
+            put("heading", if (last.hasBearing()) last.bearing.toDouble() else 0.0)
+            put("altitude", if (last.hasAltitude()) last.altitude else 0.0)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                put("speedAccuracy", if (last.hasSpeedAccuracy()) last.speedAccuracyMetersPerSecond.toDouble() else -1.0)
+                put("headingAccuracy", if (last.hasBearingAccuracy()) last.bearingAccuracyDegrees.toDouble() else -1.0)
+                put("altitudeAccuracy", if (last.hasVerticalAccuracy()) last.verticalAccuracyMeters.toDouble() else -1.0)
+            } else {
+                put("speedAccuracy", -1.0)
+                put("headingAccuracy", -1.0)
+                put("altitudeAccuracy", -1.0)
+            }
+        }
+    }
+
+    /** Current battery snapshot for geofence transition payloads (#231). */
+    private fun currentBattery(): Map<String, Any?> = BatteryUtils.getBatteryInfo(context)
 
     private fun registerGeofence(geofenceMap: Map<String, Any?>): Boolean {
         if (!hasPermission()) return false

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/DestroyAllUninitializedTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/DestroyAllUninitializedTest.kt
@@ -1,0 +1,66 @@
+package com.ikolvi.tracelet.sdk
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression for #227 — `destroyAll()` is invoked from the plugin's
+ * `onDetachedFromEngine` during engine/Activity teardown, and can run in a
+ * process/engine where `initialize()` was never called (e.g. a secondary or
+ * headless Flutter engine that is the last to detach). The `lateinit`
+ * subsystems (`motionDetector`, `locationEngine`, `geofenceManager`,
+ * `scheduleManager`) are then uninitialized, and touching them threw
+ * `UninitializedPropertyAccessException` — surfacing as a fatal
+ * "Unable to destroy activity" because it's dispatched during teardown.
+ *
+ * destroyAll() must null-guard every subsystem so teardown never throws.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DestroyAllUninitializedTest {
+
+    @Before
+    fun setUp() {
+        // destroyAll() cancels the periodic WorkManager job; production apps have
+        // WorkManager auto-initialized via the manifest provider, so stand up the
+        // in-memory test scheduler here to mirror that (this is environment setup,
+        // not the behavior under test).
+        androidx.work.testing.WorkManagerTestInitHelper.initializeTestWorkManager(
+            ApplicationProvider.getApplicationContext(),
+            androidx.work.Configuration.Builder()
+                .setExecutor(androidx.work.testing.SynchronousExecutor())
+                .build(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        ConfigManager.resetInstance()
+    }
+
+    @Test
+    fun `destroyAll on an uninitialized SDK does not throw`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sdk = TraceletSdk.getInstance(context)
+
+        // Deliberately do NOT call setEventSender()/initialize(): this mirrors a
+        // secondary/headless engine teardown. Must complete without throwing.
+        sdk.destroyAll()
+    }
+
+    @Test
+    fun `destroyAll on an uninitialized SDK with stopOnTerminate=false does not throw`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // stopOnTerminate=false drives the keepAlive branch in destroyAll().
+        ConfigManager.getInstance(context).setConfig(mapOf("stopOnTerminate" to false))
+        val sdk = TraceletSdk.getInstance(context)
+
+        sdk.destroyAll()
+    }
+}

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/SetConfigRestartTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/SetConfigRestartTest.kt
@@ -1,0 +1,130 @@
+package com.ikolvi.tracelet.sdk
+
+import android.Manifest
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression for #230 — runtime config changes (setConfig) must propagate to the
+ * active native tracking pipeline. Previously only a few location keys triggered
+ * a restart, and only the LocationEngine was restarted, so motion-detector /
+ * speed-manager parameter changes (e.g. switching ACCELEROMETER → SPEED) were
+ * silently ignored until the app was force-killed.
+ *
+ * The restart performs a clean stop()/start() of the active pipeline, which is
+ * observable here through the enabledChange(false)→(true) lifecycle events.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SetConfigRestartTest {
+
+    private lateinit var context: Context
+    private lateinit var sdk: TraceletSdk
+    private lateinit var sender: ListenerEventSender
+    private val enabledChanges = mutableListOf<Boolean>()
+
+    @Before
+    fun setUp() {
+        org.robolectric.shadows.ShadowLog.stream = System.out
+        context = ApplicationProvider.getApplicationContext()
+
+        // start()/stop() touch WorkManager (PeriodicLocationWorker.cancel) — stand
+        // up the in-memory test scheduler so those calls don't throw.
+        androidx.work.testing.WorkManagerTestInitHelper.initializeTestWorkManager(
+            context,
+            androidx.work.Configuration.Builder()
+                .setExecutor(androidx.work.testing.SynchronousExecutor())
+                .build(),
+        )
+
+        val shadowApp = shadowOf(context as android.app.Application)
+        shadowApp.grantPermissions(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+            Manifest.permission.ACTIVITY_RECOGNITION,
+        )
+
+        sender = ListenerEventSender()
+        sender.listener = object : TraceletListener {
+            override fun onEnabledChange(enabled: Boolean) { enabledChanges.add(enabled) }
+        }
+
+        sdk = TraceletSdk.getInstance(context)
+        sdk.setEventSender(sender)
+        sdk.initialize()
+    }
+
+    @After
+    fun tearDown() {
+        try { sdk.stop() } catch (_: Exception) {}
+        idle()
+        ConfigManager.resetInstance()
+        enabledChanges.clear()
+    }
+
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
+
+    private fun ready(config: Map<String, Any?>) {
+        var done = false
+        sdk.ready(
+            config + mapOf(
+                "foregroundService" to false,
+                "stopOnStationary" to false,
+                "isMoving" to true,
+            ),
+        ) { done = true }
+        idle()
+        assertTrue(done, "ready() callback should fire")
+    }
+
+    @Test
+    fun `changing motionDetectionMode at runtime restarts the active pipeline`() {
+        ready(mapOf("motionDetectionMode" to 0)) // ACCELEROMETER
+        sdk.start()
+        idle()
+        assertTrue(enabledChanges.contains(true), "start() should emit enabledChange(true)")
+
+        enabledChanges.clear()
+
+        // Switch ACCELEROMETER → SPEED. This is a motion-only key the old code
+        // ignored — it must now trigger a full stop/start of the pipeline.
+        sdk.setConfig(mapOf("motionDetectionMode" to 1)) // SPEED
+        idle()
+
+        assertTrue(
+            enabledChanges.contains(false) && enabledChanges.contains(true),
+            "motion mode change must restart the pipeline (saw enabledChanges=$enabledChanges)",
+        )
+        assertEquals(false, enabledChanges.first(), "restart must stop before starting")
+        assertEquals(true, enabledChanges.last(), "restart must leave tracking enabled")
+        assertTrue(sdk.stateManager.enabled, "tracking should remain enabled after restart")
+    }
+
+    @Test
+    fun `changing an unrelated config key does not restart the pipeline`() {
+        ready(mapOf("motionDetectionMode" to 0))
+        sdk.start()
+        idle()
+        enabledChanges.clear()
+
+        // A non-tracking key — must NOT churn the active pipeline.
+        sdk.setConfig(mapOf("stopOnTerminate" to true))
+        idle()
+
+        assertTrue(
+            enabledChanges.isEmpty(),
+            "unrelated config change must not restart tracking (saw $enabledChanges)",
+        )
+    }
+}

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerEnrichmentTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerEnrichmentTest.kt
@@ -1,0 +1,131 @@
+package com.ikolvi.tracelet.sdk.geofence
+
+import android.content.Context
+import android.location.Location
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.ConfigManager
+import com.ikolvi.tracelet.sdk.ListenerEventSender
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import uniffi.tracelet_core.DatabaseManager
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression for #231 — geofence transition events were emitted with hardcoded
+ * zero coordinate metrics (accuracy/speed/heading/altitude) and no `battery`
+ * key, leaving backends blind to telemetry at the crossing.
+ *
+ * These tests assert the enriched `coords` (sourced from the last GPS fix via
+ * the wired `lastLocationProvider`) and the presence of the `battery` payload.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GeofenceManagerEnrichmentTest {
+
+    private lateinit var context: Context
+    private lateinit var config: ConfigManager
+    private lateinit var db: DatabaseManager
+    private val captured = mutableListOf<Map<String, Any?>>()
+
+    private val centerLat = 10.787929
+    private val centerLng = 76.684183
+    private val radius = 150.0
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        config = ConfigManager.getInstance(context)
+        config.setConfig(mapOf("geofenceModeHighAccuracy" to true))
+
+        val dbPath = context.filesDir.resolve("test_geofence_enrich.db").absolutePath
+        db = DatabaseManager(dbPath)
+        db.setEncryptionKey("")
+        db.clearGeofences()
+        db.insertGeofence("ENRICH_ZONE", centerLat, centerLng, radius, null, null)
+    }
+
+    @After
+    fun tearDown() {
+        ConfigManager.resetInstance()
+        context.filesDir.resolve("test_geofence_enrich.db").delete()
+        captured.clear()
+    }
+
+    private fun managerWith(provider: (() -> Location?)?): GeofenceManager =
+        GeofenceManager(
+            context, config, ListenerEventSender(), db,
+            lastLocationProvider = provider,
+        ).apply { onGeofenceEvent = { captured.add(it) }; clearHighAccuracyState() }
+
+    private fun fix(): Location = Location("gps").apply {
+        latitude = centerLat
+        longitude = centerLng
+        accuracy = 25.0f
+        speed = 3.5f
+        bearing = 90.0f
+        altitude = 100.0
+        speedAccuracyMetersPerSecond = 0.5f
+        bearingAccuracyDegrees = 2.0f
+        verticalAccuracyMeters = 4.0f
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun lastCoords(): Map<String, Any?> =
+        captured.last()["coords"] as Map<String, Any?>
+
+    @Test
+    fun `geofence event is enriched with real GPS metrics from last fix`() {
+        val geo = managerWith { fix() }
+
+        // Establish "outside" then cross inside to fire ENTER.
+        geo.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        geo.evaluateHighAccuracyProximity(centerLat, centerLng)
+
+        val coords = lastCoords()
+        assertEquals(25.0, coords["accuracy"], "accuracy must come from last fix, not 0.0")
+        assertEquals(3.5, coords["speed"] as Double, 1e-4, "speed must come from last fix, not 0.0")
+        assertEquals(90.0, coords["heading"] as Double, 1e-4, "heading must come from last fix, not 0.0")
+        assertEquals(100.0, coords["altitude"], "altitude must come from last fix, not 0.0")
+        // Per-field accuracies surfaced on API 26+.
+        assertEquals(0.5, coords["speedAccuracy"] as Double, 1e-4)
+        assertEquals(2.0, coords["headingAccuracy"] as Double, 1e-4)
+        assertEquals(4.0, coords["altitudeAccuracy"] as Double, 1e-4)
+    }
+
+    @Test
+    fun `geofence event always carries a battery payload`() {
+        val geo = managerWith { fix() }
+
+        geo.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        geo.evaluateHighAccuracyProximity(centerLat, centerLng)
+
+        @Suppress("UNCHECKED_CAST")
+        val battery = captured.last()["battery"] as? Map<String, Any?>
+        assertNotNull(battery, "battery key must be present (#231)")
+        assertTrue(battery.containsKey("level"), "battery must include level")
+        assertTrue(battery.containsKey("is_charging"), "battery must include is_charging")
+    }
+
+    @Test
+    fun `falls back to zeroed coords and battery when no last fix available`() {
+        val geo = managerWith(null)
+
+        geo.evaluateHighAccuracyProximity(centerLat + 0.01, centerLng)
+        geo.evaluateHighAccuracyProximity(centerLat, centerLng)
+
+        val coords = lastCoords()
+        // Geofence boundary lat/lng still populated; metrics fall back to 0.0.
+        assertEquals(0.0, coords["accuracy"])
+        assertEquals(0.0, coords["speed"])
+        assertEquals(0.0, coords["heading"])
+        assertEquals(0.0, coords["altitude"])
+        // Battery is still emitted even without a GPS fix.
+        assertTrue(captured.last().containsKey("battery"))
+    }
+}

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -2939,6 +2939,15 @@ public final class TraceletSdk {
     /// Respects `stopOnTerminate: false` by skipping teardown for critical
     /// background tracking components when enabled.
     public func destroyAll() {
+        // destroyAll() is dispatched from the plugin during engine teardown. It
+        // can run in a process/engine where initialize() never executed (e.g. a
+        // secondary/headless engine). All subsystems — including configManager and
+        // stateManager — are implicitly-unwrapped optionals assigned in
+        // initialize(); touching them while nil traps fatally *during teardown*,
+        // surfacing as a crash the app can't intercept (parity with Android #227).
+        // If the SDK was never initialized there is nothing to tear down.
+        guard configManager != nil, stateManager != nil else { return }
+
         // When stopOnTerminate=false and tracking is active, the SDK should
         // continue running in the background. Tearing down subsystems here
         // would kill that background continuity.
@@ -2947,34 +2956,34 @@ public final class TraceletSdk {
         // LocationEngine — keep alive for continuous and geofence modes.
         // Periodic mode has its own scheduler lifecycle.
         if !(keepAlive && stateManager.trackingMode != .periodic) {
-            locationEngine.stop()
+            locationEngine?.stop()
         }
-        motionDetector.stop()
+        motionDetector?.stop()
 
         // GeofenceManager — keep alive only in geofence mode.
         let keepGeofencesAlive = keepAlive && stateManager.trackingMode == .geofences
         if !keepGeofencesAlive {
-            geofenceManager.destroy()
+            geofenceManager?.destroy()
         }
 
         // Subsystems that should only survive if we are in a background-active mode.
         if !keepAlive {
             // TODO: Stop Rust SyncManager if necessary
-            scheduleManager.stop()
+            scheduleManager?.stop()
             stopHeartbeat()
-            preventSuspendManager.stop()
-            backgroundActivitySessionManager.stop()
-            serviceSessionManager.stop()
+            preventSuspendManager?.stop()
+            backgroundActivitySessionManager?.stop()
+            serviceSessionManager?.stop()
         }
 
         // Sound and budget sampling are safe to stop unconditionally.
-        soundManager.stop()
+        soundManager?.stop()
         stopBatteryBudgetSampling()
 
         // Periodic scheduler — keep alive only in periodic mode.
         let keepPeriodicAlive = keepAlive && stateManager.trackingMode == .periodic
         if !keepPeriodicAlive {
-            periodicRefreshScheduler.stop()
+            periodicRefreshScheduler?.stop()
         }
     }
 

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -633,8 +633,13 @@ public final class TraceletSdk {
             configManager.getCrashModelLicenseKey() ?? "", configManager.getCrashModelSha256() ?? "",
             configManager.getCrashModelThreshold(),
         ]
-        configManager.setConfig(config)
-        
+        // Snapshot config before applying so we can detect which tracking-relevant
+        // keys changed and rebuild the WHOLE active pipeline (location + motion
+        // detector + speed manager + smart coordinator) — not just the location
+        // engine, which previously left motion sensors running on stale params (#230).
+        let oldConfig = configManager.getConfig()
+        let merged = configManager.setConfig(config)
+
         if config["encryptDatabase"] as? Bool == true {
             let key = config["encryptionKey"] as? String ?? ""
             rustDatabase?.setEncryptionKey(key: key)
@@ -642,27 +647,64 @@ public final class TraceletSdk {
             rustDatabase?.setEncryptionKey(key: "")
         }
 
+        let locationKeys = [
+            "desiredAccuracy", "distanceFilter", "locationUpdateInterval",
+            "fastestLocationUpdateInterval", "stationaryRadius", "deferTime",
+            "disableElasticity", "elasticityMultiplier",
+        ]
+        let motionKeys = [
+            "motionDetectionMode", "shakeThreshold", "stillThreshold", "stillSampleCount",
+            "stopTimeout", "motionTriggerDelay", "stopDetectionDelay", "disableStopDetection",
+            "stopOnStationary", "triggerActivities", "minimumActivityRecognitionConfidence",
+            "activityRecognitionInterval", "disableMotionActivityUpdates",
+            "speedMovingThreshold", "speedStationaryDelay", "speedWakeConfirmCount",
+            "stationaryTrackingMode", "stationaryPeriodicInterval", "stationaryPeriodicAccuracy",
+        ]
+        let needsRestart = (locationKeys + motionKeys).contains { key in
+            !valuesEqual(oldConfig[key], merged[key])
+        }
+
         if stateManager.enabled {
-            if stateManager.trackingMode == .periodic {
-                // Periodic mode — restart periodic tracking.
-                locationEngine.stopPeriodic()
-                locationEngine.startPeriodic()
-                periodicRefreshScheduler.stop()
-                periodicRefreshScheduler.start(
-                    interval: TimeInterval(configManager.getPeriodicLocationInterval())
-                )
-            } else {
-                locationEngine.stop()
-                locationEngine.start()
+            if needsRestart {
+                logger.info("setConfig: tracking-relevant config changed — restarting active pipeline")
+                // Preserve the active tracking mode and motion state across the
+                // clean stop/start so the device doesn't silently revert to a
+                // stationary continuous default.
+                let currentMode = stateManager.trackingMode
+                let wasMoving = stateManager.isMoving
+
+                _ = stop()
+
+                stateManager.enabled = true
+                stateManager.trackingMode = currentMode
+                stateManager.isMoving = wasMoving
+
+                // Rebuild the Rust processor so distanceFilter/elasticity/etc.
+                // changes take effect on the very first fix after restart.
+                locationEngine.rebuildProcessor()
+
+                switch currentMode {
+                case .periodic:
+                    _ = startPeriodic()
+                case .geofences:
+                    _ = startGeofences()
+                default:
+                    _ = start(isResume: true)
+                }
             }
 
-            // Toggle preventSuspend if it changed mid-session.
+            // Toggle preventSuspend if it changed mid-session. (start()/stop()
+            // also manage it, but ensure the final state matches the new config.)
             let nowPreventing = configManager.getPreventSuspend()
             if nowPreventing && !wasPreventing {
                 preventSuspendManager.start()
             } else if !nowPreventing && wasPreventing {
                 preventSuspendManager.stop()
             }
+        } else if needsRestart {
+            // Not actively tracking — still rebuild the processor so the next
+            // start() picks up the new location config without a stale cache.
+            locationEngine.rebuildProcessor()
         }
 
         let newBehavior: [AnyHashable] = [
@@ -679,6 +721,18 @@ public final class TraceletSdk {
         syncConfigToRustFlat()
         checkSyncProvider()
         return stateManager.toMap(configManager.getConfig())
+    }
+
+    /// Loose equality for two heterogeneous config values, used to detect which
+    /// keys changed between an old and new config snapshot. Config values are
+    /// primitives (Int/Double/Bool/String) sourced from the same dictionary
+    /// shape, so a stable string description is a reliable change signal.
+    private func valuesEqual(_ a: Any?, _ b: Any?) -> Bool {
+        switch (a, b) {
+        case (nil, nil): return true
+        case (nil, _), (_, nil): return false
+        default: return String(describing: a!) == String(describing: b!)
+        }
     }
 
     private func checkSyncProvider() {

--- a/sdk/ios/Sources/TraceletSDK/geofence/GeofenceManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/geofence/GeofenceManager.swift
@@ -282,14 +282,8 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
                 "uuid": UUID().uuidString,
                 "event": "geofence",
                 "timestamp": isoFormatter.string(from: Date()),
-                "coords": [
-                    "latitude": latitude,
-                    "longitude": longitude,
-                    "accuracy": 0.0,
-                    "speed": 0.0,
-                    "heading": 0.0,
-                    "altitude": 0.0,
-                ],
+                "coords": buildCoords(latitude: latitude, longitude: longitude),
+                "battery": BatteryUtils.getBatteryInfo(),
                 "geofence": [
                     "identifier": t.identifier,
                     "action": t.action,
@@ -486,6 +480,41 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
 
     // MARK: - Transition handling
 
+    /// Builds the `coords` payload for a geofence transition event.
+    ///
+    /// The geofence boundary `latitude`/`longitude` come from the triggering
+    /// event, while the remaining telemetry (accuracy, speed, heading, altitude
+    /// and per-field accuracies) is sourced from the most recent GPS fix when
+    /// available. Previously these were hardcoded to `0.0`, leaving backends
+    /// blind to speed/heading/accuracy at the crossing (#231).
+    private func buildCoords(latitude: Double, longitude: Double) -> [String: Any] {
+        guard let location = locationManager.location else {
+            return [
+                "latitude": latitude,
+                "longitude": longitude,
+                "accuracy": 0.0,
+                "speed": 0.0,
+                "heading": 0.0,
+                "altitude": 0.0,
+            ]
+        }
+
+        var coords: [String: Any] = [
+            "latitude": latitude,
+            "longitude": longitude,
+            "altitude": location.altitude,
+            "speed": location.speed >= 0 ? location.speed : 0.0,
+            "heading": location.course >= 0 ? location.course : 0.0,
+            "accuracy": location.horizontalAccuracy,
+            "altitudeAccuracy": location.verticalAccuracy,
+        ]
+        if #available(iOS 13.4, *) {
+            coords["speedAccuracy"] = location.speedAccuracy
+            coords["headingAccuracy"] = location.courseAccuracy
+        }
+        return coords
+    }
+
     private func handleTransition(region: CLCircularRegion, action: String) {
         // When high-accuracy mode is active, evaluateHighAccuracyProximity()
         // handles transitions in-app. Skip OS-level events to avoid duplicates.
@@ -501,14 +530,8 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
             "uuid": UUID().uuidString,
             "event": "geofence",
             "timestamp": isoFormatter.string(from: Date()),
-            "coords": [
-                "latitude": lat,
-                "longitude": lng,
-                "accuracy": 0.0,
-                "speed": 0.0,
-                "heading": 0.0,
-                "altitude": 0.0,
-            ],
+            "coords": buildCoords(latitude: lat, longitude: lng),
+            "battery": BatteryUtils.getBatteryInfo(),
             "geofence": [
                 "identifier": region.identifier,
                 "action": action,


### PR DESCRIPTION
Resolves #231, #230, #227.

## #231 — Geofence events missing coordinate metrics & battery
Geofence transition payloads were built with hardcoded `0.0` coords and no `battery` key. Both transition paths now enrich `coords` from the last GPS fix and attach the current battery snapshot.
- Android `GeofenceManager.kt` (wired `lastLocationProvider` from `TraceletSdk`), iOS `GeofenceManager.swift`, and the Dart headless `GeofenceEvent.fromMap`.

## #230 — setConfig not propagating to active native loops
`setConfig()` only watched a few location keys and restarted only the location engine, so motion/speed parameter changes (e.g. ACCELEROMETER → SPEED) were ignored until force-kill. It now diffs location + motion keys and performs a clean full-pipeline stop→restart (preserving tracking mode + motion state) and rebuilds the Rust processor.
- Android `TraceletSdk.kt`, iOS `TraceletSdk.swift`.

## #227 — `destroyAll()` throws during teardown ("Unable to destroy activity")
The `getMotionDetector` symbol from 2.0.8 was refactored away, but the same defect persisted in `destroyAll()`, which accessed `lateinit`/IUO subsystems without an init guard. When run in an engine where `initialize()` never executed (secondary/headless), teardown trapped fatally.
- Android: guard every `lateinit` access with `::x.isInitialized`.
- iOS: early-return when uninitialized + optional chaining.

## Tests
- `GeofenceManagerEnrichmentTest`, `SetConfigRestartTest`, `DestroyAllUninitializedTest`, plus a coords/battery survival case in `EventDispatcherGeofenceActionTest`. Full `:tracelet-sdk` suite green; iOS SDK builds clean.
- Example app: added `Issue230Card` + `Issue231Card` to the Recent Issues tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)