### PR TITLE
chore(release): bump version to 3.5.4

### DIFF
--- a/TraceletSDK.podspec
+++ b/TraceletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TraceletSDK'
-  s.version = '3.5.3'
+  s.version = '3.5.4'
   s.summary          = 'Production-grade background geolocation SDK for iOS.'
   s.description      = <<-DESC
     TraceletSDK provides battery-conscious background geolocation with motion detection,

--- a/bump_version.py
+++ b/bump_version.py
@@ -1,7 +1,7 @@
 import os
 
-version_from = "3.5.2"
-version_to = "3.5.3"
+version_from = "3.5.3"
+version_to = "3.5.4"
 
 # 1. Bump version strings
 exact_replacements = [
@@ -84,12 +84,16 @@ generic_changelogs = [
 
 changelog_addition = f"""## {version_to}
 
-**FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).
+**FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
 
 """
 generic_addition = f"""## {version_to}
 
-**FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
 
 """
 

--- a/example/lib/issues/issue_231_card.dart
+++ b/example/lib/issues/issue_231_card.dart
@@ -90,8 +90,10 @@ class _Issue231CardState extends State<Issue231Card> {
         }
       });
 
-      _set('Registering geofence at ${here.coords.latitude.toStringAsFixed(5)}, '
-          '${here.coords.longitude.toStringAsFixed(5)}...');
+      _set(
+        'Registering geofence at ${here.coords.latitude.toStringAsFixed(5)}, '
+        '${here.coords.longitude.toStringAsFixed(5)}...',
+      );
       await Tracelet.addGeofence(
         Geofence(
           identifier: _geofenceId,

--- a/packages/tracelet/CHANGELOG.md
+++ b/packages/tracelet/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet/pubspec.yaml
+++ b/packages/tracelet/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Production-grade background geolocation for Flutter. Battery-conscious
   tracking, geofencing, SQLite persistence, HTTP sync, and headless
   execution for iOS & Android.
-version: 3.5.3
+version: 3.5.4
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -30,10 +30,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.3
-  tracelet_android: ^3.5.3
-  tracelet_ios: ^3.5.3
-  tracelet_web: ^3.5.3
+  tracelet_platform_interface: ^3.5.4
+  tracelet_android: ^3.5.4
+  tracelet_ios: ^3.5.4
+  tracelet_web: ^3.5.4
   collection: ^1.19.1
   meta: ^1.18.0
 

--- a/packages/tracelet_android/CHANGELOG.md
+++ b/packages/tracelet_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_android/android/build.gradle
+++ b/packages/tracelet_android/android/build.gradle
@@ -48,7 +48,7 @@ android {
         // Tracelet SDK — standalone geolocation engine
         // Resolved from Maven Central when published, substituted with local
         // module via includeBuild during development.
-        api("com.ikolvi:tracelet-sdk:3.5.3")
+        api("com.ikolvi:tracelet-sdk:3.5.4")
 
         // Testing
         // Real org.json so ConfigManager's JSON persistence works under unit

--- a/packages/tracelet_android/pubspec.yaml
+++ b/packages/tracelet_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_android
 description: Android implementation of the Tracelet background geolocation plugin.
-version: 3.5.3
+version: 3.5.4
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.3
+  tracelet_platform_interface: ^3.5.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_doctor/CHANGELOG.md
+++ b/packages/tracelet_doctor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_doctor/pubspec.yaml
+++ b/packages/tracelet_doctor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Drop-in diagnostic overlay widget for Tracelet. Visualizes permissions,
   battery health, OEM compatibility, sensor availability, and tracking
   state with actionable fix suggestions.
-version: 3.5.3
+version: 3.5.4
 license: Apache-2.0
 homepage: https://github.com/Ikolvi/Tracelet
 documentation: https://tracelet.ikolvi.com
@@ -29,7 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.3
+  tracelet: ^3.5.4
   share_plus: ^13.1.0
 
 dev_dependencies:

--- a/packages/tracelet_firebase/CHANGELOG.md
+++ b/packages/tracelet_firebase/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_firebase/pubspec.yaml
+++ b/packages/tracelet_firebase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_firebase
 description: >-
   Firebase adapter for Tracelet. Automatically configures native HTTP sync to push locations directly to the Firebase RTDB and manages background auth token refresh.
-version: 3.5.3
+version: 3.5.4
 topics:
   - firebase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.3
-  tracelet_sync: ^3.5.3
+  tracelet: ^3.5.4
+  tracelet_sync: ^3.5.4
   firebase_auth: ^6.5.2
   firebase_core: ^4.10.0
 
@@ -43,4 +43,4 @@ dev_dependencies:
   flutter_lints: '6.0.0'
   mocktail: ^1.0.5
   plugin_platform_interface: any
-  tracelet_platform_interface: ^3.5.3
+  tracelet_platform_interface: ^3.5.4

--- a/packages/tracelet_ios/CHANGELOG.md
+++ b/packages/tracelet_ios/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_ios/ios/tracelet_ios.podspec
+++ b/packages/tracelet_ios/ios/tracelet_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tracelet_ios'
-  s.version = '3.5.3'
+  s.version = '3.5.4'
   s.summary          = 'iOS implementation of the Tracelet background geolocation plugin.'
   s.description      = <<-DESC
 Production-grade background geolocation for Flutter. Battery-conscious
@@ -18,7 +18,7 @@ execution for iOS.
   s.source_files = 'tracelet_ios/Sources/tracelet_ios/**/*.{swift,h}'
   s.public_header_files = 'tracelet_ios/Sources/tracelet_ios/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TraceletSDK', '3.5.3'
+  s.dependency 'TraceletSDK', '3.5.4'
   s.platform = :ios, '14.0'
   s.frameworks = 'CoreLocation', 'CoreMotion', 'UIKit', 'BackgroundTasks', 'AVFoundation', 'AudioToolbox', 'Network', 'DeviceCheck'
   s.libraries = 'sqlite3'

--- a/packages/tracelet_ios/pubspec.yaml
+++ b/packages/tracelet_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_ios
 description: iOS implementation of the Tracelet background geolocation plugin.
-version: 3.5.3
+version: 3.5.4
 topics:
   - location
   - background
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.3
+  tracelet_platform_interface: ^3.5.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_platform_interface/CHANGELOG.md
+++ b/packages/tracelet_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_platform_interface/pubspec.yaml
+++ b/packages/tracelet_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracelet_platform_interface
 description: >-
   A common platform interface for the Tracelet background geolocation plugin.
   Used by tracelet_android and tracelet_ios implementations.
-version: 3.5.3
+version: 3.5.4
 topics:
   - location
   - background

--- a/packages/tracelet_supabase/CHANGELOG.md
+++ b/packages/tracelet_supabase/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_supabase/pubspec.yaml
+++ b/packages/tracelet_supabase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tracelet_supabase
 description: >-
   Supabase adapter for Tracelet. Automatically configures Tracelet's native HTTP sync to push locations to Supabase and manages background auth token refresh.
-version: 3.5.3
+version: 3.5.4
 topics:
   - supabase
   - location
@@ -31,8 +31,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.3
-  tracelet_sync: ^3.5.3
+  tracelet: ^3.5.4
+  tracelet_sync: ^3.5.4
   supabase_flutter: '^2.12.4'
 
   meta: ^1.18.0

--- a/packages/tracelet_sync/CHANGELOG.md
+++ b/packages/tracelet_sync/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_sync/android/build.gradle.kts
+++ b/packages/tracelet_sync/android/build.gradle.kts
@@ -72,8 +72,8 @@ kotlin {
 }
 
 dependencies {
-    compileOnly("com.ikolvi:tracelet-sdk:3.5.3")
-    implementation("com.ikolvi:tracelet-sync-sdk:3.5.3")
+    compileOnly("com.ikolvi:tracelet-sdk:3.5.4")
+    implementation("com.ikolvi:tracelet-sync-sdk:3.5.4")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
 }

--- a/packages/tracelet_sync/ios/tracelet_sync.podspec
+++ b/packages/tracelet_sync/ios/tracelet_sync.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tracelet_sync'
-  s.version = '3.5.3'
+  s.version = '3.5.4'
   s.summary          = 'iOS implementation of the Tracelet Sync plugin.'
   s.description      = <<-DESC
 A new Flutter plugin project.
@@ -16,7 +16,7 @@ A new Flutter plugin project.
   s.source_files = 'tracelet_sync/Sources/tracelet_sync/**/*.{swift,h}'
   s.public_header_files = 'tracelet_sync/Sources/tracelet_sync/**/*.h', 'tracelet_sync/Sources/tracelet_sync/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TraceletSDK', '3.5.3'
+  s.dependency 'TraceletSDK', '3.5.4'
   s.platform = :ios, '14.0'
   s.vendored_frameworks = 'tracelet_sync/TraceletSyncFFI.xcframework'
 

--- a/packages/tracelet_sync/pubspec.yaml
+++ b/packages/tracelet_sync/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_sync
 description: Offline SQLite persistence and automatic HTTP synchronization engine for Tracelet.
-version: 3.5.3
+version: 3.5.4
 homepage: https://github.com/ikolvi/tracelet
 documentation: https://tracelet.ikolvi.com
 repository: https://github.com/ikolvi/tracelet/tree/main/packages/tracelet_sync
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  tracelet: ^3.5.3
+  tracelet: ^3.5.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/tracelet_web/CHANGELOG.md
+++ b/packages/tracelet_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/packages/tracelet_web/pubspec.yaml
+++ b/packages/tracelet_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tracelet_web
 description: Web implementation of the Tracelet background geolocation plugin.
-version: 3.5.3
+version: 3.5.4
 topics:
   - location
   - background
@@ -28,7 +28,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  tracelet_platform_interface: ^3.5.3
+  tracelet_platform_interface: ^3.5.4
   web: ^1.1.1
 
 dev_dependencies:

--- a/sdk/android/CHANGELOG.md
+++ b/sdk/android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/sdk/android/gradle.properties
+++ b/sdk/android/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 kotlin.code.style=official
 # Native SDK version
-SDK_VERSION=3.5.3
+SDK_VERSION=3.5.4
 
 # ── Maven Central Publishing ─────────────────────────────────────────────────
 # Set these in ~/.gradle/gradle.properties (NOT committed to git) or as

--- a/sdk/ios/CHANGELOG.md
+++ b/sdk/ios/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.5.4
+
+**FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
+**FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
+**FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+
 ## 3.5.3
 
 **FIX**: Added explicit ProGuard keep rules for `TraceletStartupProvider` in the `tracelet_android` package to prevent `ClassNotFoundException` on process start when aggressive shrinking (like R8 full mode) is used ([#228](https://github.com/Ikolvi/Tracelet/issues/228)).

--- a/sdk/ios/TraceletSDK.podspec
+++ b/sdk/ios/TraceletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TraceletSDK'
-  s.version = '3.5.3'
+  s.version = '3.5.4'
   s.summary          = 'Production-grade background geolocation SDK for iOS.'
   s.homepage         = 'https://github.com/Ikolvi/Tracelet/tree/main/sdk/ios'
   s.license          = { :type => 'Apache-2.0', :file => '../../LICENSE' }


### PR DESCRIPTION
Patch version bump to **3.5.4** for the fixes merged in #232 (#231, #230, #227).

- Bumps all packages / podspecs / gradle (`SDK_VERSION`) to 3.5.4 via `bump_version.py`
- Adds 3.5.4 CHANGELOG entries for #231 (geofence coords+battery), #230 (setConfig propagation), #227 (teardown null-guard)
- `melos format` (issue_231_card.dart)

`melos format` and `melos analyze` both pass clean across all 12 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)