### PR TITLE
fix(android): no foreground service for standard geofencing (Google Play policy)

### DIFF
--- a/packages/tracelet/CHANGELOG.md
+++ b/packages/tracelet/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer starts a foreground service, complying with Google Play's policy (effective 2026-10-28) that prohibits using a foreground service solely for geofencing. Native geofences keep firing while the app is suspended/terminated; geofence-only apps can remove `FOREGROUND_SERVICE_LOCATION` from their manifest.
 
 ## 3.5.3
 

--- a/packages/tracelet_android/CHANGELOG.md
+++ b/packages/tracelet_android/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer starts a foreground service, complying with Google Play's policy (effective 2026-10-28) that prohibits using a foreground service solely for geofencing. Native geofences keep firing while the app is suspended/terminated; geofence-only apps can remove `FOREGROUND_SERVICE_LOCATION` from their manifest.
 
 ## 3.5.3
 

--- a/packages/tracelet_doctor/CHANGELOG.md
+++ b/packages/tracelet_doctor/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer runs a foreground service, complying with Google Play's 2026-10-28 foreground-service-for-geofencing policy.
 
 ## 3.5.3
 

--- a/packages/tracelet_firebase/CHANGELOG.md
+++ b/packages/tracelet_firebase/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer runs a foreground service, complying with Google Play's 2026-10-28 foreground-service-for-geofencing policy.
 
 ## 3.5.3
 

--- a/packages/tracelet_ios/CHANGELOG.md
+++ b/packages/tracelet_ios/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer starts a foreground service, complying with Google Play's policy (effective 2026-10-28) that prohibits using a foreground service solely for geofencing. Native geofences keep firing while the app is suspended/terminated; geofence-only apps can remove `FOREGROUND_SERVICE_LOCATION` from their manifest.
 
 ## 3.5.3
 

--- a/packages/tracelet_platform_interface/CHANGELOG.md
+++ b/packages/tracelet_platform_interface/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer runs a foreground service, complying with Google Play's 2026-10-28 foreground-service-for-geofencing policy.
 
 ## 3.5.3
 

--- a/packages/tracelet_supabase/CHANGELOG.md
+++ b/packages/tracelet_supabase/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer runs a foreground service, complying with Google Play's 2026-10-28 foreground-service-for-geofencing policy.
 
 ## 3.5.3
 

--- a/packages/tracelet_sync/CHANGELOG.md
+++ b/packages/tracelet_sync/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer runs a foreground service, complying with Google Play's 2026-10-28 foreground-service-for-geofencing policy.
 
 ## 3.5.3
 

--- a/packages/tracelet_web/CHANGELOG.md
+++ b/packages/tracelet_web/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics and battery ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to active native tracking/sensor loops ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems during teardown so Activity destruction never throws ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer runs a foreground service, complying with Google Play's 2026-10-28 foreground-service-for-geofencing policy.
 
 ## 3.5.3
 

--- a/sdk/android/CHANGELOG.md
+++ b/sdk/android/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer starts a foreground service, complying with Google Play's policy (effective 2026-10-28) that prohibits using a foreground service solely for geofencing. Native geofences keep firing while the app is suspended/terminated; geofence-only apps can remove `FOREGROUND_SERVICE_LOCATION` from their manifest.
 
 ## 3.5.3
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -916,15 +916,25 @@ class TraceletSdk private constructor(private val context: Context) {
         // GeofencingClient, which detects enter/exit without continuous location
         // updates — starting them keeps the persistent location indicator on and
         // wastes battery for no benefit (parity with the iOS #210 fix).
+        //
+        // Foreground service: only high-accuracy mode (continuous GPS) needs one.
+        // Standard geofence-only mode must NOT run a foreground service — the
+        // native Geofence API fires enter/exit while suspended/terminated without
+        // it, and Google Play prohibits using a foreground service *solely* for
+        // geofencing as of 2026-10-28. Starting an FGS here would make every
+        // geofence-only Tracelet app non-compliant. Any FGS left over from a
+        // previous continuous/high-accuracy session is torn down.
         if (configManager.getGeofenceModeHighAccuracy()) {
             geofenceManager.clearHighAccuracyState()
             locationEngine.start()
+            if (configManager.isForegroundServiceEnabled()) {
+                LocationService.start(context)
+            }
         } else {
             locationEngine.stop()
-        }
-
-        if (configManager.isForegroundServiceEnabled()) {
-            LocationService.start(context)
+            if (LocationService.isServiceRunning()) {
+                LocationService.stop(context)
+            }
         }
 
         eventSender.sendEnabledChange(true)

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/GeofenceForegroundServicePolicyTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/GeofenceForegroundServicePolicyTest.kt
@@ -1,0 +1,97 @@
+package com.ikolvi.tracelet.sdk
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.model.TrackingMode
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Google Play policy (effective 2026-10-28) prohibits using a foreground service
+ * *solely* for geofencing. Tracelet's standard geofence mode relies entirely on
+ * the native Geofence API (GeofencingClient), which fires enter/exit while
+ * suspended/terminated without a foreground service — so `startGeofences()` in
+ * standard mode must NOT start one, even when `foregroundService` is enabled
+ * (continuous tracking still uses the FGS; only geofence-only mode is affected).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GeofenceForegroundServicePolicyTest {
+
+    private lateinit var context: Context
+    private lateinit var sdk: TraceletSdk
+
+    @Before
+    fun setUp() {
+        org.robolectric.shadows.ShadowLog.stream = System.out
+        context = ApplicationProvider.getApplicationContext()
+
+        androidx.work.testing.WorkManagerTestInitHelper.initializeTestWorkManager(
+            context,
+            androidx.work.Configuration.Builder()
+                .setExecutor(androidx.work.testing.SynchronousExecutor())
+                .build(),
+        )
+
+        shadowOf(context as Application).grantPermissions(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+        )
+
+        sdk = TraceletSdk.getInstance(context)
+        sdk.setEventSender(ListenerEventSender())
+        sdk.initialize()
+    }
+
+    @After
+    fun tearDown() {
+        try { sdk.stop() } catch (_: Exception) {}
+        shadowOf(Looper.getMainLooper()).idle()
+        ConfigManager.resetInstance()
+    }
+
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
+
+    private fun drainStartedServices() {
+        val app = shadowOf(context as Application)
+        while (app.nextStartedService != null) { /* drain */ }
+    }
+
+    @Test
+    fun `standard geofence mode does not start a foreground service`() {
+        var ready = false
+        sdk.ready(
+            mapOf(
+                "fg_enabled" to true,
+                "geofenceModeHighAccuracy" to false,
+            ),
+        ) { ready = true }
+        idle()
+        assert(ready)
+
+        // Ignore anything ready() may have queued; we only care about
+        // startGeofences()'s behavior.
+        drainStartedServices()
+
+        sdk.startGeofences()
+        idle()
+
+        assertEquals(TrackingMode.GEOFENCES, sdk.stateManager.trackingMode)
+        assertNull(
+            shadowOf(context as Application).peekNextStartedService(),
+            "standard geofence-only mode must not start a foreground service " +
+                "(Google Play FGS-for-geofencing policy)",
+        )
+    }
+}

--- a/sdk/ios/CHANGELOG.md
+++ b/sdk/ios/CHANGELOG.md
@@ -3,6 +3,7 @@
 **FIX**: Enrich geofence transition events with real coordinate metrics (accuracy/speed/heading/altitude) from the last GPS fix and attach the battery snapshot, instead of hardcoded zeros ([#231](https://github.com/Ikolvi/Tracelet/issues/231)).
 **FIX**: Propagate runtime `setConfig` changes to the active native tracking/sensor loops by performing a clean full-pipeline restart (location + motion/speed) when a tracking-relevant key changes ([#230](https://github.com/Ikolvi/Tracelet/issues/230)).
 **FIX**: Null-guard subsystems in `destroyAll()` so engine/Activity teardown never throws when the SDK was never initialized (fatal `Unable to destroy activity`) ([#227](https://github.com/Ikolvi/Tracelet/issues/227)).
+**FIX**: Android: standard geofence mode no longer starts a foreground service, complying with Google Play's policy (effective 2026-10-28) that prohibits using a foreground service solely for geofencing. Native geofences keep firing while the app is suspended/terminated; geofence-only apps can remove `FOREGROUND_SERVICE_LOCATION` from their manifest.
 
 ## 3.5.3
 

--- a/website/app/en/core/geofencing/page.mdx
+++ b/website/app/en/core/geofencing/page.mdx
@@ -103,3 +103,66 @@ tl.Tracelet.onGeofence((evt) {
   }
 });
 ```
+
+---
+
+## 5. Android: foreground service & Google Play policy
+
+<Callout type="warning">
+**Google Play policy change — effective October 28, 2026.** Geofencing is no
+longer a permitted use case for foreground service location. Apps that use a
+foreground service **solely** for geofencing must remove the
+`FOREGROUND_SERVICE_LOCATION` (and `FOREGROUND_SERVICE`, if unused otherwise)
+permissions from their merged manifest.
+</Callout>
+
+Tracelet's **standard** geofence mode uses the native Android Geofence API
+(`GeofencingClient`), which fires ENTER/EXIT — and relaunches your app into your
+headless task — while the app is suspended or terminated, **without** a
+foreground service. Calling `startGeofences()` in standard mode does **not** start
+a foreground service (as of `3.5.x`), so it is compliant by default.
+
+### If you use Tracelet only for geofencing
+
+1. Do **not** enable the foreground service:
+
+   ```dart
+   await tl.Tracelet.ready(const tl.Config(
+     android: tl.AndroidConfig(
+       foregroundService: tl.ForegroundServiceConfig(enabled: false),
+     ),
+     geofence: tl.GeofenceConfig(geofenceModeHighAccuracy: false),
+   ));
+   await tl.Tracelet.startGeofences();
+   ```
+
+2. The Tracelet SDK declares `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_LOCATION`
+   for its continuous-tracking use case. If your app never does continuous
+   tracking, strip them from the merged manifest with the manifest-merger
+   `remove` rule in your app's `android/app/src/main/AndroidManifest.xml`:
+
+   ```xml
+   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools">
+       <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"
+           tools:node="remove" />
+       <uses-permission android:name="android.permission.FOREGROUND_SERVICE"
+           tools:node="remove" />
+   </manifest>
+   ```
+
+### If you use continuous tracking *and* geofencing
+
+You may keep `FOREGROUND_SERVICE_LOCATION` for the tracking use case (e.g.
+navigation/fleet tracking), but the foreground service must not be used for
+geofencing. Tracelet already handles this: the FGS runs for continuous tracking
+(`start()`), and switching to geofence-only mode (`startGeofences()` in standard
+mode) tears the FGS down.
+
+<Callout type="info">
+**High-accuracy geofence mode** (`geofenceModeHighAccuracy: true`) uses
+continuous GPS for tight, in-app boundary detection, which *does* run a
+foreground service. That is continuous location — not "geofencing" in the policy
+sense — so only enable it when your app has a separate permitted location use
+case. For most apps, standard mode is the compliant and battery-efficient choice.
+</Callout>

--- a/website/app/en/getting-started/platform-setup/android/page.mdx
+++ b/website/app/en/getting-started/platform-setup/android/page.mdx
@@ -65,7 +65,31 @@ Tracelet's native code is fully guarded with `checkSelfPermission()`. **Missing 
 | `SCHEDULE_EXACT_ALARM` | **Safe.** Periodic mode falls back to using battery-friendly, but inexact, WorkManager timers. |
 | `POST_NOTIFICATIONS` | **Safe.** The foreground service persistent notification is hidden on Android 13+. Service still runs. |
 | `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` | **Safe.** You won't be able to request battery optimization exemptions from the OS. |
+| `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_LOCATION` | **Safe for geofence-only / periodic-only apps.** Removing them disables continuous foreground tracking (`start()`), but standard geofencing and periodic mode keep working. **Required** for continuous background tracking. |
 | `ACCESS_FINE_LOCATION` / `COARSE` | **UNSAFE.** Without any location permission, Tracelet cannot obtain positions. |
+
+<Callout type="warning">
+**Google Play foreground-service policy (effective Oct 28, 2026).** Geofencing is
+no longer a permitted use case for foreground service location. If your app uses a
+foreground service **solely** for geofencing, you must remove
+`FOREGROUND_SERVICE_LOCATION` (and `FOREGROUND_SERVICE`) from your merged
+manifest. Tracelet's standard geofence mode uses the native Geofence API and does
+**not** start a foreground service, so geofence-only apps are compliant — just
+strip the permissions below and keep `foregroundService.enabled = false`. See the
+[Geofencing guide](/en/core/geofencing#5-android-foreground-service--google-play-policy)
+for details.
+</Callout>
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Geofence-only / periodic-only app: no continuous foreground tracking -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" tools:node="remove" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove" />
+
+</manifest>
+```
 
 #### Example: Removing Motion & Background Permissions
 


### PR DESCRIPTION
Addresses Google Play's policy change (effective **2026-10-28**): geofencing is no longer a permitted use case for foreground service location. Apps using a foreground service **solely** for geofencing must drop `FOREGROUND_SERVICE_LOCATION`/`FOREGROUND_SERVICE`.

## Code
Tracelet already uses the native Geofence API (`GeofencingClient`), but `startGeofences()` still started a foreground service in **standard** mode when `foregroundService` was enabled — making geofence-only apps non-compliant. Standard geofence mode now:
- starts **no** foreground service (native geofences fire enter/exit while suspended/terminated), and
- tears down any FGS left over from a previous continuous/high-accuracy session.

Only **high-accuracy** mode (continuous GPS) keeps the FGS — that's a separate permitted location use case.

iOS is unaffected (the policy is Google Play / Android, and iOS standard geofence mode already uses region monitoring without a background session — #210).

## Test
`GeofenceForegroundServicePolicyTest` — standard geofence mode starts no foreground service.

## Docs
- Geofencing guide: new "Android: foreground service & Google Play policy" section.
- Android platform-setup: permission-removal table row + warning callout + manifest-merger example for geofence-only apps.

## Changelog
Added the Android FGS bullet to the existing **3.5.4** entries across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
