### PR TITLE
feat(ios): add live location provider options

### DIFF
--- a/packages/tracelet/lib/src/tracelet.dart
+++ b/packages/tracelet/lib/src/tracelet.dart
@@ -569,6 +569,51 @@ class Tracelet {
     return _platform.changePace(isMoving);
   }
 
+  /// Temporarily overrides the active OS location-provider options.
+  ///
+  /// This is intended for short-lived acquisition policies such as reducing
+  /// iOS GPS power while the device is known to be stationary. It updates the
+  /// running provider without calling [stop] or [start]. The persisted [Config],
+  /// [activeConfig], and the accepted-point filtering pipeline are unchanged.
+  ///
+  /// Passing no arguments clears the override and restores the options from
+  /// [activeConfig]. The override is also cleared when tracking stops. Returns
+  /// `false` when tracking is not active or the platform does not support live
+  /// provider updates. Currently supported on iOS.
+  ///
+  /// [distanceFilter] must be finite and non-negative. A value of zero requests
+  /// all provider updates (`kCLDistanceFilterNone` on iOS).
+  ///
+  /// ```dart
+  /// await Tracelet.updateLocationProviderOptions(
+  ///   desiredAccuracy: DesiredAccuracy.medium,
+  ///   distanceFilter: 25,
+  /// );
+  ///
+  /// // Restore the configured provider options without restarting tracking.
+  /// await Tracelet.updateLocationProviderOptions();
+  /// ```
+  static Future<bool> updateLocationProviderOptions({
+    DesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  }) {
+    if (distanceFilter != null &&
+        (!distanceFilter.isFinite || distanceFilter < 0)) {
+      throw RangeError.value(
+        distanceFilter,
+        'distanceFilter',
+        'Must be finite and non-negative',
+      );
+    }
+
+    return _platform.updateLocationProviderOptions(
+      desiredAccuracy == null
+          ? null
+          : TlDesiredAccuracy.values[desiredAccuracy.index],
+      distanceFilter,
+    );
+  }
+
   /// Confirms a pending impact candidate ([ImpactEvent.id]) as a real
   /// emergency, firing its confirmed `crash`/`fall` event immediately.
   static Future<bool> confirmImpact(int id) {

--- a/packages/tracelet/test/tracelet_test.dart
+++ b/packages/tracelet/test/tracelet_test.dart
@@ -22,6 +22,56 @@ void main() {
     expect(restored.app.heartbeatInterval, 120);
   });
 
+  group('Tracelet runtime provider options', () {
+    late MockTraceletPlatform mockPlatform;
+
+    setUp(() {
+      mockPlatform = MockTraceletPlatform();
+      TraceletPlatform.instance = mockPlatform;
+    });
+
+    test(
+      'delegates temporary provider options without changing config',
+      () async {
+        final config = Tracelet.activeConfig;
+
+        final updated = await Tracelet.updateLocationProviderOptions(
+          desiredAccuracy: DesiredAccuracy.medium,
+          distanceFilter: 25,
+        );
+
+        expect(updated, isTrue);
+        expect(
+          mockPlatform.lastProviderDesiredAccuracy,
+          TlDesiredAccuracy.medium,
+        );
+        expect(mockPlatform.lastProviderDistanceFilter, 25);
+        expect(Tracelet.activeConfig, same(config));
+      },
+    );
+
+    test('no arguments clear the provider override', () async {
+      final updated = await Tracelet.updateLocationProviderOptions();
+
+      expect(updated, isTrue);
+      expect(mockPlatform.lastProviderDesiredAccuracy, isNull);
+      expect(mockPlatform.lastProviderDistanceFilter, isNull);
+    });
+
+    test('rejects invalid distance filters before calling the platform', () {
+      expect(
+        () => Tracelet.updateLocationProviderOptions(distanceFilter: -1),
+        throwsRangeError,
+      );
+      expect(
+        () =>
+            Tracelet.updateLocationProviderOptions(distanceFilter: double.nan),
+        throwsRangeError,
+      );
+      expect(mockPlatform.providerOptionsCallCount, 0);
+    });
+  });
+
   group('Tracelet Kalman Filter integration', () {
     late MockTraceletPlatform mockPlatform;
 
@@ -71,6 +121,10 @@ void main() {
 
 class MockTraceletPlatform extends TraceletPlatform
     with EmptyEventStreamsMixin {
+  TlDesiredAccuracy? lastProviderDesiredAccuracy;
+  double? lastProviderDistanceFilter;
+  int providerOptionsCallCount = 0;
+
   final Map<String, Object?> stateResult = {
     'enabled': false,
     'trackingMode': 0,
@@ -87,6 +141,17 @@ class MockTraceletPlatform extends TraceletPlatform
   @override
   Future<Map<String, Object?>> setConfig(TlConfig config) async {
     return Map<String, Object?>.from(stateResult);
+  }
+
+  @override
+  Future<bool> updateLocationProviderOptions(
+    TlDesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  ) async {
+    providerOptionsCallCount++;
+    lastProviderDesiredAccuracy = desiredAccuracy;
+    lastProviderDistanceFilter = distanceFilter;
+    return true;
   }
 }
 

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
@@ -3490,6 +3490,15 @@ interface TraceletHostApi {
   fun watchPosition(options: TlCurrentPositionOptions, callback: (Result<Long>) -> Unit)
   fun stopWatchPosition(watchId: Long, callback: (Result<Boolean>) -> Unit)
   fun changePace(isMoving: Boolean, callback: (Result<Boolean>) -> Unit)
+  /**
+   * Temporarily overrides active OS-provider acquisition options.
+   *
+   * This does not change the persisted Tracelet config or the Rust location
+   * processor. Passing null for both values clears the override and restores
+   * the configured provider options. Currently supported on iOS; other
+   * platforms return false.
+   */
+  fun updateLocationProviderOptions(desiredAccuracy: TlDesiredAccuracy?, distanceFilter: Double?, callback: (Result<Boolean>) -> Unit)
   /** Confirms a pending impact candidate (by [id]) as a real emergency now. */
   fun confirmImpact(id: Long): Boolean
   /** Cancels a pending impact candidate (by [id]) — no confirmed event fires. */
@@ -3834,6 +3843,27 @@ interface TraceletHostApi {
             val args = message as List<Any?>
             val isMovingArg = args[0] as Boolean
             api.changePace(isMovingArg) { result: Result<Boolean> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(TraceletApiPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(TraceletApiPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.updateLocationProviderOptions$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val desiredAccuracyArg = args[0] as TlDesiredAccuracy?
+            val distanceFilterArg = args[1] as Double?
+            api.updateLocationProviderOptions(desiredAccuracyArg, distanceFilterArg) { result: Result<Boolean> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(TraceletApiPigeonUtils.wrapError(error))

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -500,6 +500,17 @@ class TraceletHostApiImpl(
         } catch (e: Exception) { callback(Result.failure(e)) }
     }
 
+    override fun updateLocationProviderOptions(
+        desiredAccuracy: TlDesiredAccuracy?,
+        distanceFilter: Double?,
+        callback: (Result<Boolean>) -> Unit,
+    ) {
+        // Android LocationRequest instances cannot be mutated in place. Keep
+        // this API side-effect free until Android gets an independently tested
+        // callback-preserving re-subscription implementation.
+        callback(Result.success(false))
+    }
+
     override fun confirmImpact(id: Long): Boolean =
         if (sdk.isReady) sdk.confirmImpact(id) else false
 
@@ -1112,4 +1123,3 @@ class TraceletHostApiImpl(
         } catch (e: Exception) { callback(Result.failure(e)) }
     }
 }
-

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
@@ -3296,6 +3296,13 @@ protocol TraceletHostApi {
   func watchPosition(options: TlCurrentPositionOptions, completion: @escaping (Result<Int64, Error>) -> Void)
   func stopWatchPosition(watchId: Int64, completion: @escaping (Result<Bool, Error>) -> Void)
   func changePace(isMoving: Bool, completion: @escaping (Result<Bool, Error>) -> Void)
+  /// Temporarily overrides active OS-provider acquisition options.
+  ///
+  /// This does not change the persisted Tracelet config or the Rust location
+  /// processor. Passing null for both values clears the override and restores
+  /// the configured provider options. Currently supported on iOS; other
+  /// platforms return false.
+  func updateLocationProviderOptions(desiredAccuracy: TlDesiredAccuracy?, distanceFilter: Double?, completion: @escaping (Result<Bool, Error>) -> Void)
   /// Confirms a pending impact candidate (by [id]) as a real emergency now.
   func confirmImpact(id: Int64) throws -> Bool
   /// Cancels a pending impact candidate (by [id]) — no confirmed event fires.
@@ -3606,6 +3613,30 @@ class TraceletHostApiSetup {
       }
     } else {
       changePaceChannel.setMessageHandler(nil)
+    }
+    /// Temporarily overrides active OS-provider acquisition options.
+    ///
+    /// This does not change the persisted Tracelet config or the Rust location
+    /// processor. Passing null for both values clears the override and restores
+    /// the configured provider options. Currently supported on iOS; other
+    /// platforms return false.
+    let updateLocationProviderOptionsChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.updateLocationProviderOptions\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      updateLocationProviderOptionsChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let desiredAccuracyArg: TlDesiredAccuracy? = nilOrValue(args[0])
+        let distanceFilterArg: Double? = nilOrValue(args[1])
+        api.updateLocationProviderOptions(desiredAccuracy: desiredAccuracyArg, distanceFilter: distanceFilterArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      updateLocationProviderOptionsChannel.setMessageHandler(nil)
     }
     /// Confirms a pending impact candidate (by [id]) as a real emergency now.
     let confirmImpactChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.confirmImpact\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
@@ -447,6 +447,24 @@ class TraceletHostApiImpl: TraceletHostApi {
         completion(.success(result))
     }
 
+    func updateLocationProviderOptions(
+        desiredAccuracy: TlDesiredAccuracy?,
+        distanceFilter: Double?,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) {
+        guard sdk.isReadyState else {
+            completion(.failure(PigeonError(code: "NOT_READY", message: "Call ready() before updateLocationProviderOptions()", details: nil)))
+            return
+        }
+        let result = sdk.updateLocationProviderOptions(
+            desiredAccuracy: desiredAccuracy.flatMap {
+                TraceletDesiredAccuracy(rawValue: $0.rawValue)
+            },
+            distanceFilter: distanceFilter
+        )
+        completion(.success(result))
+    }
+
     func confirmImpact(id: Int64) throws -> Bool {
         return sdk.isReadyState ? sdk.confirmImpact(id) : false
     }

--- a/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
+++ b/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
@@ -4004,6 +4004,36 @@ class TraceletHostApi {
     return pigeonVar_replyValue! as bool;
   }
 
+  /// Temporarily overrides active OS-provider acquisition options.
+  ///
+  /// This does not change the persisted Tracelet config or the Rust location
+  /// processor. Passing null for both values clears the override and restores
+  /// the configured provider options. Currently supported on iOS; other
+  /// platforms return false.
+  Future<bool> updateLocationProviderOptions(
+    TlDesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  ) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.tracelet_platform_interface.TraceletHostApi.updateLocationProviderOptions$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[desiredAccuracy, distanceFilter],
+    );
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
+    return pigeonVar_replyValue! as bool;
+  }
+
   /// Confirms a pending impact candidate (by [id]) as a real emergency now.
   Future<bool> confirmImpact(int id) async {
     final pigeonVar_channelName =

--- a/packages/tracelet_platform_interface/lib/src/pigeon_tracelet.dart
+++ b/packages/tracelet_platform_interface/lib/src/pigeon_tracelet.dart
@@ -174,6 +174,12 @@ class PigeonTracelet extends TraceletPlatform {
   Future<bool> changePace(bool isMoving) => _api.changePace(isMoving);
 
   @override
+  Future<bool> updateLocationProviderOptions(
+    TlDesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  ) => _api.updateLocationProviderOptions(desiredAccuracy, distanceFilter);
+
+  @override
   Future<bool> confirmImpact(int id) => _api.confirmImpact(id);
 
   @override

--- a/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
+++ b/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
@@ -141,6 +141,17 @@ abstract class TraceletPlatform extends PlatformInterface {
     throw UnimplementedError('changePace() has not been implemented.');
   }
 
+  /// Temporarily overrides active OS-provider acquisition options.
+  ///
+  /// The override is provider-only: it does not mutate the persisted config or
+  /// the accepted-point filtering pipeline. Passing null for both values clears
+  /// the override. Platforms that do not support live provider updates return
+  /// `false`.
+  Future<bool> updateLocationProviderOptions(
+    TlDesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  ) async => false;
+
   /// Confirms a pending impact candidate as a real emergency.
   Future<bool> confirmImpact(int id) {
     throw UnimplementedError('confirmImpact() has not been implemented.');

--- a/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
+++ b/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
@@ -888,6 +888,18 @@ abstract class TraceletHostApi {
   @async
   bool changePace(bool isMoving);
 
+  /// Temporarily overrides active OS-provider acquisition options.
+  ///
+  /// This does not change the persisted Tracelet config or the Rust location
+  /// processor. Passing null for both values clears the override and restores
+  /// the configured provider options. Currently supported on iOS; other
+  /// platforms return false.
+  @async
+  bool updateLocationProviderOptions(
+    TlDesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  );
+
   /// Confirms a pending impact candidate (by [id]) as a real emergency now.
   bool confirmImpact(int id);
 

--- a/packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart
+++ b/packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart
@@ -146,6 +146,15 @@ class FakeHostApi extends TraceletHostApi {
   }
 
   @override
+  Future<bool> updateLocationProviderOptions(
+    TlDesiredAccuracy? desiredAccuracy,
+    double? distanceFilter,
+  ) async {
+    _record('updateLocationProviderOptions', [desiredAccuracy, distanceFilter]);
+    return true;
+  }
+
+  @override
   Future<double> getOdometer() async {
     _record('getOdometer');
     return 456.7;
@@ -814,6 +823,20 @@ void main() {
     test('changePace() delegates', () async {
       expect(await pigeon.changePace(true), true);
       expect(fakeApi.wasCalled('changePace'), true);
+    });
+
+    test('updateLocationProviderOptions() delegates typed values', () async {
+      expect(
+        await pigeon.updateLocationProviderOptions(
+          TlDesiredAccuracy.medium,
+          25,
+        ),
+        true,
+      );
+      expect(fakeApi.lastCallArgs('updateLocationProviderOptions'), [
+        TlDesiredAccuracy.medium,
+        25.0,
+      ]);
     });
 
     test('getOdometer() returns value', () async {

--- a/sdk/ios/Package.swift
+++ b/sdk/ios/Package.swift
@@ -33,7 +33,10 @@ let package = Package(
             path: "Tests/TraceletSDKTests",
             // Only the actively-maintained suite is wired up; the other files in
             // this directory are stale against the current SDK API.
-            sources: ["MotionDetectorTests.swift"]
+            sources: [
+                "LocationEngineRuntimeProviderOptionsTests.swift",
+                "MotionDetectorTests.swift",
+            ]
         ),
     ]
 )

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -856,6 +856,23 @@ public final class TraceletSdk {
         }
     }
 
+    /// Temporarily overrides the active Core Location acquisition policy.
+    ///
+    /// Unlike `setConfig`, this does not persist configuration, rebuild the
+    /// location processor, or restart the tracking pipeline. Passing nil for
+    /// both values restores the configured provider options.
+    @discardableResult
+    public func updateLocationProviderOptions(
+        desiredAccuracy: TraceletDesiredAccuracy?,
+        distanceFilter: Double?
+    ) -> Bool {
+        guard isReady else { return false }
+        return locationEngine.updateLocationProviderOptions(
+            desiredAccuracy: desiredAccuracy?.rawValue,
+            distanceFilter: distanceFilter
+        )
+    }
+
     /// Get the current odometer value in meters.
     public func getOdometer() -> Double {
         guard isReady else { return 0.0 }
@@ -3311,4 +3328,3 @@ private struct TelematicsSinkWrapper: LocationDataSink {
         return ""
     }
 }
-

--- a/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
+++ b/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
@@ -29,6 +29,13 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
     private var nextWatchId = 0
     public private(set) var isTracking = false
 
+    /// Temporary OS-provider overrides. These intentionally do not mutate
+    /// ConfigManager or the Rust accepted-point filter. They only control how
+    /// Core Location acquires and delivers fixes while continuous tracking is
+    /// active, and are cleared by stop().
+    private var runtimeDesiredAccuracy: Int?
+    private var runtimeDistanceFilter: Double?
+
     /// Background task ID for the current periodic fix request.
     /// Ended in didUpdateLocations/didFailWithError when periodic mode is active.
     private var periodicFixBgTaskId: UIBackgroundTaskIdentifier?
@@ -229,6 +236,8 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
         deactivateDeadReckoning()
         cancelGpsLossTimer()
         stopPeriodicTimer()
+        runtimeDesiredAccuracy = nil
+        runtimeDistanceFilter = nil
         
         if #available(iOS 17.0, *) {
             #if canImport(ActivityKit)
@@ -486,7 +495,37 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
         locationManager.showsBackgroundLocationIndicator = configManager.getShowsBackgroundLocationIndicator()
         locationManager.pausesLocationUpdatesAutomatically = configManager.getPausesLocationUpdatesAutomatically()
 
-        let accuracy = configManager.getDesiredAccuracy()
+        applyLocationProviderOptions()
+        locationManager.activityType = configManager.getActivityType()
+    }
+
+    /// Replaces the active, temporary provider override without stopping or
+    /// restarting Core Location. Passing nil for both values restores the
+    /// persisted provider options. Returns false when continuous tracking is
+    /// inactive or the distance filter is invalid.
+    @discardableResult
+    public func updateLocationProviderOptions(
+        desiredAccuracy: Int?,
+        distanceFilter: Double?
+    ) -> Bool {
+        guard isTracking, !isPeriodicTracking else { return false }
+        if let distanceFilter = distanceFilter,
+           (!distanceFilter.isFinite || distanceFilter < 0) {
+            return false
+        }
+
+        runtimeDesiredAccuracy = desiredAccuracy
+        runtimeDistanceFilter = distanceFilter
+        applyLocationProviderOptions()
+        return true
+    }
+
+    /// Applies only the location provider's live acquisition policy. Keeping
+    /// this separate from ConfigManager and LocationProcessor lets callers
+    /// throttle GPS acquisition temporarily without resetting track/odometer
+    /// continuity or changing which delivered points are accepted.
+    private func applyLocationProviderOptions() {
+        let accuracy = runtimeDesiredAccuracy ?? configManager.getDesiredAccuracy()
         switch accuracy {
         case 0: locationManager.desiredAccuracy = kCLLocationAccuracyBest
         case 1: locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
@@ -495,15 +534,13 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
         default: locationManager.desiredAccuracy = kCLLocationAccuracyBest
         }
 
-        let distanceFilter = configManager.getDistanceFilter()
+        let distanceFilter = runtimeDistanceFilter ?? configManager.getDistanceFilter()
         let isSpeedMode = configManager.getMotionDetectionMode() == .speed
         if isStopTimeoutActive {
             locationManager.distanceFilter = kCLDistanceFilterNone
         } else {
             locationManager.distanceFilter = (distanceFilter > 0 && !isSpeedMode) ? distanceFilter : kCLDistanceFilterNone
         }
-
-        locationManager.activityType = configManager.getActivityType()
     }
 
     private var activeStopTimeouts: Set<String> = []
@@ -533,9 +570,7 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
             }
             locationManager.distanceFilter = kCLDistanceFilterNone
         } else {
-            let distanceFilter = configManager.getDistanceFilter()
-            let isSpeedMode = configManager.getMotionDetectionMode() == .speed
-            locationManager.distanceFilter = (distanceFilter > 0 && !isSpeedMode) ? distanceFilter : kCLDistanceFilterNone
+            applyLocationProviderOptions()
         }
     }
 

--- a/sdk/ios/Tests/TraceletSDKTests/LocationEngineRuntimeProviderOptionsTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/LocationEngineRuntimeProviderOptionsTests.swift
@@ -1,0 +1,168 @@
+import CoreLocation
+import XCTest
+
+@testable import TraceletSDK
+
+final class LocationEngineRuntimeProviderOptionsTests: XCTestCase {
+
+    private func makeEngine() -> (LocationEngine, ConfigManager, RuntimeOptionsLocationManager) {
+        let config = ConfigManager()
+        config.reset(nil)
+        _ = config.setConfig([
+            "desiredAccuracy": 0,
+            "distanceFilter": 10.0,
+            "pausesLocationUpdatesAutomatically": false,
+        ])
+
+        let engine = LocationEngine(
+            configManager: config,
+            stateManager: StateManager(),
+            eventDispatcher: RuntimeOptionsEventSender()
+        )
+        let recorder = RuntimeOptionsLocationManager()
+        engine.locationManager = recorder
+        recorder.delegate = engine
+        return (engine, config, recorder)
+    }
+
+    func testAppliesLiveProviderOptionsWithoutRestartingCoreLocation() {
+        let (engine, _, recorder) = makeEngine()
+        engine.start()
+
+        XCTAssertEqual(recorder.startUpdatingCount, 1)
+        XCTAssertEqual(recorder.stopUpdatingCount, 0)
+
+        let updated = engine.updateLocationProviderOptions(
+            desiredAccuracy: 1,
+            distanceFilter: 25
+        )
+
+        XCTAssertTrue(updated)
+        XCTAssertEqual(recorder.desiredAccuracy, kCLLocationAccuracyHundredMeters)
+        XCTAssertEqual(recorder.distanceFilter, 25)
+        XCTAssertEqual(recorder.startUpdatingCount, 1)
+        XCTAssertEqual(recorder.stopUpdatingCount, 0)
+
+        engine.stop()
+    }
+
+    func testEmptyOptionsRestoreConfiguredProviderValues() {
+        let (engine, _, recorder) = makeEngine()
+        engine.start()
+        XCTAssertTrue(
+            engine.updateLocationProviderOptions(
+                desiredAccuracy: 1,
+                distanceFilter: 25
+            )
+        )
+
+        XCTAssertTrue(
+            engine.updateLocationProviderOptions(
+                desiredAccuracy: nil,
+                distanceFilter: nil
+            )
+        )
+
+        XCTAssertEqual(recorder.desiredAccuracy, kCLLocationAccuracyBest)
+        XCTAssertEqual(recorder.distanceFilter, 10)
+        XCTAssertEqual(recorder.startUpdatingCount, 1)
+        XCTAssertEqual(recorder.stopUpdatingCount, 0)
+
+        engine.stop()
+    }
+
+    func testStopClearsRuntimeProviderOverride() {
+        let (engine, _, recorder) = makeEngine()
+        engine.start()
+        XCTAssertTrue(
+            engine.updateLocationProviderOptions(
+                desiredAccuracy: 1,
+                distanceFilter: 25
+            )
+        )
+
+        engine.stop()
+        engine.start()
+
+        XCTAssertEqual(recorder.desiredAccuracy, kCLLocationAccuracyBest)
+        XCTAssertEqual(recorder.distanceFilter, 10)
+
+        engine.stop()
+    }
+
+    func testRejectsInvalidFilterAndInactiveTracking() {
+        let (engine, _, recorder) = makeEngine()
+
+        XCTAssertFalse(
+            engine.updateLocationProviderOptions(
+                desiredAccuracy: 1,
+                distanceFilter: 25
+            )
+        )
+
+        engine.start()
+        XCTAssertFalse(
+            engine.updateLocationProviderOptions(
+                desiredAccuracy: 1,
+                distanceFilter: -.infinity
+            )
+        )
+        XCTAssertEqual(recorder.desiredAccuracy, kCLLocationAccuracyBest)
+        XCTAssertEqual(recorder.distanceFilter, 10)
+
+        engine.stop()
+    }
+}
+
+private final class RuntimeOptionsLocationManager: CLLocationManager {
+    private var allowsBackground = false
+    private(set) var startUpdatingCount = 0
+    private(set) var stopUpdatingCount = 0
+
+    override var allowsBackgroundLocationUpdates: Bool {
+        get { allowsBackground }
+        set { allowsBackground = newValue }
+    }
+
+    override var authorizationStatus: CLAuthorizationStatus {
+        .authorizedAlways
+    }
+
+    override func startUpdatingLocation() {
+        startUpdatingCount += 1
+    }
+
+    override func stopUpdatingLocation() {
+        stopUpdatingCount += 1
+    }
+
+    override func startMonitoringSignificantLocationChanges() {}
+
+    override func stopMonitoringSignificantLocationChanges() {}
+}
+
+private final class RuntimeOptionsEventSender: TraceletEventSending {
+    func sendLocation(_ data: [String: Any]) {}
+    func sendMotionChange(_ data: [String: Any]) {}
+    func sendActivityChange(_ data: [String: Any]) {}
+    func sendProviderChange(_ data: [String: Any]) {}
+    func sendGeofence(_ data: [String: Any]) {}
+    func sendGeofencesChange(_ data: [String: Any]) {}
+    func sendHeartbeat(_ data: [String: Any]) {}
+    func sendHttp(_ data: [String: Any]) {}
+    func sendSchedule(_ data: [String: Any]) {}
+    func sendPowerSaveChange(_ isPowerSave: Bool) {}
+    func sendConnectivityChange(_ data: [String: Any]) {}
+    func sendEnabledChange(_ enabled: Bool) {}
+    func sendNotificationAction(_ data: [String: Any]) {}
+    func sendAuthorization(_ data: [String: Any]) {}
+    func sendWatchPosition(_ data: [String: Any]) {}
+    func sendRemoteConfigEvent(_ data: [String: Any]) {}
+    func sendTrip(_ data: [String: Any]) {}
+    func sendBudgetAdjustment(_ data: [String: Any]) {}
+    func sendSpeedMotionEvent(_ data: [String: Any]) {}
+    func sendDrivingEvent(_ data: [String: Any]) {}
+    func sendImpact(_ data: [String: Any]) {}
+    func sendModeChange(_ data: [String: Any]) {}
+    func hasListener(eventName: String) -> Bool { false }
+}

--- a/sdk/ios/Tests/TraceletSDKTests/MotionDetectorTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/MotionDetectorTests.swift
@@ -229,5 +229,8 @@ class DummyEventDispatcher: TraceletEventSending {
     func sendTrip(_ data: [String : Any]) {}
     func sendBudgetAdjustment(_ data: [String : Any]) {}
     func sendSpeedMotionEvent(_ data: [String : Any]) {}
+    func sendDrivingEvent(_ data: [String : Any]) {}
+    func sendImpact(_ data: [String : Any]) {}
+    func sendModeChange(_ data: [String : Any]) {}
     func hasListener(eventName: String) -> Bool { return false }
 }


### PR DESCRIPTION
### Summary

`Tracelet.setConfig()` is currently the only public way to change `desiredAccuracy` or `distanceFilter` while tracking. Since both are tracking-relevant keys, that path intentionally performs a clean full-pipeline restart (#230).

That behavior is correct for persistent configuration changes, but it makes short-lived iOS acquisition policies (for example, temporarily reducing Core Location accuracy during confirmed stationary periods) introduce an avoidable tracking gap.

This PR adds a separate live API:

```dart
await Tracelet.updateLocationProviderOptions(
  desiredAccuracy: DesiredAccuracy.medium,
  distanceFilter: 25,
);

// Restore the configured provider options.
await Tracelet.updateLocationProviderOptions();
```

### Root cause

`CLLocationManager.desiredAccuracy` and `CLLocationManager.distanceFilter` can be updated on the active manager, but the current Flutter API can only reach them through persisted Tracelet configuration.

Routing a temporary acquisition policy through `setConfig()` also changes more than the OS provider: it restarts the tracking pipeline and rebuilds processor state. A short-lived power policy should not need to stop/start Core Location or mutate the accepted-point filter.

### Implementation

- Adds a typed Pigeon API and public `Tracelet.updateLocationProviderOptions(...)` wrapper.
- Applies temporary overrides directly to the active iOS `CLLocationManager`.
- Keeps persisted `Config`, `activeConfig`, and the Rust accepted-point filtering pipeline unchanged.
- Passing no arguments restores the configured provider values.
- `stop()` clears the temporary override.
- Returns `false` when continuous tracking is inactive, periodic mode is active, or the platform does not support a live update.
- Android intentionally returns `false`: its `LocationRequest` is immutable, and a callback-preserving re-subscription needs separate Android design and testing.

### Verified

- `dart analyze packages/tracelet/lib packages/tracelet_platform_interface/lib packages/tracelet/test/tracelet_test.dart packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart`
- `flutter test test/pigeon_tracelet_test.dart` (81 tests)
- `flutter test test/tracelet_test.dart --plain-name "Tracelet runtime provider options"` (3 tests)
- `flutter test` in both `packages/tracelet_ios` and `packages/tracelet_android`
- `xcodebuild test -scheme TraceletSDK -destination <iOS Simulator>` (10 tests)
- Native regression coverage verifies the live update does not call `stopUpdatingLocation()` or call `startUpdatingLocation()` again, restores configured values, rejects invalid filters, and clears overrides on stop.

### Separate, not included in this PR

- Automatic stationary detection, battery thresholds, and recovery state machines remain app-level policy.
- This does not change persisted Tracelet configuration or Rust-side accepted-point filtering.
- Android live provider updates are deliberately out of scope.
- The `tracelet_sync` AGP compatibility issue in #239 is separate and is already released in `tracelet_sync` 3.5.7.
