### PR TITLE
fix(ios): use effective activity (fused mode) in buildLocationMap instead of hardcoded "unknown"

### DIFF
--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -1887,8 +1887,9 @@ public final class TraceletSdk {
         }
         // Keep the LocationEngine's activity in sync so enriched locations don't
         // report a permanent "unknown" (#155).
-        motionDetector.onActivityChanged = { [weak self] type, _ in
+        motionDetector.onActivityChanged = { [weak self] type, confidence in
             self?.locationEngine.currentActivityType = type
+            self?.locationEngine.currentActivityConfidence = confidence
         }
         // 3.3.0: feed accelerometer samples (g) to the classifier/impact keystone.
         motionDetector.onAccelSample = { [weak self] magnitudeG in
@@ -2377,6 +2378,7 @@ public final class TraceletSdk {
             // #214 pt3: keep the engine's fused mode fresh every window so it can be
             // persisted into the location's activity column when authoritative.
             locationEngine?.fusedTransportMode = String(describing: result.mode).lowercased()
+            locationEngine?.fusedTransportModeConfidence = result.confidence
             if result.changed {
                 eventSender.sendModeChange([
                     "mode": String(describing: result.mode).lowercased(),

--- a/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
+++ b/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
@@ -131,11 +131,18 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
     /// Current activity type — set by MotionDetector for DR algorithm selection.
     public var currentActivityType: String = "unknown"
 
+    /// Confidence (0–100) of `currentActivityType`, from the platform Activity
+    /// Recognition. -1 when unknown/unset.
+    public var currentActivityConfidence: Int = -1
+
     /// Latest fused transport mode (e.g. "driving") from the transport classifier,
     /// kept fresh by the SDK. When `fusedClassifierAuthoritative` is enabled it
     /// becomes the persisted `activity.type`, so the classified mode survives
     /// process termination and syncs historically (#214 part 3).
     public var fusedTransportMode: String?
+
+    /// Confidence (0.0–1.0) of `fusedTransportMode`, kept fresh alongside it.
+    public var fusedTransportModeConfidence: Double = 0
 
     /// The activity type to persist/dispatch: the fused transport mode when the
     /// classifier is authoritative (and available), otherwise the raw AR activity.
@@ -144,6 +151,16 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
             return fusedTransportMode ?? currentActivityType
         }
         return currentActivityType
+    }
+
+    /// The activity confidence to persist/dispatch (0–100), matching
+    /// `effectiveActivityType()`: the fused mode confidence (scaled from 0.0–1.0)
+    /// when authoritative and available, otherwise the platform AR confidence.
+    private func effectiveActivityConfidence() -> Int {
+        if configManager.getFusedClassifierAuthoritative(), fusedTransportMode != nil {
+            return Int((fusedTransportModeConfidence * 100).rounded())
+        }
+        return currentActivityConfidence
     }
 
     public init(configManager: ConfigManager,
@@ -1315,7 +1332,7 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
                 // even with fusedClassifierAuthoritative=true (the dead-reckoning
                 // path below already did this; buildLocationMap was missed).
                 "type": effectiveActivityType(),
-                "confidence": -1,
+                "confidence": effectiveActivityConfidence(),
             ],
             "battery": battery,
             "event": "",

--- a/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
+++ b/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
@@ -1308,7 +1308,13 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
             "mock": mock,
             "mockHeuristics": mockHeuristics as Any,
             "activity": [
-                "type": "unknown",
+                // #214 pt3: use the effective activity — the fused transport mode
+                // when the classifier is authoritative (falls back to the platform
+                // Activity Recognition value). Previously hardcoded "unknown", so
+                // every persisted/dispatched location dropped the classified mode
+                // even with fusedClassifierAuthoritative=true (the dead-reckoning
+                // path below already did this; buildLocationMap was missed).
+                "type": effectiveActivityType(),
                 "confidence": -1,
             ],
             "battery": battery,


### PR DESCRIPTION
## Problem

On iOS, `LocationEngine.buildLocationMap(_:)` hardcodes the activity field:

```swift
"activity": [
    "type": "unknown",
    "confidence": -1,
],
```

`buildLocationMap` builds **every** location that is persisted to the DB and dispatched (real-time + `getLocations()`), so every iOS location ends up with `activity.type == "unknown"` regardless of the classifier — even when:

- `ClassifierConfig.enableFusedClassifier = true` **and** `fusedClassifierAuthoritative = true`, and
- the fused classifier is emitting confident modes via `onModeChange` (observed `vehicle` at confidence 0.95, `walking`/`cycling`/`still` at 0.70–0.85).

So the classified transport mode reaches the `onModeChange` event stream but never the per-point `activity` column that consumers read back from the location store.

## Root cause

`effectiveActivityType()` already exists to return the fused transport mode when authoritative (falling back to the platform Activity Recognition value), and the **dead-reckoning** path already uses it (the `#214 pt3` block later in the same file). `buildLocationMap` — the main path — was never routed through it and kept the hardcoded `"unknown"`. The confidence was likewise never populated: the `onActivityChanged` callback dropped the AR confidence (`type, _`), and the fused `result.confidence` was never stored.

## Fix

1. `buildLocationMap` now uses `effectiveActivityType()` for `activity.type`, matching the dead-reckoning path.
2. Added a matching `effectiveActivityConfidence()` and populate `activity.confidence` (0–100) instead of hardcoded `-1`: the fused mode confidence (scaled from 0.0–1.0) when authoritative and available, otherwise the platform AR confidence.
3. Wired the two confidence sources into `LocationEngine`: forward the AR confidence from `onActivityChanged` (was discarded), and keep `fusedTransportModeConfidence` fresh next to `fusedTransportMode` in the classifier window.

With `fusedClassifierAuthoritative = true` the per-point `activity` now carries the fused kinematic mode + confidence (works even where CMMotionActivity is unavailable, and — per the existing `#214 pt3` intent — the persisted value survives termination); otherwise it falls back to the platform Activity Recognition value as before.

## How it was found

Field data from a dual-tracking evaluation: iOS devices showed `activity` 100% `unknown` across all persisted locations while the `onModeChange` stream carried confident modes at the same timestamps. Android was unaffected (separate `buildLocationMap`), which pointed straight at the iOS builder.

## Scope

iOS only. The Android `buildLocationMap` populates activity from Activity Recognition already; if you want `fusedClassifierAuthoritative` honored symmetrically there too, happy to follow up in a separate PR.
