### PR TITLE
fix(ios): heartbeat writer duplicates location rows (getLocations returns them twice)

### DIFF
--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -1209,11 +1209,17 @@ public final class TraceletSdk {
             }
         }
         
-        // Prevent duplicate insertions of the exact same GPS fix
-        if eventType == "location", let ts = timestamp, ts == lastInsertedTimestamp {
+        // Prevent duplicate insertions of the exact same GPS fix. The heartbeat
+        // writer (startHeartbeat) tags the last GPS fix with event="heartbeat"
+        // and calls insertLocation too, so it must share the location writer's
+        // dedup key. Otherwise a fix already persisted by the normal dispatch is
+        // re-inserted by the heartbeat (identical timestamp), producing
+        // byte-identical duplicate rows that getLocations() then returns twice.
+        let persistsGpsFix = eventType == "location" || eventType == "heartbeat"
+        if persistsGpsFix, let ts = timestamp, ts == lastInsertedTimestamp {
             return ""
         }
-        if eventType == "location" { lastInsertedTimestamp = timestamp }
+        if persistsGpsFix { lastInsertedTimestamp = timestamp }
         
         var routeContext = rustEngineState?.getRouteContext()
 


### PR DESCRIPTION
## Problem

On iOS, the same GPS fix can be persisted twice, so `getLocations()` returns byte-identical duplicate location rows. Observed on-device across multiple iPhones running 3.6.0: roughly **half the points of a moving trip are duplicated** (adjacent, identical timestamp/coords/activity).

## Root cause

Two writers persist locations with two independent, non-cross-checking dedup states:

1. **Normal dispatch** calls `insertLocation` with `event="location"`. The guard dedups only for that event type (`TraceletSdk.swift`):
   ```swift
   if eventType == "location", let ts = timestamp, ts == lastInsertedTimestamp { return "" }
   if eventType == "location" { lastInsertedTimestamp = timestamp }
   ```
2. **Heartbeat timer** (`startHeartbeat`) builds a map from `getLastGpsLocation()`, sets `locationMap["event"] = "heartbeat"`, and calls `insertLocation` too:
   ```swift
   locationMap["event"] = "heartbeat"
   ...
   if fixTime != self.lastHeartbeatLocationTime {
       self.lastHeartbeatLocationTime = fixTime
       let _ = self.insertLocation(locationMap)
   }
   ```

Because the heartbeat map's `eventType` is `"heartbeat"`, the `eventType == "location"` guard is skipped: the fix already stored by the normal dispatch is inserted a second time. `lastInsertedTimestamp` and `lastHeartbeatLocationTime` don't cross-check, so every fix that coincides with a heartbeat tick becomes a duplicate row. (This is the iOS analogue of the Android-only #248/#249 double-insert fix, but a distinct path — here no `UNIQUE` constraint fires, so the duplicate row is actually stored.)

## Fix

Extend the dedup guard so both writers share one last-inserted-timestamp key:

```swift
let persistsGpsFix = eventType == "location" || eventType == "heartbeat"
if persistsGpsFix, let ts = timestamp, ts == lastInsertedTimestamp { return "" }
if persistsGpsFix { lastInsertedTimestamp = timestamp }
```

Heartbeat still persists genuinely new stationary fixes (its own `lastHeartbeatLocationTime` guard is unchanged, and a new fix has a timestamp that differs from `lastInsertedTimestamp`); it just no longer re-inserts a fix the normal path already stored.

## Testing

The dedup lives on `TraceletSdk.insertLocation` (which needs the Rust DB), while the existing `TraceletSdkTests` cover `DatabaseManager.insertLocation` directly, so this path isn't exercised by the current suite. The change is minimal and doesn't alter behavior for any non-heartbeat event. Happy to add coverage if you can point me at the preferred way to stand up a `TraceletSdk` with an in-memory store in tests.