### PR TITLE
fix(android): initialize SDK off the main thread to avoid ANR on plugin attach

### DIFF
--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -291,7 +291,34 @@ class TraceletSdk private constructor(private val context: Context) {
         check(::eventSender.isInitialized) {
             "setEventSender() must be called before initialize()"
         }
+        // Run the heavy setup — which opens the Rust DB and fsyncs it to disk —
+        // off the calling thread. onAttachedToEngine runs on the platform main
+        // thread; when a background FlutterEngine (e.g. audio_service's
+        // MediaBrowserService, spun up by the system after the app was killed)
+        // attaches, GeneratedPluginRegistrant re-attaches this plugin and this
+        // init would otherwise fsync on that service's main thread → ANR on a
+        // large DB. ready() blocks on initCompleteLatch before it uses the DB or
+        // the engines set up here.
+        synchronized(initLock) {
+            if (initStarted) return
+            initStarted = true
+        }
+        Thread({
+            try {
+                initializeInternal()
+            } catch (t: Throwable) {
+                logger.error("initializeInternal failed: ${t.message}")
+            } finally {
+                initCompleteLatch.countDown()
+            }
+        }, "tracelet-init").start()
+    }
 
+    private val initLock = Any()
+    @Volatile private var initStarted = false
+    private val initCompleteLatch = java.util.concurrent.CountDownLatch(1)
+
+    private fun initializeInternal() {
         // Bootstrap factory for headless/boot restart
         TraceletBootstrap.eventSenderFactory = { ctx ->
             getInstance(ctx).getEventSender()
@@ -587,6 +614,12 @@ class TraceletSdk private constructor(private val context: Context) {
      * @param callback Receives the current state map when ready.
      */
     fun ready(config: Map<String, Any?>, callback: (Map<String, Any?>) -> Unit) {
+        // initialize() opens the DB and wires the engines on a background thread
+        // (see its comment). Block until that finishes, otherwise completeReady()
+        // would touch not-yet-initialized lateinit engines.
+        if (!initCompleteLatch.await(15, java.util.concurrent.TimeUnit.SECONDS)) {
+            logger.error("ready() proceeded before initialize() finished (15s timeout)")
+        }
         val merged = configManager.setConfig(config)
 
         if (merged["encryptDatabase"] == true) {


### PR DESCRIPTION
## Problem

`TraceletSdk.initialize()` opens the Rust `DatabaseManager`, which `fsync`s to disk. It is called **synchronously** from `TraceletAndroidPlugin.onAttachedToEngine`, which runs on the platform **main thread**.

Android's `FlutterLoader` re-attaches every plugin (via `GeneratedPluginRegistrant`) to **any** `FlutterEngine` that gets created. So when a background engine is spun up — in our case `audio_service`'s `MediaBrowserService`, which the system can (re)create after the app is swiped away — `onAttachedToEngine` runs again and `initialize()` `fsync`s on **that service's main thread**. On a database that has grown over days of tracking, this blocks the main thread past the 5s ANR threshold.

Observed in production (Crashlytics ANR), read bottom-up:

```
main (native): fsync
  DatabaseManager.<init>  (uniffi_tracelet_core_fn_constructor_databasemanager_new)
  TraceletSdk.initialize
  TraceletAndroidPlugin.onAttachedToEngine
  GeneratedPluginRegistrant.registerWith
  FlutterEngine.<init>
  AudioServicePlugin.getFlutterEngine
  AudioService.onCreate
```

The `isPrimaryCandidate` guard (ISSUE 136) does **not** prevent this: when the app was killed, `primaryInstance == null`, so the audio service's engine *is* the primary candidate and runs the full init.

## Fix

- `initialize()` now runs the heavy setup (`initializeInternal()`) on a background thread (`"tracelet-init"`), guarded to run once via `initStarted`.
- `ready()` blocks on a `CountDownLatch` (15s cap) before it touches the DB / engines, so tracking-startup ordering is preserved.
- The init body is only **extracted** into `initializeInternal()` — unchanged otherwise.

Net effect: the plugin-attach path no longer does blocking disk I/O on the main thread, while `ready()` still sees a fully-initialized SDK.

## Review notes

- `initialize()` is now **once-per-process** via `initStarted`. If any teardown path is expected to re-run `initialize()`, it should reset `initStarted` + the latch — happy to wire that up if you point me at it.
- The three new fields are declared right after `initialize()` to keep the diff cohesive; can move them to the top of the class if you prefer.
- Not unit-tested (threading + native DB); verified by inspection. Manual repro: kill the app, let the system revive the audio/media service, confirm no ANR on a large DB.
