### PR TITLE
feat(android): add requestTermination for headless isolate GPS shutdown

### DIFF
--- a/packages/tracelet/lib/src/tracelet.dart
+++ b/packages/tracelet/lib/src/tracelet.dart
@@ -271,6 +271,24 @@ class Tracelet {
     return _stateFromMap(result);
   }
 
+  /// Request the native service to terminate from a headless isolate.
+  ///
+  /// Unlike [stop], this uses the headless MethodChannel directly,
+  /// so it works from FCM background handlers where Pigeon is unavailable.
+  /// Returns whether the native service acknowledged the request.
+  /// No [State] is returned since Pigeon is unavailable in headless isolates.
+  ///
+  /// Android only. On iOS, returns `false` (headless architecture differs).
+  static Future<bool> requestTermination() async {
+    try {
+      const channel = MethodChannel('com.tracelet/methods');
+      final result = await channel.invokeMethod<bool>('requestTermination');
+      return result ?? false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
   /// Start geofence-only tracking mode.
   ///
   /// The plugin will only monitor geofences without continuous location

--- a/packages/tracelet/test/request_termination_test.dart
+++ b/packages/tracelet/test/request_termination_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet/tracelet.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.tracelet/methods');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('requestTermination', () {
+    test('returns true when native service acknowledges', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            expect(call.method, 'requestTermination');
+            return true;
+          });
+
+      expect(await Tracelet.requestTermination(), isTrue);
+    });
+
+    test('returns false on MissingPluginException (iOS)', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            throw MissingPluginException('No implementation');
+          });
+
+      expect(await Tracelet.requestTermination(), isFalse);
+    });
+
+    test('returns false when channel returns null', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async => null);
+
+      expect(await Tracelet.requestTermination(), isFalse);
+    });
+  });
+}

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessTaskService.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessTaskService.kt
@@ -328,6 +328,14 @@ class HeadlessTaskService(
                                 syncBodyLatch?.countDown()
                                 result.success(true)
                             }
+                            "requestTermination" -> {
+                                try {
+                                    TraceletSdk.getInstance(context).stop()
+                                    result.success(true)
+                                } catch (e: Exception) {
+                                    result.error("STOP_FAILED", e.message, null)
+                                }
+                            }
                             else -> result.notImplemented()
                         }
                     }


### PR DESCRIPTION
## Summary

- Add `"requestTermination"` handler to `HeadlessTaskService.kt` methods channel, calling `TraceletSdk.getInstance(context).stop()` with try/catch error handling
- Add `Tracelet.requestTermination()` static method that invokes the headless MethodChannel directly, with `MissingPluginException` catch for iOS graceful fallback
- Add unit tests for the new method (success, iOS fallback, null response)
- Android only — iOS headless architecture differs and is out of scope

Closes #267

## Why

When an FCM silent push triggers a background task (e.g. auto-punchout) while the app is killed, the background handler cannot stop `TraceletEngine` because `Tracelet.stop()` uses Pigeon which doesn't work from headless isolates. The GPS foreground service keeps running, draining battery until the user manually opens the app.

`requestTermination()` uses the existing `com.tracelet/methods` MethodChannel (same one used by `setDynamicHeaders` and `setSyncBodyResponse`) which IS available in headless isolates, routing directly to the native `TraceletSdk.stop()`.

## Usage

```dart
// In FCM background handler or other headless isolate:
final stopped = await Tracelet.requestTermination();
// Returns true if native service acknowledged, false on iOS or failure
```

## Test plan

- [x] Unit tests for `Tracelet.requestTermination()` (3 cases: success, MissingPluginException, null)
- [ ] Verify Kotlin compiles via CI Gradle build
- [ ] `melos run analyze` clean on `packages/tracelet`
- [ ] `melos run test` passes
- [ ] Manual test: trigger FCM silent push while app killed, verify GPS service stops
- [ ] Verify iOS gracefully returns `false` (no crash)