### PR TITLE
fix(android): await init on every boot/broadcast entry point (geofenceManager lateinit crash, regression from #260)

### DIFF
--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -291,7 +291,34 @@ class TraceletSdk private constructor(private val context: Context) {
         check(::eventSender.isInitialized) {
             "setEventSender() must be called before initialize()"
         }
+        // Run the heavy setup — which opens the Rust DB and fsyncs it to disk —
+        // off the calling thread. onAttachedToEngine runs on the platform main
+        // thread; when a background FlutterEngine (e.g. audio_service's
+        // MediaBrowserService, spun up by the system after the app was killed)
+        // attaches, GeneratedPluginRegistrant re-attaches this plugin and this
+        // init would otherwise fsync on that service's main thread → ANR on a
+        // large DB. ready() blocks on initCompleteLatch before it uses the DB or
+        // the engines set up here.
+        synchronized(initLock) {
+            if (initStarted) return
+            initStarted = true
+        }
+        Thread({
+            try {
+                initializeInternal()
+            } catch (t: Throwable) {
+                logger.error("initializeInternal failed: ${t.message}")
+            } finally {
+                initCompleteLatch.countDown()
+            }
+        }, "tracelet-init").start()
+    }
 
+    private val initLock = Any()
+    @Volatile private var initStarted = false
+    private val initCompleteLatch = java.util.concurrent.CountDownLatch(1)
+
+    private fun initializeInternal() {
         // Bootstrap factory for headless/boot restart
         TraceletBootstrap.eventSenderFactory = { ctx ->
             getInstance(ctx).getEventSender()
@@ -587,6 +614,12 @@ class TraceletSdk private constructor(private val context: Context) {
      * @param callback Receives the current state map when ready.
      */
     fun ready(config: Map<String, Any?>, callback: (Map<String, Any?>) -> Unit) {
+        // initialize() opens the DB and wires the engines on a background thread
+        // (see its comment). Block until that finishes, otherwise completeReady()
+        // would touch not-yet-initialized lateinit engines.
+        if (!initCompleteLatch.await(15, java.util.concurrent.TimeUnit.SECONDS)) {
+            logger.error("ready() proceeded before initialize() finished (15s timeout)")
+        }
         val merged = configManager.setConfig(config)
 
         if (merged["encryptDatabase"] == true) {

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -307,7 +307,12 @@ class TraceletSdk private constructor(private val context: Context) {
             try {
                 initializeInternal()
             } catch (t: Throwable) {
-                logger.error("initializeInternal failed: ${t.message}")
+                // Record the failure so awaitInit() reports it instead of
+                // letting callers dereference half-wired lateinit managers and
+                // crash later with a misleading UninitializedPropertyAccessException.
+                // Log the full stacktrace, not just the message.
+                initFailed = true
+                logger.error("initializeInternal failed: ${t.stackTraceToString()}")
             } finally {
                 initCompleteLatch.countDown()
             }
@@ -316,7 +321,29 @@ class TraceletSdk private constructor(private val context: Context) {
 
     private val initLock = Any()
     @Volatile private var initStarted = false
+    @Volatile private var initFailed = false
     private val initCompleteLatch = java.util.concurrent.CountDownLatch(1)
+
+    /**
+     * Blocks until [initializeInternal] has finished wiring the subsystems
+     * (Rust DB, engines, geofenceManager). Every entry point that touches those
+     * lateinit managers synchronously — ready() and the native boot / broadcast
+     * paths — must call this after ensuring initialize() has been kicked off,
+     * otherwise it risks reading an unassigned lateinit while the background
+     * "tracelet-init" thread is still running.
+     *
+     * @return true if init completed (subsystems are safe to touch), false on
+     * timeout or init failure — callers on paths that dereference lateinit
+     * managers should bail instead of proceeding when this returns false.
+     */
+    internal fun awaitInit(): Boolean {
+        val done = initCompleteLatch.await(30, java.util.concurrent.TimeUnit.SECONDS)
+        if (!done) {
+            logger.error("awaitInit() timed out — subsystems still unset")
+            return false
+        }
+        return !initFailed
+    }
 
     private fun initializeInternal() {
         // Bootstrap factory for headless/boot restart
@@ -615,10 +642,14 @@ class TraceletSdk private constructor(private val context: Context) {
      */
     fun ready(config: Map<String, Any?>, callback: (Map<String, Any?>) -> Unit) {
         // initialize() opens the DB and wires the engines on a background thread
-        // (see its comment). Block until that finishes, otherwise completeReady()
-        // would touch not-yet-initialized lateinit engines.
-        if (!initCompleteLatch.await(15, java.util.concurrent.TimeUnit.SECONDS)) {
-            logger.error("ready() proceeded before initialize() finished (15s timeout)")
+        // (see its comment). Ensure it has been kicked off (idempotent via the
+        // initStarted guard) then block until it finishes, otherwise
+        // completeReady() would touch not-yet-initialized lateinit engines. Kept
+        // consistent with bootstrapForBackground so ready() never depends on an
+        // external ordering guarantee for who called initialize() first.
+        initialize()
+        if (!awaitInit()) {
+            logger.error("ready() proceeding without a completed initialize() — startup may be degraded")
         }
         val merged = configManager.setConfig(config)
 
@@ -1280,8 +1311,26 @@ class TraceletSdk private constructor(private val context: Context) {
         if (!::eventSender.isInitialized) {
             setEventSender(sender)
         }
-        if (rustDatabase == null) {
-            initialize()
+        // The boot / task-removal path (LocationService.onStartCommand →
+        // startBootTracking) reads lateinit managers (geofenceManager,
+        // locationEngine) as soon as this returns. Since initialize() runs its
+        // heavy setup on the background "tracelet-init" thread, we must wait for
+        // it to finish here — otherwise the service touches an unassigned
+        // lateinit and crashes in onStartCommand ("lateinit property
+        // geofenceManager has not been initialized"). Do NOT gate on
+        // `rustDatabase == null`: rustDatabase is assigned early inside
+        // initializeInternal, well before geofenceManager, so that check can
+        // pass while the managers are still unset. initialize() is idempotent
+        // (initStarted guard), so calling it unconditionally both starts init
+        // when this is the first entry point and joins an in-flight init begun
+        // by an engine attach; awaitInit() then blocks until it completes.
+        initialize()
+        if (!awaitInit()) {
+            // Init did not finish (timeout / failure): the managers this path
+            // and its caller (startBootTracking) read are still unset. Bail
+            // rather than dereference them and crash the service.
+            logger.error("bootstrapForBackground: init not ready — skipping background bootstrap")
+            return
         }
         // Initialize the behavior engines (telematics / transport / crash-fall) in
         // the background process too. Without this they stay null after a reboot or

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/receiver/CrashConfirmReceiver.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/receiver/CrashConfirmReceiver.kt
@@ -59,8 +59,15 @@ class CrashConfirmReceiver : BroadcastReceiver() {
                 val sender = TraceletBootstrap.eventSenderFactory?.invoke(context)
                     ?: ListenerEventSender()
                 sdk.setEventSender(sender)
+                // initialize() now wires subsystems on a background thread and
+                // returns immediately; wait for it before re-delivering, otherwise
+                // deliverConfirmedImpact touches unset lateinit state and throws again.
                 sdk.initialize()
-                sdk.deliverConfirmedImpact(candidate)
+                if (sdk.awaitInit()) {
+                    sdk.deliverConfirmedImpact(candidate)
+                } else {
+                    TraceletLog.warning("CrashConfirm: SDK init not ready — impact delivery skipped")
+                }
             }
         } catch (e: Exception) {
             TraceletLog.error("CrashConfirm alarm: failed to deliver confirmed impact — ${e.message}")

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/receiver/GeofenceBroadcastReceiver.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/receiver/GeofenceBroadcastReceiver.kt
@@ -49,8 +49,12 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                     val sender = TraceletBootstrap.eventSenderFactory?.invoke(context)
                         ?: ListenerEventSender()
                     sdk.setEventSender(sender)
+                    // initialize() wires geofenceManager on a background thread and
+                    // returns immediately; wait for it before reading the lateinit,
+                    // otherwise this throws again, the transition is dropped, and a
+                    // cold-boot geofence enter/exit (a trip start) is silently lost.
                     sdk.initialize()
-                    sdk.geofenceManager
+                    if (sdk.awaitInit()) sdk.geofenceManager else null
                 }
             } catch (e: Exception) {
                 TraceletLog.error("Failed to bootstrap SDK: ${e.message}")

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -1149,11 +1149,18 @@ class LocationService : Service(), DefaultLifecycleObserver {
             // Geofence mode: re-register persisted geofences with Play Services
             // and restore the static BroadcastReceiver reference so transition
             // events are not silently dropped after process death.
-            val geoManager = sdk.geofenceManager
-            if (trackingMode == TrackingMode.GEOFENCES) {
-                geoManager.reRegisterAll()
+            // Guard: initialize() wires geofenceManager on a background thread, so
+            // in the pathological case where it hasn't finished (awaitInit timeout)
+            // reading the lateinit here would crash the service — skip instead.
+            if (sdk.awaitInit()) {
+                val geoManager = sdk.geofenceManager
+                if (trackingMode == TrackingMode.GEOFENCES) {
+                    geoManager.reRegisterAll()
+                }
+                GeofenceBroadcastReceiver.geofenceManager = geoManager
+            } else {
+                TraceletLog.warning("boot: SDK init not ready — skipping geofence re-registration")
             }
-            GeofenceBroadcastReceiver.geofenceManager = geoManager
 
             // Wire the location stream into proximity evaluation. Without this,
             // geofenceModeHighAccuracy — which suppresses OS-level geofence


### PR DESCRIPTION
## Problem

Regression from #260 (moving `initialize()` off the main thread). Since that change, `TraceletSdk.initialize()` runs its heavy setup — opening the Rust `DatabaseManager` and wiring the `lateinit` managers (`geofenceManager`, `locationEngine`, …) — on a background `tracelet-init` thread and returns immediately. Entry points that were synchronous before, and that dereference those managers right after calling `initialize()`, now race that thread.

Observed in production (Android, fatal):

```
Fatal Exception: lateinit property geofenceManager has not been initialized
  at TraceletSdk.getGeofenceManager
  at LocationService.startBootTracking
  at LocationService.onStartCommand
```

…with the `tracelet-init` thread still inside `initializeInternal()` at crash time.

`ready()` already waited on the init latch, but the **native boot / broadcast paths do not go through `ready()`**, so they were unguarded.

## Affected call sites

- **`LocationService.startBootTracking`** → `bootstrapForBackground()` was gated only on `rustDatabase == null`. `rustDatabase` is assigned *early* in `initializeInternal`, well before `geofenceManager`, so the guard could pass while managers were still unset; `startBootTracking` then reads `sdk.geofenceManager` → crash.
- **`GeofenceBroadcastReceiver.onReceive`** — `initialize()` then immediately reads `geofenceManager`. Now throws, is caught, `manager` becomes `null`, and the geofence transition is **silently dropped** — a cold-boot enter/exit (a trip start) is lost.
- **`CrashConfirmReceiver`** — `initialize()` then `deliverConfirmedImpact()` on not-yet-wired state.

`PeriodicLocationWorker` is unaffected (routes through `bootstrapForBackground`, and its direct `locationEngine` read is already `isReady`-gated).

## Fix

Centered on a single gate:

- `awaitInit()` now returns `Boolean` — `true` when subsystems are safe to touch, `false` on timeout or init failure. Timeout raised 15s → 30s.
- `initializeInternal()` failure sets an `initFailed` flag and logs the **full stacktrace** (was only `t.message`), so `awaitInit()` reports failure instead of letting callers hit a later, misleading `UninitializedPropertyAccessException`.
- Every synchronous entry point routes through `initialize()` + `awaitInit()` and **bails** (skip / return) when it returns `false`, rather than dereferencing: `ready()`, `bootstrapForBackground()`, `startBootTracking`'s geofence wiring, `GeofenceBroadcastReceiver`, `CrashConfirmReceiver`.
- `ready()` now also calls `initialize()` first (previously relied on `onAttachedToEngine` having called it).

No self-deadlock: `awaitInit()` only runs on service / broadcast / plugin threads, never on `tracelet-init`.

## Known limitation (pre-existing, not addressed here)

`ready()` runs on the platform main thread and blocks on `awaitInit()`; #260 moved the DB open off-thread, but the foreground path still waits for it. A follow-up could make `ready()` complete asynchronously after init. Called out here for visibility; out of scope for this regression fix.

## Testing

Not compiled locally (native + Rust toolchain); verified by inspection, as with #252/#260. Repro: `startOnBoot: true` + `stopOnTerminate: false`, cold boot / task-removal restart.
