### PR TITLE
fix(geofence): accuracy-aware EXIT to prevent GPS-drift false exits (…

### DIFF
--- a/example/lib/issues/issue_274_card.dart
+++ b/example/lib/issues/issue_274_card.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #274 — GPS drift fires a false EXIT on small-radius geofences
+/// (high-accuracy mode).
+///
+/// A device standing still WELL inside a small attendance geofence (e.g. 50 m)
+/// occasionally receives a single high-drift GPS fix: the reported position
+/// lands far outside the radius, but the fix also carries a correspondingly
+/// large `horizontalAccuracy` (the OS is telling you "I'm not sure — could be
+/// ±150 m"). The exit-hysteresis band from #268 absorbs small stationary
+/// jitter, but a large single-fix drift spike sails right past it and fires a
+/// bogus EXIT even though the user never moved.
+///
+/// The fix makes the EXIT decision accuracy-aware: a circular geofence only
+/// EXITs once the ENTIRE error circle clears the fence
+/// (`distance - accuracy > radius + exitBuffer`). ENTER stays accuracy-agnostic
+/// so arrivals still trigger promptly.
+///
+/// This card drives the REAL shipped [GeofenceEvaluator] with a scripted
+/// sequence for a 50 m geofence (exit threshold 70 m):
+///
+///   1. A solid ±8 m fix ~10 m from center → ENTER.
+///   2. A drift spike reported ~160 m out but with ±150 m accuracy — the
+///      nearest plausible position is `160 - 150 = 10 m`, still inside.
+///   3. A recovered ±6 m fix ~12 m from center.
+///   4. A GENUINE departure: ~120 m out with a tight ±10 m accuracy → EXIT.
+///
+///   • BUGGY build (no accuracy gating) → the drift spike at step 2 fires a
+///     false EXIT → FAILED, which is how you manually confirm #274 exists.
+///   • FIXED build → exactly one ENTER, no EXIT on the drift spike, and one
+///     EXIT only on the real departure → SUCCESS.
+class Issue274Card extends StatefulWidget {
+  const Issue274Card({super.key});
+
+  @override
+  State<Issue274Card> createState() => _Issue274CardState();
+}
+
+class _Issue274CardState extends State<Issue274Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    try {
+      const centerLat = 37.4219983;
+      const centerLng = -122.084;
+      const radius =
+          50.0; // exit threshold = radius + max(radius*0.1, 20) = 70m
+
+      final geofences = <Map<String, Object?>>[
+        {
+          'identifier': 'issue-274',
+          'latitude': centerLat,
+          'longitude': centerLng,
+          'radius': radius,
+        },
+      ];
+
+      // (distance from center in meters, reported horizontalAccuracy in meters)
+      const fixes = <(double, double)>[
+        (10, 8), // solid fix inside            → ENTER
+        (160, 150), // high-drift, low-confidence  → must HOLD (no EXIT)
+        (12, 6), // recovered accurate fix      → no change
+        (120, 10), // genuine departure, accurate → EXIT
+      ];
+
+      final evaluator = GeofenceEvaluator();
+      final log = StringBuffer();
+      var enters = 0;
+      var exits = 0;
+      var driftFalseExit = false;
+
+      for (var i = 0; i < fixes.length; i++) {
+        final (d, acc) = fixes[i];
+        // ~d meters due north of the center (1° lat ≈ 111_320 m).
+        final pointLat = centerLat + d / 111320.0;
+        final transitions = evaluator.evaluateProximity(
+          latitude: pointLat,
+          longitude: centerLng,
+          accuracy: acc,
+          geofences: geofences,
+        );
+        final actions = transitions.map((t) => t.action).join(', ');
+        log.writeln(
+          '~${d.toStringAsFixed(0)}m (±${acc.toStringAsFixed(0)}m) -> '
+          '${actions.isEmpty ? '(no change)' : actions}',
+        );
+        for (final t in transitions) {
+          if (t.action == 'ENTER') enters++;
+          if (t.action == 'EXIT') {
+            exits++;
+            // Step index 1 (the drift spike) must NOT produce an EXIT.
+            if (i == 1) driftFalseExit = true;
+          }
+        }
+      }
+
+      // Fixed behavior: exactly one ENTER, exactly one EXIT (the real
+      // departure), and NO exit on the drift spike.
+      final fixed = enters == 1 && exits == 1 && !driftFalseExit;
+
+      if (fixed) {
+        _set(
+          '✅ SUCCESS (drift ignored): the real GeofenceEvaluator held INSIDE '
+          'through the ±150 m drift spike and only EXITed on the genuine, '
+          'accurate departure — $enters ENTER, $exits EXIT.\n\n'
+          '$log\n'
+          'The accuracy-aware exit condition '
+          '(distance - accuracy > radius + buffer) absorbed the low-confidence '
+          'fix. #274 is fixed on this build.',
+        );
+      } else if (driftFalseExit) {
+        _set(
+          '❌ FAILED — #274 REPRODUCED: the ±150 m drift spike fired a false '
+          'EXIT while the device was standing still inside the fence '
+          '($enters ENTER / $exits EXIT).\n\n'
+          '$log\n'
+          'A single high-drift, low-confidence fix should not trigger EXIT. '
+          'This confirms the evaluator ignores horizontal accuracy.',
+        );
+      } else {
+        _set(
+          '❌ FAILED: unexpected transition counts — $enters ENTER / $exits '
+          'EXIT.\n\n$log',
+        );
+      }
+    } catch (e) {
+      _set('❌ FAILED: $e');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'geofence gps drift false exit accuracy horizontal accuracy small '
+          'radius attendance stationary high accuracy geofenceevaluator '
+          'proximity hysteresis exit gating 274',
+      title: '#274: GPS drift fires a false EXIT on small-radius geofences',
+      description:
+          'Drives the real GeofenceEvaluator with a scripted sequence for a '
+          '50 m geofence: a solid fix inside, a ±150 m drift spike reported far '
+          'outside the radius, a recovery, then a genuine accurate departure. '
+          'On a buggy build the drift spike fires a false EXIT so you can '
+          'confirm #274 exists; on the fixed build the accuracy-aware exit '
+          'holds through the drift and EXITs only on the real departure. Runs '
+          'in-process; no permissions or device movement required.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -37,6 +37,7 @@ import 'package:tracelet_example/issues/issue_265_card.dart';
 import 'package:tracelet_example/issues/issue_267_card.dart';
 import 'package:tracelet_example/issues/issue_268_card.dart';
 import 'package:tracelet_example/issues/issue_270_card.dart';
+import 'package:tracelet_example/issues/issue_274_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1709,6 +1710,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                   // own title/description/keywords via IssueSearchScope, so they
                   // are rendered directly. Cards with a bespoke layout (no shell)
                   // stay wrapped in _searchableCard with explicit keywords.
+                  const Issue274Card(),
                   const Issue270Card(),
                   const Issue268Card(),
                   const Issue267Card(),

--- a/packages/tracelet_platform_interface/lib/src/algorithms/geofence_evaluator.dart
+++ b/packages/tracelet_platform_interface/lib/src/algorithms/geofence_evaluator.dart
@@ -140,11 +140,23 @@ class GeofenceEvaluator {
   /// - `vertices` (`List<List<double>>`) — optional polygon vertices
   ///   (`[[lat, lng], ...]`). When present with ≥ 3 vertices, the geofence
   ///   is treated as a polygon.
+  ///
+  /// [accuracy] is the fix's horizontal accuracy radius in meters. It makes the
+  /// circular EXIT decision drift-aware: a geofence only EXITs once the entire
+  /// accuracy circle clears the fence (`distance - accuracy > radius + buffer`),
+  /// preventing a single high-drift fix from firing a false EXIT (#274). Pass
+  /// `0.0` (the default) to disable gating and keep the legacy behavior.
   List<GeofenceTransition> evaluateProximity({
     required double latitude,
     required double longitude,
     required List<Map<String, Object?>> geofences,
+    double accuracy = 0.0,
   }) {
+    // Clamp unknown/invalid accuracy (some platforms report negative when the
+    // fix has no horizontal accuracy) to 0 so gating is a no-op rather than
+    // pulling the exit threshold inward (#274).
+    final acc = accuracy.isFinite && accuracy > 0 ? accuracy : 0.0;
+
     // When a spatial index exists, use it to narrow candidates.
     final effectiveGeofences = _resolveGeofences(
       latitude,
@@ -230,7 +242,14 @@ class GeofenceEvaluator {
           ? scaledBuffer
           : _minExitHysteresisMeters;
       final entered = distance <= gfRadius;
-      final exited = distance > gfRadius + exitBuffer;
+      // Accuracy-aware EXIT (#274): require the whole error circle to clear the
+      // fence, not just the reported point. `distance - acc` is the nearest the
+      // device could plausibly be given the fix uncertainty; only exit when even
+      // that is clearly beyond the boundary. This stops a single high-drift fix
+      // (reported with a correspondingly large accuracy) from firing a false
+      // EXIT while the device is stationary inside the fence. ENTER is left
+      // accuracy-agnostic so arrivals still trigger promptly.
+      final exited = (distance - acc) > gfRadius + exitBuffer;
 
       if (entered && !wasInside) {
         _insideGeofenceIds.add(identifier);

--- a/packages/tracelet_platform_interface/test/algorithms/geofence_evaluator_test.dart
+++ b/packages/tracelet_platform_interface/test/algorithms/geofence_evaluator_test.dart
@@ -354,6 +354,80 @@ void main() async {
       expect(transitions[0].action, 'EXIT');
     });
 
+    test('high-accuracy drift does not fire a false EXIT (#274)', () {
+      const centerLat = 37.4219983;
+      const centerLng = -122.084;
+      final geofences = <Map<String, Object?>>[
+        {
+          'identifier': 'attendance',
+          'latitude': centerLat,
+          'longitude': centerLng,
+          'radius': 50.0, // exit threshold = 70 m
+        },
+      ];
+
+      // Solid fix inside with good accuracy → ENTER.
+      final inside = pointNorth(centerLat, centerLng, 10);
+      final enter = evaluator.evaluateProximity(
+        latitude: inside.lat,
+        longitude: inside.lng,
+        accuracy: 8,
+        geofences: geofences,
+      );
+      expect(enter, hasLength(1));
+      expect(enter[0].action, 'ENTER');
+
+      // Drift spike: reported 160 m out but with ±150 m accuracy. The nearest
+      // plausible position (160 - 150 = 10 m) is still inside → hold, no EXIT.
+      final drift = pointNorth(centerLat, centerLng, 160);
+      final driftTransitions = evaluator.evaluateProximity(
+        latitude: drift.lat,
+        longitude: drift.lng,
+        accuracy: 150,
+        geofences: geofences,
+      );
+      expect(
+        driftTransitions,
+        isEmpty,
+        reason: 'high-drift low-confidence fix must not fire EXIT',
+      );
+    });
+
+    test(
+      'accurate genuine departure still EXITs with gating active (#274)',
+      () {
+        const centerLat = 37.4219983;
+        const centerLng = -122.084;
+        final geofences = <Map<String, Object?>>[
+          {
+            'identifier': 'attendance',
+            'latitude': centerLat,
+            'longitude': centerLng,
+            'radius': 50.0, // exit threshold = 70 m
+          },
+        ];
+
+        final inside = pointNorth(centerLat, centerLng, 10);
+        evaluator.evaluateProximity(
+          latitude: inside.lat,
+          longitude: inside.lng,
+          accuracy: 8,
+          geofences: geofences,
+        );
+
+        // 120 m out with ±10 m accuracy: 120 - 10 = 110 > 70 → real EXIT.
+        final far = pointNorth(centerLat, centerLng, 120);
+        final transitions = evaluator.evaluateProximity(
+          latitude: far.lat,
+          longitude: far.lng,
+          accuracy: 10,
+          geofences: geofences,
+        );
+        expect(transitions, hasLength(1));
+        expect(transitions[0].action, 'EXIT');
+      },
+    );
+
     test('polygon with integer vertices works', () {
       final geofences = <Map<String, Object?>>[
         {

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -845,10 +845,10 @@ class TraceletSdk private constructor(private val context: Context) {
         }
 
         // Wire proximity-based geofence monitoring + trip waypoints
-        locationEngine.onLocationUpdate = { lat, lng ->
+        locationEngine.onLocationUpdate = { lat, lng, accuracy ->
             geofenceManager.updateProximity(lat, lng)
             if (configManager.getGeofenceModeHighAccuracy()) {
-                geofenceManager.evaluateHighAccuracyProximity(lat, lng)
+                geofenceManager.evaluateHighAccuracyProximity(lat, lng, accuracy)
             }
             tripManager.onLocationReceived(lat, lng, System.currentTimeMillis().toString())
         }
@@ -1023,10 +1023,10 @@ class TraceletSdk private constructor(private val context: Context) {
 
         geofenceManager.reRegisterAll()
 
-        locationEngine.onLocationUpdate = { lat, lng ->
+        locationEngine.onLocationUpdate = { lat, lng, accuracy ->
             geofenceManager.updateProximity(lat, lng)
             if (configManager.getGeofenceModeHighAccuracy()) {
-                geofenceManager.evaluateHighAccuracyProximity(lat, lng)
+                geofenceManager.evaluateHighAccuracyProximity(lat, lng, accuracy)
             }
         }
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
@@ -342,7 +342,7 @@ class GeofenceManager(
      *
      * Called on each location update when `geofenceModeHighAccuracy` is enabled.
      */
-    fun evaluateHighAccuracyProximity(latitude: Double, longitude: Double) {
+    fun evaluateHighAccuracyProximity(latitude: Double, longitude: Double, accuracy: Double = 0.0) {
         val allGeofences = getCachedGeofences()
         if (allGeofences.isEmpty()) return
 
@@ -350,6 +350,7 @@ class GeofenceManager(
         val transitions = geofenceEvaluator.evaluateProximity(
             latitude = latitude,
             longitude = longitude,
+            accuracy = accuracy,
             geofences = coreGeofences,
         )
         if (transitions.isEmpty()) return

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationEngine.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationEngine.kt
@@ -242,8 +242,13 @@ class LocationEngine(
     var lastEffectiveSpeed: Double = 0.0
         private set
 
-    /** Optional callback invoked on every accepted location (for geofenceModeHighAccuracy). */
-    var onLocationUpdate: ((Double, Double) -> Unit)? = null
+    /**
+     * Optional callback invoked on every accepted location (for geofenceModeHighAccuracy).
+     *
+     * Params: latitude, longitude, horizontalAccuracy (meters). Accuracy feeds
+     * the drift-aware geofence EXIT decision (issue #274); pass 0.0 when unknown.
+     */
+    var onLocationUpdate: ((Double, Double, Double) -> Unit)? = null
 
     /** Optional callback invoked after a location is persisted to the database.
      *  Used by the plugin to trigger HTTP auto-sync. */
@@ -462,7 +467,7 @@ class LocationEngine(
 
                         // Notify proximity-based geofence monitoring
                         if (lat != null && lng != null) {
-                            onLocationUpdate?.invoke(lat, lng)
+                            onLocationUpdate?.invoke(lat, lng, accuracy ?: 0.0)
                         }
                     } else {
                         TraceletLog.warning("periodic fix — no location available (fresh + fallback both null)")
@@ -980,7 +985,7 @@ class LocationEngine(
                         // Dispatch to Dart but do NOT persist or audit.
                         val locationData = privacyResult.location ?: finalEnriched
                         events.sendLocation(locationData)
-                        onLocationUpdate?.invoke(location.latitude, location.longitude)
+                        onLocationUpdate?.invoke(location.latitude, location.longitude, location.accuracy.toDouble())
                         return
                     }
                     PrivacyZoneManager.ProcessedLocation.Action.DEGRADED -> {
@@ -994,7 +999,7 @@ class LocationEngine(
                         }
                         persistLocationIfAllowed(withAudit, actualEvent)
                         events.sendLocation(withAudit)
-                        onLocationUpdate?.invoke(location.latitude, location.longitude)
+                        onLocationUpdate?.invoke(location.latitude, location.longitude, location.accuracy.toDouble())
                         
                         if (isForcedAccept) {
                             try {
@@ -1023,7 +1028,7 @@ class LocationEngine(
             events.sendLocation(enrichedWithAudit)
 
             // Notify geofenceModeHighAccuracy listener (if active)
-            onLocationUpdate?.invoke(location.latitude, location.longitude)
+            onLocationUpdate?.invoke(location.latitude, location.longitude, location.accuracy.toDouble())
             
             if (isForcedAccept) {
                 try {

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -1186,10 +1186,10 @@ class LocationService : Service(), DefaultLifecycleObserver {
             if (config.getGeofenceModeHighAccuracy()) {
                 geoManager.clearHighAccuracyState()
             }
-            bootLocationEngine?.onLocationUpdate = { lat, lng ->
+            bootLocationEngine?.onLocationUpdate = { lat, lng, accuracy ->
                 geoManager.updateProximity(lat, lng)
                 if (config.getGeofenceModeHighAccuracy()) {
-                    geoManager.evaluateHighAccuracyProximity(lat, lng)
+                    geoManager.evaluateHighAccuracyProximity(lat, lng, accuracy)
                 }
             }
             TraceletLog.debug("Geofence registrations restored after boot/task-removal (proximity stream wired)")

--- a/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
@@ -1108,7 +1108,7 @@ external fun uniffi_tracelet_core_fn_method_geofenceevaluator_clear(`ptr`: Long,
 ): Unit
 external fun uniffi_tracelet_core_fn_method_geofenceevaluator_clear_index(`ptr`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
-external fun uniffi_tracelet_core_fn_method_geofenceevaluator_evaluate_proximity(`ptr`: Long,`latitude`: Double,`longitude`: Double,`geofences`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+external fun uniffi_tracelet_core_fn_method_geofenceevaluator_evaluate_proximity(`ptr`: Long,`latitude`: Double,`longitude`: Double,`accuracy`: Double,`geofences`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 external fun uniffi_tracelet_core_fn_method_geofenceevaluator_index_geofences(`ptr`: Long,`geofences`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -1538,7 +1538,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_tracelet_core_checksum_method_geofenceevaluator_clear_index() != 37834.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tracelet_core_checksum_method_geofenceevaluator_evaluate_proximity() != 38287.toShort()) {
+    if (lib.uniffi_tracelet_core_checksum_method_geofenceevaluator_evaluate_proximity() != 39120.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_method_geofenceevaluator_index_geofences() != 2949.toShort()) {
@@ -4995,8 +4995,19 @@ public interface GeofenceEvaluatorInterface {
     
     /**
      * Evaluates a location update and returns a list of triggered geofence transitions.
+     *
+     * `accuracy` is the fix's horizontal accuracy radius in meters (a 68%
+     * confidence circle). It is used to make the EXIT decision drift-aware:
+     * a circular geofence only EXITs once the *entire* accuracy circle clears
+     * the fence (`distance - accuracy > radius + exitBuffer`). This prevents a
+     * single high-drift fix — which is reported with a correspondingly large
+     * accuracy value — from producing a false EXIT while the device is
+     * stationary inside the fence (issue #274). Pass `0.0` (or any
+     * non-positive/non-finite value) to disable accuracy gating and preserve
+     * the legacy `distance`-only behavior. ENTER is intentionally left
+     * accuracy-agnostic so arrivals still trigger promptly.
      */
-    fun `evaluateProximity`(`latitude`: kotlin.Double, `longitude`: kotlin.Double, `geofences`: List<CoreGeofence>): List<GeofenceTransition>
+    fun `evaluateProximity`(`latitude`: kotlin.Double, `longitude`: kotlin.Double, `accuracy`: kotlin.Double, `geofences`: List<CoreGeofence>): List<GeofenceTransition>
     
     /**
      * Indexes a collection of geofences for efficient spatial querying.
@@ -5148,13 +5159,24 @@ open class GeofenceEvaluator: Disposable, AutoCloseable, GeofenceEvaluatorInterf
     
     /**
      * Evaluates a location update and returns a list of triggered geofence transitions.
-     */override fun `evaluateProximity`(`latitude`: kotlin.Double, `longitude`: kotlin.Double, `geofences`: List<CoreGeofence>): List<GeofenceTransition> {
+     *
+     * `accuracy` is the fix's horizontal accuracy radius in meters (a 68%
+     * confidence circle). It is used to make the EXIT decision drift-aware:
+     * a circular geofence only EXITs once the *entire* accuracy circle clears
+     * the fence (`distance - accuracy > radius + exitBuffer`). This prevents a
+     * single high-drift fix — which is reported with a correspondingly large
+     * accuracy value — from producing a false EXIT while the device is
+     * stationary inside the fence (issue #274). Pass `0.0` (or any
+     * non-positive/non-finite value) to disable accuracy gating and preserve
+     * the legacy `distance`-only behavior. ENTER is intentionally left
+     * accuracy-agnostic so arrivals still trigger promptly.
+     */override fun `evaluateProximity`(`latitude`: kotlin.Double, `longitude`: kotlin.Double, `accuracy`: kotlin.Double, `geofences`: List<CoreGeofence>): List<GeofenceTransition> {
             return FfiConverterSequenceTypeGeofenceTransition.lift(
     callWithHandle {
     uniffiRustCall() { _status ->
     UniffiLib.uniffi_tracelet_core_fn_method_geofenceevaluator_evaluate_proximity(
         it,
-        FfiConverterDouble.lower(`latitude`),FfiConverterDouble.lower(`longitude`),FfiConverterSequenceTypeCoreGeofence.lower(`geofences`),_status)
+        FfiConverterDouble.lower(`latitude`),FfiConverterDouble.lower(`longitude`),FfiConverterDouble.lower(`accuracy`),FfiConverterSequenceTypeCoreGeofence.lower(`geofences`),_status)
 }
     }
     )

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -407,10 +407,10 @@ public final class TraceletSdk {
         periodicRefreshScheduler.stop()
 
         // Wire proximity-based geofence monitoring + trip waypoints.
-        locationEngine.onLocationUpdate = { [weak self] lat, lng in
+        locationEngine.onLocationUpdate = { [weak self] lat, lng, accuracy in
             self?.geofenceManager.updateProximity(latitude: lat, longitude: lng)
             if self?.configManager.getGeofenceModeHighAccuracy() == true {
-                self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng)
+                self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng, accuracy: accuracy)
             }
             self?.tripManager.onLocationReceived(
                 latitude: lat,
@@ -512,10 +512,10 @@ public final class TraceletSdk {
         geofenceManager.reRegisterAll()
 
         // Wire proximity-based geofence monitoring.
-        locationEngine.onLocationUpdate = { [weak self] lat, lng in
+        locationEngine.onLocationUpdate = { [weak self] lat, lng, accuracy in
             self?.geofenceManager.updateProximity(latitude: lat, longitude: lng)
             if self?.configManager.getGeofenceModeHighAccuracy() == true {
-                self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng)
+                self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng, accuracy: accuracy)
             }
         }
 
@@ -581,10 +581,10 @@ public final class TraceletSdk {
         locationEngine.startPeriodic()
 
         // Wire proximity-based geofence monitoring.
-        locationEngine.onLocationUpdate = { [weak self] lat, lng in
+        locationEngine.onLocationUpdate = { [weak self] lat, lng, accuracy in
             self?.geofenceManager.updateProximity(latitude: lat, longitude: lng)
             if self?.configManager.getGeofenceModeHighAccuracy() == true {
-                self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng)
+                self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng, accuracy: accuracy)
             }
         }
 
@@ -3012,10 +3012,10 @@ public final class TraceletSdk {
         switch trackingMode {
         case .continuous:
             locationEngine.start()
-            locationEngine.onLocationUpdate = { [weak self] lat, lng in
+            locationEngine.onLocationUpdate = { [weak self] lat, lng, accuracy in
                 self?.geofenceManager.updateProximity(latitude: lat, longitude: lng)
                 if self?.configManager.getGeofenceModeHighAccuracy() == true {
-                    self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng)
+                    self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng, accuracy: accuracy)
                 }
                 self?.tripManager.onLocationReceived(
                     latitude: lat,
@@ -3039,10 +3039,10 @@ public final class TraceletSdk {
 
         case .geofences:
             geofenceManager.reRegisterAll()
-            locationEngine.onLocationUpdate = { [weak self] lat, lng in
+            locationEngine.onLocationUpdate = { [weak self] lat, lng, accuracy in
                 self?.geofenceManager.updateProximity(latitude: lat, longitude: lng)
                 if self?.configManager.getGeofenceModeHighAccuracy() == true {
-                    self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng)
+                    self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng, accuracy: accuracy)
                 }
             }
             locationEngine.start()
@@ -3052,10 +3052,10 @@ public final class TraceletSdk {
 
         case .periodic:
             locationEngine.startPeriodic()
-            locationEngine.onLocationUpdate = { [weak self] lat, lng in
+            locationEngine.onLocationUpdate = { [weak self] lat, lng, accuracy in
                 self?.geofenceManager.updateProximity(latitude: lat, longitude: lng)
                 if self?.configManager.getGeofenceModeHighAccuracy() == true {
-                    self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng)
+                    self?.geofenceManager.evaluateHighAccuracyProximity(latitude: lat, longitude: lng, accuracy: accuracy)
                 }
             }
             let interval = TimeInterval(configManager.getPeriodicLocationInterval())

--- a/sdk/ios/Sources/TraceletSDK/geofence/GeofenceManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/geofence/GeofenceManager.swift
@@ -258,7 +258,7 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
     /// and geofencesChange events via `TraceletEventSending`.
     ///
     /// Called on each location update when `geofenceModeHighAccuracy` is enabled.
-    public func evaluateHighAccuracyProximity(latitude: Double, longitude: Double) {
+    public func evaluateHighAccuracyProximity(latitude: Double, longitude: Double, accuracy: Double = 0.0) {
         let allGeofences = getCachedGeofences()
         if allGeofences.isEmpty { return }
 
@@ -266,6 +266,7 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
         let transitions = geofenceEvaluator.evaluateProximity(
             latitude: latitude,
             longitude: longitude,
+            accuracy: accuracy,
             geofences: coreGeofences
         )
         if transitions.isEmpty { return }

--- a/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
+++ b/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
@@ -63,7 +63,12 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
     public private(set) var lastEffectiveSpeed: Double = 0.0
 
     /// Optional callback invoked on every accepted location (for geofenceModeHighAccuracy).
-    public var onLocationUpdate: ((Double, Double) -> Void)?
+    ///
+    /// Params: latitude, longitude, horizontalAccuracy (meters). Accuracy feeds
+    /// the drift-aware geofence EXIT decision (issue #274). CLLocation reports a
+    /// negative `horizontalAccuracy` when invalid; the evaluator treats any
+    /// non-positive value as "unknown" and skips gating.
+    public var onLocationUpdate: ((Double, Double, Double) -> Void)?
 
     /// Optional callback invoked after a location is persisted to the database.
     /// Used by the plugin to trigger HTTP auto-sync.
@@ -1039,7 +1044,7 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
                 
                 enrichWithAddressIfNeeded(locationMap: data, location: location) { [weak self] enrichedData in
                     self?.eventDispatcher.sendLocation(enrichedData)
-                    self?.onLocationUpdate?(location.coordinate.latitude, location.coordinate.longitude)
+                    self?.onLocationUpdate?(location.coordinate.latitude, location.coordinate.longitude, location.horizontalAccuracy)
                     if self?.isPeriodicTracking == true {
                         self?.locationManager.stopUpdatingLocation()
                         self?.locationManager.allowsBackgroundLocationUpdates = false
@@ -1063,7 +1068,7 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
                 enrichWithAddressIfNeeded(locationMap: degraded, location: location) { [weak self] enrichedDegraded in
                     self?.persistLocationIfAllowed(enrichedDegraded, event: pzEventTag)
                     self?.eventDispatcher.sendLocation(enrichedDegraded)
-                    self?.onLocationUpdate?(location.coordinate.latitude, location.coordinate.longitude)
+                    self?.onLocationUpdate?(location.coordinate.latitude, location.coordinate.longitude, location.horizontalAccuracy)
                     if self?.isPeriodicTracking == true {
                         self?.locationManager.stopUpdatingLocation()
                         self?.locationManager.allowsBackgroundLocationUpdates = false
@@ -1095,7 +1100,7 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
             self.eventDispatcher.sendLocation(enrichedMap)
 
             // Notify geofenceModeHighAccuracy listener (if active)
-            self.onLocationUpdate?(location.coordinate.latitude, location.coordinate.longitude)
+            self.onLocationUpdate?(location.coordinate.latitude, location.coordinate.longitude, location.horizontalAccuracy)
 
             // In periodic mode, immediately stop GPS after receiving the fix
             // to minimise blue-arrow visibility.

--- a/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
@@ -2335,8 +2335,19 @@ public protocol GeofenceEvaluatorProtocol: AnyObject, Sendable {
     
     /**
      * Evaluates a location update and returns a list of triggered geofence transitions.
+     *
+     * `accuracy` is the fix's horizontal accuracy radius in meters (a 68%
+     * confidence circle). It is used to make the EXIT decision drift-aware:
+     * a circular geofence only EXITs once the *entire* accuracy circle clears
+     * the fence (`distance - accuracy > radius + exitBuffer`). This prevents a
+     * single high-drift fix — which is reported with a correspondingly large
+     * accuracy value — from producing a false EXIT while the device is
+     * stationary inside the fence (issue #274). Pass `0.0` (or any
+     * non-positive/non-finite value) to disable accuracy gating and preserve
+     * the legacy `distance`-only behavior. ENTER is intentionally left
+     * accuracy-agnostic so arrivals still trigger promptly.
      */
-    func evaluateProximity(latitude: Double, longitude: Double, geofences: [CoreGeofence])  -> [GeofenceTransition]
+    func evaluateProximity(latitude: Double, longitude: Double, accuracy: Double, geofences: [CoreGeofence])  -> [GeofenceTransition]
     
     /**
      * Indexes a collection of geofences for efficient spatial querying.
@@ -2431,13 +2442,25 @@ open func clearIndex()  {try! rustCall() {
     
     /**
      * Evaluates a location update and returns a list of triggered geofence transitions.
+     *
+     * `accuracy` is the fix's horizontal accuracy radius in meters (a 68%
+     * confidence circle). It is used to make the EXIT decision drift-aware:
+     * a circular geofence only EXITs once the *entire* accuracy circle clears
+     * the fence (`distance - accuracy > radius + exitBuffer`). This prevents a
+     * single high-drift fix — which is reported with a correspondingly large
+     * accuracy value — from producing a false EXIT while the device is
+     * stationary inside the fence (issue #274). Pass `0.0` (or any
+     * non-positive/non-finite value) to disable accuracy gating and preserve
+     * the legacy `distance`-only behavior. ENTER is intentionally left
+     * accuracy-agnostic so arrivals still trigger promptly.
      */
-open func evaluateProximity(latitude: Double, longitude: Double, geofences: [CoreGeofence]) -> [GeofenceTransition]  {
+open func evaluateProximity(latitude: Double, longitude: Double, accuracy: Double, geofences: [CoreGeofence]) -> [GeofenceTransition]  {
     return try!  FfiConverterSequenceTypeGeofenceTransition.lift(try! rustCall() {
     uniffi_tracelet_core_fn_method_geofenceevaluator_evaluate_proximity(
             self.uniffiCloneHandle(),
         FfiConverterDouble.lower(latitude),
         FfiConverterDouble.lower(longitude),
+        FfiConverterDouble.lower(accuracy),
         FfiConverterSequenceTypeCoreGeofence.lower(geofences),$0
     )
 })
@@ -9754,7 +9777,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_tracelet_core_checksum_method_geofenceevaluator_clear_index() != 37834) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_tracelet_core_checksum_method_geofenceevaluator_evaluate_proximity() != 38287) {
+    if (uniffi_tracelet_core_checksum_method_geofenceevaluator_evaluate_proximity() != 39120) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_method_geofenceevaluator_index_geofences() != 2949) {

--- a/sdk/ios/Sources/TraceletSDK/tracelet_coreFFI.h
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_coreFFI.h
@@ -794,7 +794,7 @@ void uniffi_tracelet_core_fn_method_geofenceevaluator_clear_index(uint64_t ptr, 
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_TRACELET_CORE_FN_METHOD_GEOFENCEEVALUATOR_EVALUATE_PROXIMITY
 #define UNIFFI_FFIDEF_UNIFFI_TRACELET_CORE_FN_METHOD_GEOFENCEEVALUATOR_EVALUATE_PROXIMITY
-RustBuffer uniffi_tracelet_core_fn_method_geofenceevaluator_evaluate_proximity(uint64_t ptr, double latitude, double longitude, RustBuffer geofences, RustCallStatus *_Nonnull out_status
+RustBuffer uniffi_tracelet_core_fn_method_geofenceevaluator_evaluate_proximity(uint64_t ptr, double latitude, double longitude, double accuracy, RustBuffer geofences, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_TRACELET_CORE_FN_METHOD_GEOFENCEEVALUATOR_INDEX_GEOFENCES

--- a/sdk/rust-core/core/src/spatial/geofence_evaluator.rs
+++ b/sdk/rust-core/core/src/spatial/geofence_evaluator.rs
@@ -79,7 +79,21 @@ impl GeofenceEvaluator {
     }
 
     /// Evaluates a location update and returns a list of triggered geofence transitions.
-    pub fn evaluate_proximity(&self, latitude: f64, longitude: f64, geofences: Vec<CoreGeofence>) -> Vec<GeofenceTransition> {
+    ///
+    /// `accuracy` is the fix's horizontal accuracy radius in meters (a 68%
+    /// confidence circle). It is used to make the EXIT decision drift-aware:
+    /// a circular geofence only EXITs once the *entire* accuracy circle clears
+    /// the fence (`distance - accuracy > radius + exitBuffer`). This prevents a
+    /// single high-drift fix — which is reported with a correspondingly large
+    /// accuracy value — from producing a false EXIT while the device is
+    /// stationary inside the fence (issue #274). Pass `0.0` (or any
+    /// non-positive/non-finite value) to disable accuracy gating and preserve
+    /// the legacy `distance`-only behavior. ENTER is intentionally left
+    /// accuracy-agnostic so arrivals still trigger promptly.
+    pub fn evaluate_proximity(&self, latitude: f64, longitude: f64, accuracy: f64, geofences: Vec<CoreGeofence>) -> Vec<GeofenceTransition> {
+        // Clamp unknown/invalid accuracy (iOS reports negative when invalid) to
+        // 0 so gating is a no-op rather than pulling the exit threshold inward.
+        let acc = if accuracy.is_finite() && accuracy > 0.0 { accuracy } else { 0.0 };
         let effective_geofences = self.resolve_geofences(latitude, longitude, geofences);
         let mut transitions = Vec::new();
         let mut inside_ids = self.inside_geofence_ids.write().unwrap();
@@ -123,7 +137,11 @@ impl GeofenceEvaluator {
             let exit_buffer = (gf.radius * GEOFENCE_EXIT_HYSTERESIS_FRACTION)
                 .max(GEOFENCE_MIN_EXIT_HYSTERESIS_METERS);
             let entered = distance <= gf.radius;
-            let exited = distance > gf.radius + exit_buffer;
+            // Accuracy-aware EXIT (#274): require the whole error circle to be
+            // beyond the fence, not just the reported point. `distance - acc`
+            // is the nearest the device could plausibly be to the center given
+            // the fix uncertainty; only exit when even that is clearly outside.
+            let exited = (distance - acc) > gf.radius + exit_buffer;
 
             if entered && !was_inside {
                 inside_ids.insert(identifier.clone());
@@ -239,7 +257,7 @@ mod tests {
         let (mut enters, mut exits) = (0usize, 0usize);
         for d in distances {
             let (plat, plng) = point_north(lat, lng, d);
-            let (e, x) = count(&eval.evaluate_proximity(plat, plng, vec![gf.clone()]));
+            let (e, x) = count(&eval.evaluate_proximity(plat, plng, 0.0, vec![gf.clone()]));
             enters += e;
             exits += x;
         }
@@ -258,12 +276,12 @@ mod tests {
 
         // Enter well inside.
         let (plat, plng) = point_north(lat, lng, 20.0);
-        let (e, _) = count(&eval.evaluate_proximity(plat, plng, vec![gf.clone()]));
+        let (e, _) = count(&eval.evaluate_proximity(plat, plng, 0.0, vec![gf.clone()]));
         assert_eq!(e, 1);
 
         // Move clearly outside (well past radius + 20 m buffer).
         let (plat, plng) = point_north(lat, lng, 400.0);
-        let (_, x) = count(&eval.evaluate_proximity(plat, plng, vec![gf.clone()]));
+        let (_, x) = count(&eval.evaluate_proximity(plat, plng, 0.0, vec![gf.clone()]));
         assert_eq!(x, 1, "a clear departure must fire exactly one EXIT");
     }
 
@@ -280,11 +298,55 @@ mod tests {
         let (mut enters, mut exits) = (0usize, 0usize);
         for d in distances {
             let (plat, plng) = point_north(lat, lng, d);
-            let (e, x) = count(&eval.evaluate_proximity(plat, plng, vec![gf.clone()]));
+            let (e, x) = count(&eval.evaluate_proximity(plat, plng, 0.0, vec![gf.clone()]));
             enters += e;
             exits += x;
         }
         assert_eq!(enters, 1);
         assert_eq!(exits, 0);
+    }
+
+    /// Regression for #274: a stationary device inside a small fence whose GPS
+    /// briefly drifts well past `radius + buffer` must NOT fire a false EXIT
+    /// when the fix carries a correspondingly large accuracy value.
+    #[test]
+    fn high_accuracy_drift_does_not_false_exit() {
+        let (lat, lng) = (37.4219983, -122.084);
+        let gf = circular("attendance", lat, lng, 50.0); // exit threshold = 70 m
+        let eval = GeofenceEvaluator::new();
+
+        // Solid fix inside with good accuracy → ENTER.
+        let (plat, plng) = point_north(lat, lng, 10.0);
+        let (e, x) = count(&eval.evaluate_proximity(plat, plng, 8.0, vec![gf.clone()]));
+        assert_eq!((e, x), (1, 0), "good-accuracy fix inside must ENTER once");
+
+        // Drift spike: reported 160 m out but with ±150 m accuracy. The nearest
+        // plausible position (160 - 150 = 10 m) is still inside → hold, no EXIT.
+        let (plat, plng) = point_north(lat, lng, 160.0);
+        let (_, x) = count(&eval.evaluate_proximity(plat, plng, 150.0, vec![gf.clone()]));
+        assert_eq!(x, 0, "high-drift low-confidence fix must not fire EXIT");
+
+        // Recovered accurate fix back inside → still no spurious transitions.
+        let (plat, plng) = point_north(lat, lng, 12.0);
+        let (e, x) = count(&eval.evaluate_proximity(plat, plng, 6.0, vec![gf.clone()]));
+        assert_eq!((e, x), (0, 0), "recovery must not re-ENTER or EXIT");
+    }
+
+    /// A genuine departure reported with good accuracy must still EXIT even
+    /// though accuracy gating is active — gating only holds when the error
+    /// circle overlaps the fence.
+    #[test]
+    fn accurate_departure_still_exits_with_gating() {
+        let (lat, lng) = (37.4219983, -122.084);
+        let gf = circular("attendance", lat, lng, 50.0); // exit threshold = 70 m
+        let eval = GeofenceEvaluator::new();
+
+        let (plat, plng) = point_north(lat, lng, 10.0);
+        let _ = eval.evaluate_proximity(plat, plng, 8.0, vec![gf.clone()]);
+
+        // 120 m out with ±10 m accuracy: 120 - 10 = 110 > 70 → real EXIT.
+        let (plat, plng) = point_north(lat, lng, 120.0);
+        let (_, x) = count(&eval.evaluate_proximity(plat, plng, 10.0, vec![gf.clone()]));
+        assert_eq!(x, 1, "an accurate genuine departure must still EXIT");
     }
 }


### PR DESCRIPTION
…#274)

A stationary device inside a small-radius geofence could emit a false EXIT when a single GPS fix drifted beyond radius + hysteresis, even though the device never moved. The evaluator ignored the fix's horizontal accuracy, trusting a low-confidence drift spike as much as a tight fix.

The circular EXIT decision is now accuracy-aware: a geofence only EXITs once the entire error circle clears the fence
(distance - accuracy > radius + exitBuffer). ENTER stays accuracy-agnostic so arrivals still trigger promptly. Passing 0 accuracy preserves the legacy distance-only behavior.

- rust-core: add accuracy param to GeofenceEvaluator::evaluate_proximity (canonical logic) + regenerated UniFFI bindings (kotlin/swift/FFI header)
- android/ios: thread horizontalAccuracy from LocationEngine.onLocationUpdate through GeofenceManager.evaluateHighAccuracyProximity
- dart: mirror the accuracy-aware exit in the pure-Dart GeofenceEvaluator
- tests: Rust + Dart drift regressions (false-exit suppressed, genuine accurate departure still exits)
- example: add Issue274Card driving the real evaluator through a drift scenario

Follow-up (not in this change): optional GeofenceConfig knobs geofenceMaxAccuracyRadius and geofenceExitConfirmations.