### PR TITLE
feat(geofence): tunable geofenceExitAccuracyMax for accuracy-aware ex…

### DIFF
--- a/packages/tracelet/lib/src/models/config.dart
+++ b/packages/tracelet/lib/src/models/config.dart
@@ -1774,6 +1774,7 @@ class GeofenceConfig {
     this.geofenceInitialTrigger = true,
     this.geofenceProximityRadius = 1000,
     this.geofenceModeHighAccuracy = false,
+    this.geofenceExitAccuracyMax = -1,
   });
 
   /// Creates a [GeofenceConfig] from a map.
@@ -1794,6 +1795,10 @@ class GeofenceConfig {
       geofenceModeHighAccuracy: ensureBool(
         map['geofenceModeHighAccuracy'],
         fallback: false,
+      ),
+      geofenceExitAccuracyMax: ensureInt(
+        map['geofenceExitAccuracyMax'],
+        fallback: -1,
       ),
     );
   }
@@ -1828,6 +1833,29 @@ class GeofenceConfig {
   /// mode is enabled.
   final bool geofenceModeHighAccuracy;
 
+  /// Tunes the accuracy-aware geofence EXIT gating (high-accuracy mode only).
+  ///
+  /// In high-accuracy mode a circular geofence only fires EXIT once the whole
+  /// GPS error circle clears the fence — `distance - accuracy > radius + buffer`
+  /// — so a single high-drift, low-confidence fix can't produce a false EXIT
+  /// while a device sits still inside a small geofence (issue #274). The
+  /// tradeoff is that a *genuine* departure is delayed by roughly the fix's
+  /// horizontal accuracy, which matters most where GPS is chronically poor
+  /// (deep indoors, urban canyons).
+  ///
+  /// This value (in meters) tunes that behavior:
+  /// - `-1` (default): full gating — most resistant to drift-induced false
+  ///   exits; genuine exits may lag by the current GPS uncertainty.
+  /// - `0`: gating disabled — EXIT fires as soon as the reported point clears
+  ///   `radius + buffer` (fastest, pre-#274 behavior; drift-prone).
+  /// - `N > 0`: clamp — absorb drift up to `N` meters but never delay a genuine
+  ///   EXIT by more than ~`N` meters. A good middle ground for small fences in
+  ///   mixed GPS conditions (e.g. `20`).
+  ///
+  /// Has no effect in standard (OS region-monitoring) geofence mode, where the
+  /// OS decides EXIT.
+  final int geofenceExitAccuracyMax;
+
   /// Serializes to a map.
   Map<String, Object?> toMap() {
     return <String, Object?>{
@@ -1835,6 +1863,7 @@ class GeofenceConfig {
       'geofenceInitialTrigger': geofenceInitialTrigger,
       'geofenceProximityRadius': geofenceProximityRadius,
       'geofenceModeHighAccuracy': geofenceModeHighAccuracy,
+      'geofenceExitAccuracyMax': geofenceExitAccuracyMax,
     };
   }
 
@@ -1844,6 +1873,7 @@ class GeofenceConfig {
     geofenceProximityRadius: geofenceProximityRadius,
     geofenceInitialTrigger: geofenceInitialTrigger,
     geofenceModeHighAccuracy: geofenceModeHighAccuracy,
+    geofenceExitAccuracyMax: geofenceExitAccuracyMax,
   );
 
   @override
@@ -1854,7 +1884,8 @@ class GeofenceConfig {
           geofenceInitialTriggerEntry == other.geofenceInitialTriggerEntry &&
           geofenceInitialTrigger == other.geofenceInitialTrigger &&
           geofenceProximityRadius == other.geofenceProximityRadius &&
-          geofenceModeHighAccuracy == other.geofenceModeHighAccuracy;
+          geofenceModeHighAccuracy == other.geofenceModeHighAccuracy &&
+          geofenceExitAccuracyMax == other.geofenceExitAccuracyMax;
 
   @override
   int get hashCode => Object.hash(
@@ -1862,6 +1893,7 @@ class GeofenceConfig {
     geofenceInitialTrigger,
     geofenceProximityRadius,
     geofenceModeHighAccuracy,
+    geofenceExitAccuracyMax,
   );
 }
 

--- a/packages/tracelet/test/models_test.dart
+++ b/packages/tracelet/test/models_test.dart
@@ -260,6 +260,24 @@ void main() {
       },
     );
 
+    test(
+      'GeofenceConfig round-trip preserves geofenceExitAccuracyMax (#276)',
+      () {
+        const config = GeofenceConfig(geofenceExitAccuracyMax: 20);
+        final map = config.toMap();
+        expect(map['geofenceExitAccuracyMax'], 20);
+
+        final restored = GeofenceConfig.fromMap(map);
+        expect(restored.geofenceExitAccuracyMax, 20);
+
+        // Pigeon conversion carries the value too.
+        expect(config.toTlConfig().geofenceExitAccuracyMax, 20);
+
+        // Default is -1 (full accuracy-aware exit gating; issue #274).
+        expect(const GeofenceConfig().geofenceExitAccuracyMax, -1);
+      },
+    );
+
     test('ForegroundServiceConfig equality includes all fields', () {
       const a = ForegroundServiceConfig(
         channelId: 'ch1',

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/TraceletApi.g.kt
@@ -1314,7 +1314,8 @@ data class TlGeofenceConfig (
   val geofenceInitialTriggerEntry: Boolean,
   val geofenceProximityRadius: Long,
   val geofenceInitialTrigger: Boolean,
-  val geofenceModeHighAccuracy: Boolean
+  val geofenceModeHighAccuracy: Boolean,
+  val geofenceExitAccuracyMax: Long
 )
  {
   companion object {
@@ -1323,7 +1324,8 @@ data class TlGeofenceConfig (
       val geofenceProximityRadius = pigeonVar_list[1] as Long
       val geofenceInitialTrigger = pigeonVar_list[2] as Boolean
       val geofenceModeHighAccuracy = pigeonVar_list[3] as Boolean
-      return TlGeofenceConfig(geofenceInitialTriggerEntry, geofenceProximityRadius, geofenceInitialTrigger, geofenceModeHighAccuracy)
+      val geofenceExitAccuracyMax = pigeonVar_list[4] as Long
+      return TlGeofenceConfig(geofenceInitialTriggerEntry, geofenceProximityRadius, geofenceInitialTrigger, geofenceModeHighAccuracy, geofenceExitAccuracyMax)
     }
   }
   fun toList(): List<Any?> {
@@ -1332,6 +1334,7 @@ data class TlGeofenceConfig (
       geofenceProximityRadius,
       geofenceInitialTrigger,
       geofenceModeHighAccuracy,
+      geofenceExitAccuracyMax,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -1342,7 +1345,7 @@ data class TlGeofenceConfig (
       return true
     }
     val other = other as TlGeofenceConfig
-    return TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && TraceletApiPigeonUtils.deepEquals(this.geofenceProximityRadius, other.geofenceProximityRadius) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTrigger, other.geofenceInitialTrigger) && TraceletApiPigeonUtils.deepEquals(this.geofenceModeHighAccuracy, other.geofenceModeHighAccuracy)
+    return TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTriggerEntry, other.geofenceInitialTriggerEntry) && TraceletApiPigeonUtils.deepEquals(this.geofenceProximityRadius, other.geofenceProximityRadius) && TraceletApiPigeonUtils.deepEquals(this.geofenceInitialTrigger, other.geofenceInitialTrigger) && TraceletApiPigeonUtils.deepEquals(this.geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) && TraceletApiPigeonUtils.deepEquals(this.geofenceExitAccuracyMax, other.geofenceExitAccuracyMax)
   }
 
   override fun hashCode(): Int {
@@ -1351,6 +1354,7 @@ data class TlGeofenceConfig (
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceProximityRadius)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceInitialTrigger)
     result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceModeHighAccuracy)
+    result = 31 * result + TraceletApiPigeonUtils.deepHash(this.geofenceExitAccuracyMax)
     return result
   }
 }

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletHostApiImpl.kt
@@ -290,6 +290,7 @@ class TraceletHostApiImpl(
             put("geofenceInitialTriggerEntry", c.geofence.geofenceInitialTriggerEntry)
             put("geofenceProximityRadius", c.geofence.geofenceProximityRadius)
             put("geofenceInitialTrigger", c.geofence.geofenceInitialTrigger)
+            put("geofenceExitAccuracyMax", c.geofence.geofenceExitAccuracyMax)
         })
         put("persistence", buildMap {
             put("persistMode", c.persistence.persistMode.raw)

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletApi.g.swift
@@ -1272,6 +1272,7 @@ struct TlGeofenceConfig: Hashable {
   var geofenceProximityRadius: Int64
   var geofenceInitialTrigger: Bool
   var geofenceModeHighAccuracy: Bool
+  var geofenceExitAccuracyMax: Int64
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -1280,12 +1281,14 @@ struct TlGeofenceConfig: Hashable {
     let geofenceProximityRadius = pigeonVar_list[1] as! Int64
     let geofenceInitialTrigger = pigeonVar_list[2] as! Bool
     let geofenceModeHighAccuracy = pigeonVar_list[3] as! Bool
+    let geofenceExitAccuracyMax = pigeonVar_list[4] as! Int64
 
     return TlGeofenceConfig(
       geofenceInitialTriggerEntry: geofenceInitialTriggerEntry,
       geofenceProximityRadius: geofenceProximityRadius,
       geofenceInitialTrigger: geofenceInitialTrigger,
-      geofenceModeHighAccuracy: geofenceModeHighAccuracy
+      geofenceModeHighAccuracy: geofenceModeHighAccuracy,
+      geofenceExitAccuracyMax: geofenceExitAccuracyMax
     )
   }
   func toList() -> [Any?] {
@@ -1294,13 +1297,14 @@ struct TlGeofenceConfig: Hashable {
       geofenceProximityRadius,
       geofenceInitialTrigger,
       geofenceModeHighAccuracy,
+      geofenceExitAccuracyMax,
     ]
   }
   static func == (lhs: TlGeofenceConfig, rhs: TlGeofenceConfig) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsTraceletApi(lhs.geofenceInitialTriggerEntry, rhs.geofenceInitialTriggerEntry) && deepEqualsTraceletApi(lhs.geofenceProximityRadius, rhs.geofenceProximityRadius) && deepEqualsTraceletApi(lhs.geofenceInitialTrigger, rhs.geofenceInitialTrigger) && deepEqualsTraceletApi(lhs.geofenceModeHighAccuracy, rhs.geofenceModeHighAccuracy)
+    return deepEqualsTraceletApi(lhs.geofenceInitialTriggerEntry, rhs.geofenceInitialTriggerEntry) && deepEqualsTraceletApi(lhs.geofenceProximityRadius, rhs.geofenceProximityRadius) && deepEqualsTraceletApi(lhs.geofenceInitialTrigger, rhs.geofenceInitialTrigger) && deepEqualsTraceletApi(lhs.geofenceModeHighAccuracy, rhs.geofenceModeHighAccuracy) && deepEqualsTraceletApi(lhs.geofenceExitAccuracyMax, rhs.geofenceExitAccuracyMax)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -1309,6 +1313,7 @@ struct TlGeofenceConfig: Hashable {
     deepHashTraceletApi(value: geofenceProximityRadius, hasher: &hasher)
     deepHashTraceletApi(value: geofenceInitialTrigger, hasher: &hasher)
     deepHashTraceletApi(value: geofenceModeHighAccuracy, hasher: &hasher)
+    deepHashTraceletApi(value: geofenceExitAccuracyMax, hasher: &hasher)
   }
 }
 

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletHostApiImpl.swift
@@ -161,6 +161,9 @@ class TraceletHostApiImpl: TraceletHostApi {
         dict["geofenceInitialTriggerEntry"] = c.geofence.geofenceInitialTriggerEntry
         dict["geofenceProximityRadius"] = c.geofence.geofenceProximityRadius
         dict["geofenceInitialTrigger"] = c.geofence.geofenceInitialTrigger
+        // Tunes the accuracy-aware EXIT gating (#274/#276): -1 full gating
+        // (default), 0 disabled, N>0 clamp accuracy to N meters.
+        dict["geofenceExitAccuracyMax"] = c.geofence.geofenceExitAccuracyMax
         // High-accuracy geofencing: cross-platform GeofenceConfig flag, OR'd with
         // the deprecated Android-only flag for backward compatibility. When true,
         // iOS evaluates transitions from continuous GPS (reliable tight radii /

--- a/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
+++ b/packages/tracelet_platform_interface/lib/src/generated/tracelet_api.g.dart
@@ -1429,6 +1429,7 @@ class TlGeofenceConfig {
     required this.geofenceProximityRadius,
     required this.geofenceInitialTrigger,
     required this.geofenceModeHighAccuracy,
+    required this.geofenceExitAccuracyMax,
   });
 
   bool geofenceInitialTriggerEntry;
@@ -1439,12 +1440,15 @@ class TlGeofenceConfig {
 
   bool geofenceModeHighAccuracy;
 
+  int geofenceExitAccuracyMax;
+
   List<Object?> _toList() {
     return <Object?>[
       geofenceInitialTriggerEntry,
       geofenceProximityRadius,
       geofenceInitialTrigger,
       geofenceModeHighAccuracy,
+      geofenceExitAccuracyMax,
     ];
   }
 
@@ -1459,6 +1463,7 @@ class TlGeofenceConfig {
       geofenceProximityRadius: result[1]! as int,
       geofenceInitialTrigger: result[2]! as bool,
       geofenceModeHighAccuracy: result[3]! as bool,
+      geofenceExitAccuracyMax: result[4]! as int,
     );
   }
 
@@ -1477,7 +1482,8 @@ class TlGeofenceConfig {
         ) &&
         _deepEquals(geofenceProximityRadius, other.geofenceProximityRadius) &&
         _deepEquals(geofenceInitialTrigger, other.geofenceInitialTrigger) &&
-        _deepEquals(geofenceModeHighAccuracy, other.geofenceModeHighAccuracy);
+        _deepEquals(geofenceModeHighAccuracy, other.geofenceModeHighAccuracy) &&
+        _deepEquals(geofenceExitAccuracyMax, other.geofenceExitAccuracyMax);
   }
 
   @override

--- a/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
+++ b/packages/tracelet_platform_interface/pigeons/tracelet_api.dart
@@ -417,11 +417,13 @@ class TlGeofenceConfig {
     required this.geofenceProximityRadius,
     required this.geofenceInitialTrigger,
     required this.geofenceModeHighAccuracy,
+    required this.geofenceExitAccuracyMax,
   });
   final bool geofenceInitialTriggerEntry;
   final int geofenceProximityRadius;
   final bool geofenceInitialTrigger;
   final bool geofenceModeHighAccuracy;
+  final int geofenceExitAccuracyMax;
 }
 
 class TlPersistenceConfig {

--- a/packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart
+++ b/packages/tracelet_platform_interface/test/pigeon_tracelet_test.dart
@@ -738,6 +738,7 @@ void main() {
         geofenceProximityRadius: 1000,
         geofenceInitialTrigger: true,
         geofenceModeHighAccuracy: false,
+        geofenceExitAccuracyMax: -1,
       ),
       persistence: TlPersistenceConfig(
         persistMode: TlPersistMode.all,

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
@@ -689,6 +689,11 @@ class ConfigManager(context: Context) {
     fun getGeofenceProximityRadius(): Int =
         getInt("geofenceProximityRadius", DEFAULT_GEOFENCE_PROXIMITY_RADIUS)
 
+    /** Tunes the accuracy-aware geofence EXIT gating (#274/#276).
+     * -1 = full gating (default), 0 = disabled, N>0 = clamp accuracy to N meters. */
+    fun getGeofenceExitAccuracyMax(): Int =
+        getInt("geofenceExitAccuracyMax", -1)
+
     fun getGeofenceInitialTriggerEntry(): Boolean =
         getBool("geofenceInitialTriggerEntry", DEFAULT_GEOFENCE_INITIAL_TRIGGER_ENTRY)
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManager.kt
@@ -342,6 +342,23 @@ class GeofenceManager(
      *
      * Called on each location update when `geofenceModeHighAccuracy` is enabled.
      */
+    /**
+     * Applies the [ConfigManager.getGeofenceExitAccuracyMax] policy to the raw
+     * fix accuracy before it reaches the evaluator's accuracy-aware EXIT test
+     * (#274/#276):
+     * - `-1` (default): pass accuracy through unchanged (full gating).
+     * - `0`: return 0 — disables gating (fastest, drift-prone EXIT).
+     * - `N > 0`: clamp accuracy to N, bounding the worst-case EXIT delay.
+     */
+    private fun effectiveExitAccuracy(accuracy: Double): Double {
+        val max = config.getGeofenceExitAccuracyMax()
+        return when {
+            max < 0 -> accuracy
+            max == 0 -> 0.0
+            else -> minOf(accuracy, max.toDouble())
+        }
+    }
+
     fun evaluateHighAccuracyProximity(latitude: Double, longitude: Double, accuracy: Double = 0.0) {
         val allGeofences = getCachedGeofences()
         if (allGeofences.isEmpty()) return
@@ -350,7 +367,7 @@ class GeofenceManager(
         val transitions = geofenceEvaluator.evaluateProximity(
             latitude = latitude,
             longitude = longitude,
-            accuracy = accuracy,
+            accuracy = effectiveExitAccuracy(accuracy),
             geofences = coreGeofences,
         )
         if (transitions.isEmpty()) return

--- a/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
@@ -237,6 +237,9 @@ public final class ConfigManager {
     public func getStillSampleCount() -> Int { (cache["stillSampleCount"] as? NSNumber)?.intValue ?? 30 }
 
     // GeofenceConfig
+    /// Tunes the accuracy-aware geofence EXIT gating (#274/#276): -1 full gating
+    /// (default), 0 disabled, N>0 clamp accuracy to N meters.
+    public func getGeofenceExitAccuracyMax() -> Int { (cache["geofenceExitAccuracyMax"] as? NSNumber)?.intValue ?? -1 }
     public func getGeofenceInitialTriggerEntry() -> Bool { cache["geofenceInitialTriggerEntry"] as? Bool ?? true }
     public func getGeofenceInitialTrigger() -> Bool { cache["geofenceInitialTrigger"] as? Bool ?? true }
     public func getGeofenceModeKnockOut() -> Bool { cache["geofenceModeKnockOut"] as? Bool ?? false }
@@ -462,6 +465,7 @@ public final class ConfigManager {
             "disableElasticity": false,
             "elasticityMultiplier": 1.0,
             "geofenceProximityRadius": 1000.0,
+            "geofenceExitAccuracyMax": -1,
             "locationUpdateInterval": 1000,
             "fastestLocationUpdateInterval": -1,
             "deferTime": 0,

--- a/sdk/ios/Sources/TraceletSDK/geofence/GeofenceManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/geofence/GeofenceManager.swift
@@ -258,6 +258,18 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
     /// and geofencesChange events via `TraceletEventSending`.
     ///
     /// Called on each location update when `geofenceModeHighAccuracy` is enabled.
+    /// Applies the `getGeofenceExitAccuracyMax` policy to the raw fix accuracy
+    /// before it reaches the evaluator's accuracy-aware EXIT test (#274/#276):
+    /// - `-1` (default): pass accuracy through unchanged (full gating).
+    /// - `0`: return 0 — disables gating (fastest, drift-prone EXIT).
+    /// - `N > 0`: clamp accuracy to N, bounding the worst-case EXIT delay.
+    private func effectiveExitAccuracy(_ accuracy: Double) -> Double {
+        let max = configManager.getGeofenceExitAccuracyMax()
+        if max < 0 { return accuracy }
+        if max == 0 { return 0.0 }
+        return Swift.min(accuracy, Double(max))
+    }
+
     public func evaluateHighAccuracyProximity(latitude: Double, longitude: Double, accuracy: Double = 0.0) {
         let allGeofences = getCachedGeofences()
         if allGeofences.isEmpty { return }
@@ -266,7 +278,7 @@ public final class GeofenceManager: NSObject, CLLocationManagerDelegate {
         let transitions = geofenceEvaluator.evaluateProximity(
             latitude: latitude,
             longitude: longitude,
-            accuracy: accuracy,
+            accuracy: effectiveExitAccuracy(accuracy),
             geofences: coreGeofences
         )
         if transitions.isEmpty { return }

--- a/website/app/en/api-reference/page.mdx
+++ b/website/app/en/api-reference/page.mdx
@@ -182,6 +182,12 @@ Cross-platform geofencing behavior (iOS + Android).
   Fire an ENTER immediately if the device is already inside a geofence when it is registered.
 - **`geofenceProximityRadius`**: `int` *(Default: `1000`)*
   Radius (meters) for proximity-based loading — only geofences within this distance are actively registered with the OS (lets you manage far more than the iOS 20-region limit).
+- **`geofenceExitAccuracyMax`**: `int` *(Default: `-1`)*
+  Tunes the accuracy-aware EXIT gating in **high-accuracy mode** (no effect in standard mode). A circular geofence only EXITs once the whole GPS error circle clears the fence (`distance - accuracy > radius + buffer`), which prevents a single high-drift fix from firing a false EXIT while a device sits still inside a small fence — at the cost of delaying a genuine exit by roughly the GPS uncertainty.
+  - **`-1` (default)** — full gating; most resistant to false exits.
+  - **`0`** — gating disabled; fastest exit, but drift-prone (pre-fix behavior).
+  - **`N > 0`** — clamp accuracy to `N` meters; absorbs drift up to `N` while bounding the worst-case exit delay to ~`N` meters.
+  [See GPS drift & false EXIT 📖](/en/core/geofencing)
 
 ---
 

--- a/website/app/en/core/geofencing/page.mdx
+++ b/website/app/en/core/geofencing/page.mdx
@@ -176,3 +176,64 @@ foreground service. That is continuous location — not "geofencing" in the poli
 sense — so only enable it when your app has a separate permitted location use
 case. For most apps, standard mode is the compliant and battery-efficient choice.
 </Callout>
+
+## 6. GPS drift and false EXIT events (high-accuracy mode)
+
+In high-accuracy mode, transitions are evaluated in-app from every GPS fix. A
+device standing still just inside a small geofence can occasionally receive a
+single fix that drifts well outside the radius — even though it never moved. To
+prevent that from firing a false EXIT, Tracelet's exit decision is
+**accuracy-aware**: a circular geofence only EXITs once the *entire* GPS error
+circle clears the fence:
+
+```text
+EXIT fires when:  distance - horizontalAccuracy > radius + buffer
+```
+
+A fix reported 160 m out but with ±150 m accuracy is only "10 m out" at its most
+optimistic, so it is treated as still inside and no EXIT fires. A confident,
+accurate fix at the same distance exits normally. ENTER is intentionally left
+accuracy-agnostic, so arrivals still trigger promptly.
+
+### The tradeoff
+
+Because the exit threshold grows with the fix's reported accuracy, a **genuine**
+departure is delayed by roughly the current GPS uncertainty. For a 50 m geofence
+(70 m exit threshold):
+
+| Horizontal accuracy | EXIT fires at ~ |
+| ------------------- | --------------- |
+| ±8 m (good, outdoors) | 78 m |
+| ±20 m (typical) | 90 m |
+| ±50 m (poor) | 120 m |
+| ±150 m (very poor) | 220 m |
+
+Outdoors with a good signal this is negligible. In chronically poor-GPS
+conditions (deep indoors, urban canyons) a real exit can lag noticeably.
+
+### Tuning it: `geofenceExitAccuracyMax`
+
+If your use case prefers a faster, more eager EXIT — or you want to bound the
+worst-case delay — set `GeofenceConfig.geofenceExitAccuracyMax` (in meters):
+
+| Value | Behavior |
+| ----- | -------- |
+| `-1` *(default)* | Full accuracy gating. Most resistant to drift-induced false exits; genuine exits may lag by the current GPS uncertainty. |
+| `0` | Gating disabled. EXIT fires as soon as the reported point clears `radius + buffer` — fastest exit, but a single drift spike can produce a false EXIT. |
+| `N > 0` | Clamp. Absorb drift up to `N` meters, but never delay a genuine EXIT by more than ~`N` meters. A good middle ground for small fences in mixed conditions (e.g. `20`). |
+
+```dart
+await tl.Tracelet.ready(const tl.Config(
+  geofence: tl.GeofenceConfig(
+    geofenceModeHighAccuracy: true,
+    // Absorb drift up to 20 m, but keep genuine exits reasonably prompt.
+    geofenceExitAccuracyMax: 20,
+  ),
+));
+```
+
+<Callout type="info">
+This gating applies only to the **high-accuracy** in-app path. In standard
+(OS region-monitoring) mode the operating system decides EXIT, and
+`geofenceExitAccuracyMax` has no effect.
+</Callout>


### PR DESCRIPTION
…it (#276)

Follow-up to #274. The accuracy-aware EXIT gating (a geofence only EXITs once the whole GPS error circle clears the fence) prevents drift-induced false exits but delays a genuine exit by roughly the GPS uncertainty, which can be noticeable where GPS is chronically poor.

Adds GeofenceConfig.geofenceExitAccuracyMax (int, meters) to tune it:
  -1 (default) full gating; 0 disables gating (fast, pre-#274 exit);
  N>0 clamps the accuracy used in the exit test to N, bounding the
  worst-case exit delay while still absorbing drift up to N.

Applied natively in GeofenceManager.evaluateHighAccuracyProximity via an effectiveExitAccuracy() clamp before calling the evaluator, so no Rust or UniFFI change is required. High-accuracy path only; no effect in standard OS region-monitoring mode.

- pigeon: add field to TlGeofenceConfig + regenerate (dart/kotlin/swift)
- dart: GeofenceConfig field/fromMap/toMap/toTlConfig/==/hashCode + test
- native: flatten into config map (both platforms), ConfigManager getter (default -1), clamp helper in GeofenceManager (both platforms)
- docs: geofencing page section (behavior + tradeoff + tuning) and api-reference GeofenceConfig entry