### PR TITLE
test(geofence): example card + tests for geofenceExitAccuracyMax (#276)

### DIFF
--- a/example/lib/issues/issue_276_card.dart
+++ b/example/lib/issues/issue_276_card.dart
@@ -1,0 +1,177 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #276 — tunable accuracy-aware geofence EXIT (`geofenceExitAccuracyMax`).
+///
+/// #274 made the high-accuracy EXIT decision accuracy-aware so a single
+/// high-drift GPS fix can't fire a false EXIT while a device sits still inside
+/// a small geofence. The tradeoff is that a *genuine* departure is delayed by
+/// roughly the GPS uncertainty. `GeofenceConfig.geofenceExitAccuracyMax` lets
+/// apps tune that:
+///
+///   • `-1` (default) — full gating (most drift-resistant).
+///   • `0`            — gating off (fastest exit, drift-prone / pre-#274).
+///   • `N > 0`        — clamp accuracy to N m (bounded delay, still absorbs
+///                      drift up to N).
+///
+/// This card drives the REAL shipped [GeofenceEvaluator], applying the exact
+/// clamp the native layer applies (`effectiveExitAccuracy`), and runs the same
+/// scenario under all three settings for a 50 m geofence (exit threshold 70 m):
+///
+///   1. ENTER with a solid ±8 m fix ~10 m from center.
+///   2. Stationary DRIFT spike: reported ~85 m out but with ±150 m accuracy
+///      (device never moved).
+///   3. GENUINE departure: ~120 m out with a tight ±10 m accuracy.
+///
+/// Expected — confirming the knob behaves as documented:
+///   • `-1` and `N=20` → absorb the drift (no false EXIT) AND detect the real
+///     departure. Ideal.
+///   • `0` → fires a false EXIT on the drift (fast but drift-prone).
+class Issue276Card extends StatefulWidget {
+  const Issue276Card({super.key});
+
+  @override
+  State<Issue276Card> createState() => _Issue276CardState();
+}
+
+class _Issue276CardState extends State<Issue276Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  /// Mirrors the native `GeofenceManager.effectiveExitAccuracy` clamp so the
+  /// in-process demo matches on-device behavior:
+  /// `-1` pass-through, `0` disables gating, `N>0` clamps to N.
+  static double _effectiveExitAccuracy(double accuracy, int exitAccuracyMax) {
+    if (exitAccuracyMax < 0) return accuracy;
+    if (exitAccuracyMax == 0) return 0;
+    return math.min(accuracy, exitAccuracyMax.toDouble());
+  }
+
+  /// Runs the enter → stationary-drift → genuine-departure sequence for one
+  /// `geofenceExitAccuracyMax` setting. Returns whether the drift produced a
+  /// (false) EXIT and whether the genuine departure produced an EXIT.
+  ({bool driftExit, bool realExit}) _runScenario(int exitAccuracyMax) {
+    const centerLat = 37.4219983;
+    const centerLng = -122.084;
+    final geofences = <Map<String, Object?>>[
+      {
+        'identifier': 'issue-276',
+        'latitude': centerLat,
+        'longitude': centerLng,
+        'radius': 50.0, // exit threshold = 70 m
+      },
+    ];
+
+    final evaluator = GeofenceEvaluator();
+
+    ({double lat, double lng}) north(double d) =>
+        (lat: centerLat + d / 111320.0, lng: centerLng);
+
+    List<GeofenceTransition> eval(double d, double acc) {
+      final p = north(d);
+      return evaluator.evaluateProximity(
+        latitude: p.lat,
+        longitude: p.lng,
+        accuracy: _effectiveExitAccuracy(acc, exitAccuracyMax),
+        geofences: geofences,
+      );
+    }
+
+    // 1. Enter well inside with good accuracy.
+    eval(10, 8);
+
+    // 2. Stationary drift spike (reported far out, but low-confidence).
+    final drift = eval(85, 150);
+    final driftExit = drift.any((t) => t.action == 'EXIT');
+
+    // 3. Genuine, accurate departure.
+    final real = eval(120, 10);
+    final realExit = real.any((t) => t.action == 'EXIT');
+
+    return (driftExit: driftExit, realExit: realExit);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    try {
+      const modes = <int>[-1, 0, 20];
+      final log = StringBuffer();
+      final results = <int, ({bool driftExit, bool realExit})>{};
+
+      for (final m in modes) {
+        final r = _runScenario(m);
+        results[m] = r;
+        final label = m == -1
+            ? 'full gating'
+            : m == 0
+            ? 'gating off'
+            : 'clamp ${m}m';
+        log.writeln(
+          'geofenceExitAccuracyMax=$m ($label): '
+          'drift→${r.driftExit ? 'EXIT (false)' : 'held'}, '
+          'departure→${r.realExit ? 'EXIT' : 'no exit'}',
+        );
+      }
+
+      final full = results[-1]!;
+      final off = results[0]!;
+      final clamp = results[20]!;
+
+      // Documented behavior: full & clamp absorb the stationary drift yet still
+      // detect the genuine departure; disabling gating lets the drift through.
+      final ok =
+          !full.driftExit &&
+          full.realExit &&
+          !clamp.driftExit &&
+          clamp.realExit &&
+          off.driftExit &&
+          off.realExit;
+
+      if (ok) {
+        _set(
+          '✅ SUCCESS: geofenceExitAccuracyMax behaves as documented.\n\n'
+          '$log\n'
+          '• -1 (default) and 20 m absorbed the ±150 m stationary drift AND '
+          'still fired EXIT on the genuine departure.\n'
+          '• 0 fired a false EXIT on the drift — the eager, pre-#274 behavior '
+          'you opt into for the fastest exits.',
+        );
+      } else {
+        _set('❌ FAILED: unexpected behavior for one or more settings.\n\n$log');
+      }
+    } catch (e) {
+      _set('❌ FAILED: $e');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'geofence exit accuracy max geofenceExitAccuracyMax tunable gating '
+          'gps drift false exit clamp high accuracy geofenceevaluator 276 274',
+      title:
+          '#276: Tunable accuracy-aware geofence EXIT (geofenceExitAccuracyMax)',
+      description:
+          'Drives the real GeofenceEvaluator under all three '
+          'geofenceExitAccuracyMax settings (-1 full gating, 0 off, 20 m clamp) '
+          'for a 50 m geofence, running the same enter → stationary-drift → '
+          'genuine-departure sequence. Confirms full/clamp absorb a ±150 m '
+          'drift spike while still detecting a real departure, and that '
+          'disabling gating (0) reproduces the eager pre-#274 exit. Runs '
+          'in-process; no permissions or movement required.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -38,6 +38,7 @@ import 'package:tracelet_example/issues/issue_267_card.dart';
 import 'package:tracelet_example/issues/issue_268_card.dart';
 import 'package:tracelet_example/issues/issue_270_card.dart';
 import 'package:tracelet_example/issues/issue_274_card.dart';
+import 'package:tracelet_example/issues/issue_276_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1710,6 +1711,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                   // own title/description/keywords via IssueSearchScope, so they
                   // are rendered directly. Cards with a bespoke layout (no shell)
                   // stay wrapped in _searchableCard with explicit keywords.
+                  const Issue276Card(),
                   const Issue274Card(),
                   const Issue270Card(),
                   const Issue268Card(),

--- a/packages/tracelet_platform_interface/test/algorithms/geofence_evaluator_test.dart
+++ b/packages/tracelet_platform_interface/test/algorithms/geofence_evaluator_test.dart
@@ -453,5 +453,90 @@ void main() async {
       expect(transitions, hasLength(1));
       expect(transitions[0].action, 'ENTER');
     });
+
+    // ── geofenceExitAccuracyMax regimes (#276) ────────────────────────────
+    //
+    // The native GeofenceManager clamps the raw fix accuracy before it reaches
+    // the evaluator. These tests exercise the evaluator with the exact clamp
+    // (`effectiveExitAccuracy`) the native layer applies, for a 50 m fence
+    // (exit threshold 70 m): ENTER inside, then a *stationary* ±150 m drift
+    // spike reported ~85 m out.
+    double effectiveExitAccuracy(double accuracy, int exitAccuracyMax) {
+      if (exitAccuracyMax < 0) return accuracy;
+      if (exitAccuracyMax == 0) return 0;
+      return accuracy < exitAccuracyMax ? accuracy : exitAccuracyMax.toDouble();
+    }
+
+    bool driftExitsUnder(int exitAccuracyMax, {required GeofenceEvaluator ev}) {
+      const centerLat = 37.4219983;
+      const centerLng = -122.084;
+      final geofences = <Map<String, Object?>>[
+        {
+          'identifier': 'gate',
+          'latitude': centerLat,
+          'longitude': centerLng,
+          'radius': 50.0,
+        },
+      ];
+      final inside = pointNorth(centerLat, centerLng, 10);
+      ev.evaluateProximity(
+        latitude: inside.lat,
+        longitude: inside.lng,
+        accuracy: effectiveExitAccuracy(8, exitAccuracyMax),
+        geofences: geofences,
+      );
+      final drift = pointNorth(centerLat, centerLng, 85);
+      final t = ev.evaluateProximity(
+        latitude: drift.lat,
+        longitude: drift.lng,
+        accuracy: effectiveExitAccuracy(150, exitAccuracyMax),
+        geofences: geofences,
+      );
+      return t.any((e) => e.action == 'EXIT');
+    }
+
+    test('geofenceExitAccuracyMax = -1 (full gating) absorbs drift (#276)', () {
+      expect(driftExitsUnder(-1, ev: evaluator), isFalse);
+    });
+
+    test('geofenceExitAccuracyMax = 0 (disabled) lets drift EXIT (#276)', () {
+      expect(driftExitsUnder(0, ev: evaluator), isTrue);
+    });
+
+    test('geofenceExitAccuracyMax = 20 (clamp) absorbs drift (#276)', () {
+      expect(driftExitsUnder(20, ev: evaluator), isFalse);
+    });
+
+    test(
+      'geofenceExitAccuracyMax = 20 still allows a genuine departure (#276)',
+      () {
+        const centerLat = 37.4219983;
+        const centerLng = -122.084;
+        final geofences = <Map<String, Object?>>[
+          {
+            'identifier': 'gate',
+            'latitude': centerLat,
+            'longitude': centerLng,
+            'radius': 50.0,
+          },
+        ];
+        final inside = pointNorth(centerLat, centerLng, 10);
+        evaluator.evaluateProximity(
+          latitude: inside.lat,
+          longitude: inside.lng,
+          accuracy: effectiveExitAccuracy(8, 20),
+          geofences: geofences,
+        );
+        // 120 m out, ±10 m: clamp keeps 10 → 120 - 10 = 110 > 70 → EXIT.
+        final far = pointNorth(centerLat, centerLng, 120);
+        final t = evaluator.evaluateProximity(
+          latitude: far.lat,
+          longitude: far.lng,
+          accuracy: effectiveExitAccuracy(10, 20),
+          geofences: geofences,
+        );
+        expect(t.where((e) => e.action == 'EXIT'), hasLength(1));
+      },
+    );
   });
 }

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerExitAccuracyTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/geofence/GeofenceManagerExitAccuracyTest.kt
@@ -1,0 +1,112 @@
+package com.ikolvi.tracelet.sdk.geofence
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.ConfigManager
+import com.ikolvi.tracelet.sdk.ListenerEventSender
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import uniffi.tracelet_core.DatabaseManager
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies `GeofenceConfig.geofenceExitAccuracyMax` (#276) tunes the
+ * accuracy-aware EXIT gating introduced in #274.
+ *
+ * Scenario for a 50 m geofence (exit threshold = radius + max(radius*0.1, 20) =
+ * 70 m): ENTER at center, then a *stationary* ±150 m drift spike reported ~85 m
+ * out (the device never moved). The gating policy decides whether that spike
+ * fires a (false) EXIT:
+ * - `-1` (default): full gating → `85 - 150 < 70` → held, no EXIT.
+ * - `0`: gating off → `85 - 0 > 70` → EXIT (drift-prone).
+ * - `20`: clamp → `85 - 20 = 65 < 70` → held, yet a genuine accurate departure
+ *   still exits.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GeofenceManagerExitAccuracyTest {
+
+    private lateinit var context: Context
+    private lateinit var config: ConfigManager
+    private lateinit var db: DatabaseManager
+    private lateinit var geoManager: GeofenceManager
+    private val captured = mutableListOf<Map<String, Any?>>()
+
+    private val centerLat = 10.787929
+    private val centerLng = 76.684183
+    private val radius = 50.0 // exit threshold = 70 m
+
+    // ~meters due north of the center (1 deg lat ~= 111_320 m).
+    private fun north(meters: Double) = centerLat + meters / 111320.0
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        config = ConfigManager.getInstance(context)
+
+        val dbPath = context.filesDir.resolve("test_geofence_exit_accuracy.db").absolutePath
+        db = DatabaseManager(dbPath)
+        db.setEncryptionKey("")
+        db.clearGeofences()
+        db.insertGeofence("ZONE_276", centerLat, centerLng, radius, null, null)
+
+        geoManager = GeofenceManager(context, config, ListenerEventSender(), db)
+        geoManager.onGeofenceEvent = { captured.add(it) }
+        geoManager.clearHighAccuracyState()
+    }
+
+    @After
+    fun tearDown() {
+        ConfigManager.resetInstance()
+        context.filesDir.resolve("test_geofence_exit_accuracy.db").delete()
+    }
+
+    private fun exitCount(): Int = captured.count {
+        ((it["geofence"] as? Map<*, *>)?.get("action") as? String) == "EXIT"
+    }
+
+    private fun configure(exitAccuracyMax: Int) {
+        config.setConfig(
+            mapOf(
+                "geofenceModeHighAccuracy" to true,
+                "geofenceExitAccuracyMax" to exitAccuracyMax,
+            ),
+        )
+    }
+
+    /** ENTER inside, then a stationary ±150 m drift spike reported ~85 m out. */
+    private fun enterThenDrift() {
+        geoManager.evaluateHighAccuracyProximity(centerLat, centerLng, 8.0)
+        geoManager.evaluateHighAccuracyProximity(north(85.0), centerLng, 150.0)
+    }
+
+    @Test
+    fun `default full gating absorbs a high-drift fix (no false EXIT)`() {
+        configure(-1)
+        enterThenDrift()
+        assertEquals(0, exitCount(), "full gating must not EXIT on a ±150 m drift spike")
+    }
+
+    @Test
+    fun `gating disabled fires EXIT on the drift spike`() {
+        configure(0)
+        enterThenDrift()
+        assertTrue(exitCount() >= 1, "with gating off, the drift spike should fire EXIT")
+    }
+
+    @Test
+    fun `clamp absorbs drift but still allows a genuine departure to EXIT`() {
+        configure(20)
+        enterThenDrift()
+        assertEquals(0, exitCount(), "clamp 20 m must absorb the ±150 m drift spike")
+
+        // Genuine, accurate departure ~120 m out: 120 - 10 = 110 > 70 -> EXIT.
+        geoManager.evaluateHighAccuracyProximity(north(120.0), centerLng, 10.0)
+        assertTrue(exitCount() >= 1, "a genuine accurate departure must still EXIT")
+    }
+}


### PR DESCRIPTION
Adds an in-process example card and tests exercising the tunable accuracy-aware EXIT gating from #276.

- example: Issue276Card drives the real GeofenceEvaluator under all three geofenceExitAccuracyMax settings (-1 full, 0 off, 20 clamp), applying the same clamp the native layer uses, and confirms full/clamp absorb a stationary +/-150m drift spike while still detecting a genuine departure, and that disabling gating (0) reproduces the eager pre-#274 exit
- android: GeofenceManagerExitAccuracyTest verifies the native clamp wiring end-to-end (-1 no false exit, 0 fires exit, 20 absorbs drift yet exits on a genuine departure)
- dart: four evaluator-level regime tests mirroring the native clamp

melos format + analyze both pass. Dart evaluator tests: 19/19 pass.