### PR TITLE
fix(doctor): a granted motion permission no longer reads as "Restricted"

### DIFF
--- a/packages/tracelet/CHANGELOG.md
+++ b/packages/tracelet/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **FEAT**: `TraceletBugReport` gained a **Geofence transitions (decision trace)** section that lifts `[geofence]` lines out of the general log stream and scans `geofenceTraceLimit` (2000) entries rather than the 500-entry log window. Crossings are rare while lifecycle chatter is not, so in a busy app the transitions were being pushed out of the exported window before anyone generated a report.
 
+**FIX**: `HealthCheck.motionPermission` is documented correctly and gained a typed `HealthCheck.motionAuthorization` getter. The field carries a `MotionAuthorizationStatus` index (`notDetermined`, `granted`, `deniedForever` → 0, 1, 2), but its doc comment described CoreMotion's `CMAuthorizationStatus` scale, which orders the cases differently and has a separate `restricted` value. Callers that implemented the documented contract — including Tracelet Doctor — reported a *granted* permission as "Restricted". The new getter returns the typed value (`null` when out of range) so the mapping cannot be misread.
+
 **PERF**: the native loggers no longer run a `DELETE` after every log write. Retention is 500-2000 rows, so pruning is now amortized every 50 writes on both platforms.
 
 ## 3.7.2

--- a/packages/tracelet/lib/src/models/health_check.dart
+++ b/packages/tracelet/lib/src/models/health_check.dart
@@ -425,14 +425,31 @@ class HealthCheck {
   /// Current location authorization status.
   final AuthorizationStatus locationPermission;
 
-  /// Motion / activity recognition permission status.
+  /// Motion / activity recognition permission status, as a
+  /// [MotionAuthorizationStatus] index.
   ///
-  /// Platform values:
-  /// - `0` — not determined
-  /// - `1` — restricted
-  /// - `2` — denied
-  /// - `3` — authorized / granted
+  /// - `0` — [MotionAuthorizationStatus.notDetermined]
+  /// - `1` — [MotionAuthorizationStatus.granted]
+  /// - `2` — [MotionAuthorizationStatus.deniedForever]
+  ///
+  /// Note this is **not** CoreMotion's `CMAuthorizationStatus` scale, which
+  /// orders the cases differently and has a separate `restricted` value. This
+  /// doc comment previously described that scale, and callers that decoded the
+  /// int accordingly reported a granted permission as "Restricted".
+  ///
+  /// Prefer [motionAuthorization], which returns the typed value so the
+  /// mapping cannot be misread.
   final int motionPermission;
+
+  /// [motionPermission] decoded into its source enum.
+  ///
+  /// Returns `null` if the value is outside the enum's range, which can happen
+  /// when a report is deserialized from a newer or malformed payload.
+  MotionAuthorizationStatus? get motionAuthorization =>
+      motionPermission >= 0 &&
+          motionPermission < MotionAuthorizationStatus.values.length
+      ? MotionAuthorizationStatus.values[motionPermission]
+      : null;
 
   /// Accuracy authorization level (iOS 14+).
   ///

--- a/packages/tracelet/test/health_check_motion_permission_test.dart
+++ b/packages/tracelet/test/health_check_motion_permission_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet/tracelet.dart';
+
+/// Pins the meaning of [HealthCheck.motionPermission].
+///
+/// The field is populated from `MotionAuthorizationStatus.index`
+/// (`notDetermined`, `granted`, `deniedForever` → 0, 1, 2) but was documented as
+/// CoreMotion's `CMAuthorizationStatus` scale, which orders the cases
+/// differently and has an extra `restricted` value. Doctor implemented the
+/// documented contract, so a device with motion activity **granted** displayed a
+/// red "Restricted" while the warning list simultaneously reported "All Clear".
+///
+/// The two scales disagreeing is the actual defect, so these tests assert the
+/// decoding against the enum itself rather than against hardcoded integers.
+void main() {
+  group('HealthCheck.motionAuthorization', () {
+    HealthCheck withMotion(int value) => HealthCheck(
+      trackingEnabled: true,
+      trackingMode: TrackingMode.location,
+      timestamp: DateTime.utc(2026, 8, 2),
+      motionPermission: value,
+    );
+
+    test('decodes each index to its MotionAuthorizationStatus', () {
+      for (final status in MotionAuthorizationStatus.values) {
+        expect(
+          withMotion(status.index).motionAuthorization,
+          status,
+          reason: 'index ${status.index} must decode to $status',
+        );
+      }
+    });
+
+    test('index 1 is granted, not restricted', () {
+      // The regression itself. CMAuthorizationStatus puts `restricted` at 1;
+      // this enum puts `granted` there.
+      expect(
+        withMotion(1).motionAuthorization,
+        MotionAuthorizationStatus.granted,
+      );
+    });
+
+    test('returns null for an out-of-range value', () {
+      // A newer or malformed payload must not throw or silently alias onto a
+      // valid case.
+      expect(withMotion(-1).motionAuthorization, isNull);
+      expect(
+        withMotion(MotionAuthorizationStatus.values.length).motionAuthorization,
+        isNull,
+      );
+    });
+
+    test('the denied warning threshold matches deniedForever', () {
+      // _computeWarnings hardcodes `motionPermission == 2`. If the enum ever
+      // gains or reorders a case, that constant silently stops meaning "denied".
+      expect(MotionAuthorizationStatus.deniedForever.index, 2);
+    });
+
+    test('granted does not raise the motion-permission warning', () {
+      final health = HealthCheck.fromMaps(
+        state: const <String, Object?>{},
+        provider: const <String, Object?>{},
+        settingsHealth: const <String, Object?>{},
+        sensors: const <String, Object?>{
+          'accelerometer': true,
+          'significantMotion': true,
+        },
+        deviceInfo: const <String, Object?>{},
+        isPowerSave: false,
+        ignoringBatteryOpt: true,
+        locationPermissionStatus: AuthorizationStatus.always.index,
+        motionPermissionStatus: MotionAuthorizationStatus.granted.index,
+        dbCount: 0,
+      );
+
+      expect(health.motionAuthorization, MotionAuthorizationStatus.granted);
+      expect(
+        health.warnings,
+        isNot(contains(HealthWarning.motionPermissionDenied)),
+        reason: 'a granted permission must not be reported as denied',
+      );
+    });
+
+    test('deniedForever does raise the motion-permission warning', () {
+      final health = HealthCheck.fromMaps(
+        state: const <String, Object?>{},
+        provider: const <String, Object?>{},
+        settingsHealth: const <String, Object?>{},
+        sensors: const <String, Object?>{
+          'accelerometer': true,
+          'significantMotion': true,
+        },
+        deviceInfo: const <String, Object?>{},
+        isPowerSave: false,
+        ignoringBatteryOpt: true,
+        locationPermissionStatus: AuthorizationStatus.always.index,
+        motionPermissionStatus: MotionAuthorizationStatus.deniedForever.index,
+        dbCount: 0,
+      );
+
+      expect(health.warnings, contains(HealthWarning.motionPermissionDenied));
+    });
+  });
+}

--- a/packages/tracelet_doctor/CHANGELOG.md
+++ b/packages/tracelet_doctor/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 3.7.3
 
-Version alignment with tracelet 3.7.3.
+**FIX**: the Permissions card no longer reports a granted motion/activity permission as a red "Restricted". `HealthCheck.motionPermission` carries a `MotionAuthorizationStatus` index (`notDetermined`, `granted`, `deniedForever` → 0, 1, 2), but the card decoded it against CoreMotion's `CMAuthorizationStatus` scale, where index 1 is `restricted` — so a healthy device showed a red "Restricted" beside an "All Clear" warning list, the warning path checking `== 2` and being unaffected. The card now switches over the enum via the new `HealthCheck.motionAuthorization` getter, which makes the mapping exhaustive at compile time, and the dead `3 => 'Granted'` branch (unreachable — the enum has no index 3) is gone.
+
+**FIX**: the bug report prints the motion permission by name rather than as a bare index, so `Motion permission | 0` no longer reads as a boolean or a count.
+
+**FEAT**: the bug report gained a **Geofence transitions (decision trace)** section, filtering `[geofence]` log lines and scanning 2000 entries rather than the 500-entry general log window, so rare ENTER/EXIT crossings are not buried by lifecycle chatter. Both the copy and share actions include it.
 
 ## 3.7.2
 

--- a/packages/tracelet_doctor/lib/src/bug_report.dart
+++ b/packages/tracelet_doctor/lib/src/bug_report.dart
@@ -120,7 +120,15 @@ class TraceletBugReport {
       buffer.writeln(
         '| Location permission | ${health.locationPermission.name} |',
       );
-      buffer.writeln('| Motion permission | ${health.motionPermission} |');
+      // Name, not the raw index. `Motion permission | 0` in a bug report is
+      // ambiguous — it reads as a boolean or a count, and it can't be checked
+      // against the enum without opening the source. Keep the index alongside
+      // it since the field is still an int on the wire.
+      buffer.writeln(
+        '| Motion permission | '
+        '${health.motionAuthorization?.name ?? 'unknown'} '
+        '(${health.motionPermission}) |',
+      );
       buffer.writeln('| Accuracy | ${health.accuracyAuthorization.name} |');
       buffer.writeln(
         '| Location services | ${health.locationServicesEnabled} |',

--- a/packages/tracelet_doctor/lib/src/doctor_sheet.dart
+++ b/packages/tracelet_doctor/lib/src/doctor_sheet.dart
@@ -137,7 +137,8 @@ class _DoctorSheetContentState extends State<_DoctorSheetContent>
 
   bool _busyReport = false;
 
-  /// Builds the full bug report (health + config + logs + telematics).
+  /// Builds the full bug report (health + foreground-service health + config +
+  /// telematics + geofence decision trace + logs).
   Future<String?> _buildReport() async {
     setState(() => _busyReport = true);
     try {

--- a/packages/tracelet_doctor/lib/src/widgets/permission_card.dart
+++ b/packages/tracelet_doctor/lib/src/widgets/permission_card.dart
@@ -27,18 +27,24 @@ class PermissionCard extends StatelessWidget {
       AuthorizationStatus.notDetermined => 'Not Determined',
     };
 
-    final motionLabel = switch (health.motionPermission) {
-      0 => 'Not Determined',
-      1 => 'Restricted',
-      2 => 'Denied',
-      3 => 'Granted',
-      _ => 'Unknown',
+    // Switch over the enum rather than raw indices: HealthCheck.motionPermission
+    // carries a MotionAuthorizationStatus index, and decoding it against
+    // CoreMotion's CMAuthorizationStatus scale reported `granted` (index 1) as a
+    // red "Restricted". An exhaustive switch also means adding an enum case
+    // fails to compile instead of silently falling through to "Unknown".
+    final motionStatus = health.motionAuthorization;
+    final motionLabel = switch (motionStatus) {
+      MotionAuthorizationStatus.notDetermined => 'Not Determined',
+      MotionAuthorizationStatus.granted => 'Granted',
+      MotionAuthorizationStatus.deniedForever => 'Denied',
+      null => 'Unknown',
     };
-    final motionColor = health.motionPermission == 3
-        ? DoctorTheme.success
-        : health.motionPermission == 0
-        ? DoctorTheme.warning
-        : DoctorTheme.error;
+    final motionColor = switch (motionStatus) {
+      MotionAuthorizationStatus.granted => DoctorTheme.success,
+      MotionAuthorizationStatus.notDetermined => DoctorTheme.warning,
+      MotionAuthorizationStatus.deniedForever => DoctorTheme.error,
+      null => DoctorTheme.warning,
+    };
 
     final accuracyLabel =
         health.accuracyAuthorization == AccuracyAuthorization.full

--- a/packages/tracelet_doctor/test/permission_card_motion_label_test.dart
+++ b/packages/tracelet_doctor/test/permission_card_motion_label_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_doctor/src/doctor_theme.dart';
+import 'package:tracelet_doctor/src/widgets/permission_card.dart';
+
+/// Pins the motion-activity label rendered by [PermissionCard].
+///
+/// `HealthCheck.motionPermission` carries a `MotionAuthorizationStatus` index
+/// (`notDetermined`, `granted`, `deniedForever` → 0, 1, 2), but the card decoded
+/// it against CoreMotion's `CMAuthorizationStatus` scale, where index 1 is
+/// `restricted`. A device with motion activity **granted** therefore showed a red
+/// "Restricted", while the warning list beside it correctly said "All Clear" —
+/// the warning path uses `== 2`, so it was unaffected.
+///
+/// The old switch also had a `3 => 'Granted'` branch that could never be reached,
+/// since the enum has no index 3.
+void main() {
+  HealthCheck healthWithMotion(MotionAuthorizationStatus status) => HealthCheck(
+    trackingEnabled: true,
+    trackingMode: TrackingMode.location,
+    timestamp: DateTime.utc(2026, 8, 2),
+    locationPermission: AuthorizationStatus.always,
+    motionPermission: status.index,
+  );
+
+  Future<void> pump(WidgetTester tester, HealthCheck health) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          backgroundColor: DoctorTheme.sheetBackground,
+          body: SingleChildScrollView(child: PermissionCard(health: health)),
+        ),
+      ),
+    );
+  }
+
+  /// The colour the card applied to the motion value.
+  Color? motionValueColor(WidgetTester tester, String label) {
+    final text = tester.widget<Text>(find.text(label));
+    return text.style?.color;
+  }
+
+  group('PermissionCard motion activity label', () {
+    testWidgets('granted renders as Granted, never Restricted', (tester) async {
+      await pump(tester, healthWithMotion(MotionAuthorizationStatus.granted));
+
+      expect(find.text('Granted'), findsOneWidget);
+      expect(
+        find.text('Restricted'),
+        findsNothing,
+        reason: 'a granted motion permission must not read as Restricted',
+      );
+    });
+
+    testWidgets('granted is coloured as success, not error', (tester) async {
+      await pump(tester, healthWithMotion(MotionAuthorizationStatus.granted));
+
+      expect(
+        motionValueColor(tester, 'Granted'),
+        DoctorTheme.success,
+        reason: 'granted was previously rendered in the error colour',
+      );
+    });
+
+    testWidgets('notDetermined renders as Not Determined', (tester) async {
+      await pump(
+        tester,
+        healthWithMotion(MotionAuthorizationStatus.notDetermined),
+      );
+
+      expect(find.text('Not Determined'), findsOneWidget);
+      expect(motionValueColor(tester, 'Not Determined'), DoctorTheme.warning);
+    });
+
+    testWidgets('deniedForever renders as Denied in the error colour', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        healthWithMotion(MotionAuthorizationStatus.deniedForever),
+      );
+
+      expect(find.text('Denied'), findsOneWidget);
+      expect(motionValueColor(tester, 'Denied'), DoctorTheme.error);
+    });
+
+    testWidgets('every enum value renders a label and none say Restricted', (
+      tester,
+    ) async {
+      // Guards the whole mapping rather than one case: if the enum gains a
+      // value, this fails until the card handles it. "Restricted" is not a
+      // member of MotionAuthorizationStatus at all, so it must never appear.
+      for (final status in MotionAuthorizationStatus.values) {
+        await pump(tester, healthWithMotion(status));
+
+        expect(
+          find.text('Unknown'),
+          findsNothing,
+          reason: '$status fell through to Unknown',
+        );
+        expect(
+          find.text('Restricted'),
+          findsNothing,
+          reason: '$status rendered as Restricted',
+        );
+      }
+    });
+
+    testWidgets('an out-of-range value degrades to Unknown', (tester) async {
+      await pump(
+        tester,
+        HealthCheck(
+          trackingEnabled: true,
+          trackingMode: TrackingMode.location,
+          timestamp: DateTime.utc(2026, 8, 2),
+          locationPermission: AuthorizationStatus.always,
+          motionPermission: 99,
+        ),
+      );
+
+      expect(find.text('Unknown'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Doctor reported **"Motion Activity: Restricted"** in red on a device where activity recognition was granted and working — directly beside an "All Clear" warning list, a live `Smart (Hybrid)` motion sensor and a `Stationary` motion state.

The permission was fine. The label was wrong.

## Root cause

A contract error rather than a UI slip. `HealthCheck.motionPermission` is populated from `MotionAuthorizationStatus.index` (`tracelet.dart:451`):

```
0 = notDetermined,  1 = granted,  2 = deniedForever
```

but the field's own doc comment described CoreMotion's `CMAuthorizationStatus`:

```
0 = notDetermined,  1 = restricted,  2 = denied,  3 = authorized
```

`PermissionCard` implemented the documented contract faithfully, so `granted` (index 1) rendered as a red "Restricted", and the `3 => 'Granted'` branch was dead code — the enum has no index 3.

The warning path was unaffected, because `_computeWarnings` checks `motionPermission == 2`, which happens to coincide with `deniedForever`. That's why the card *contradicted* the warning list instead of both being wrong, and it's what made the screenshot self-diagnosing.

## Changes

- **Corrected the field doc** and added a typed `HealthCheck.motionAuthorization` getter returning `MotionAuthorizationStatus` (`null` when out of range, e.g. a report deserialized from a newer payload). The raw `int` was the leak; a typed accessor means the mapping can't be misread again.
- **`PermissionCard` switches over the enum** rather than raw indices, so both the label and the colour are exhaustive at compile time. Adding an enum case now fails the build instead of silently falling through to "Unknown".
- **The bug report prints the name** with the index alongside. `Motion permission | 0` was ambiguous — it reads as a boolean or a count, and couldn't be checked without opening the source.
- Fixed a stale doc comment on `_buildReport`, which still listed the sections as "health + config + logs + telematics"; it also carries foreground-service health and, since 3.7.3, the geofence decision trace.

## Testing

| Suite | Result |
|---|---|
| `tracelet` | 492 pass (6 new) |
| `tracelet_doctor` | 25 pass (6 new) |
| `melos run format` / `analyze` | clean |

The model tests assert the decoding against `MotionAuthorizationStatus` itself rather than hardcoded integers — the two scales disagreeing *is* the defect, so hardcoding either one would re-encode it. One test also pins `deniedForever.index == 2`, since `_computeWarnings` hardcodes that constant and would silently stop meaning "denied" if the enum were reordered.

Verified red: reverting `PermissionCard` fails 3 of 6 widget tests, including `Found 1 widget with text "Restricted"` — the exact reported symptom.

## Release

Changelog entries go under the existing **3.7.3** heading rather than a new bump. 3.7.3 is staged on `main` (#289) but not yet tagged or released — latest release is 3.7.2 — so bumping would produce a 3.7.3 that never ships.

## Note

Also confirms an adjacent question: the geofence decision trace **is** included in both Doctor export paths. `_copyReport` and `_shareReport` both call a bare `TraceletBugReport.build()`, which picks up the default `geofenceTraceLimit = 2000`, so the section lands in the clipboard copy and the shared `.md` with no further wiring.
