### PR TITLE
fix(ci): point the SPM binaryTarget at the built xcframework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,15 @@ jobs:
         working-directory: sdk/ios
         run: |
           set -euo pipefail
+          # Package.swift consumes the Rust core as a binaryTarget built by
+          # build-ios.sh (run earlier in this job). *.xcframework is gitignored,
+          # so assert it is present rather than letting SwiftPM fail with the
+          # opaque "does not contain a binary artifact".
+          XCF="../rust-core/out/TraceletCore.xcframework"
+          if [ ! -d "$XCF" ]; then
+            echo "❌ $XCF is missing — 'Build iOS Rust Core' must run before this step."
+            exit 1
+          fi
           # Resolve a concrete simulator UDID rather than hardcoding a device
           # name or OS version, both of which drift with the runner image.
           # `generic/platform=iOS Simulator` is not usable for `test`.

--- a/sdk/ios/Package.swift
+++ b/sdk/ios/Package.swift
@@ -13,7 +13,12 @@ let package = Package(
         .library(name: "TraceletSDK", targets: ["TraceletSDK"]),
     ],
     targets: [
-        .binaryTarget(name: "TraceletCore", path: "TraceletCore.xcframework"),
+        // Points at the canonical build output of sdk/rust-core/build-ios.sh —
+        // the same path TraceletSDK.podspec vendors. `*.xcframework` is
+        // gitignored, so a copy under sdk/ios/ only exists on machines that have
+        // manually placed one; CI checks out without it and SwiftPM fails with
+        // "does not contain a binary artifact". Run build-ios.sh first.
+        .binaryTarget(name: "TraceletCore", path: "../rust-core/out/TraceletCore.xcframework"),
         .target(
             name: "TraceletSDK",
             dependencies: ["TraceletCore"],


### PR DESCRIPTION
## Summary

Fixes the red `Build iOS` job on `main`. The "Run TraceletSDK unit tests (iOS Simulator)" step I added in #289 fails at package resolution:

```
local binary target 'TraceletCore' at '.../sdk/ios/TraceletCore.xcframework'
does not contain a binary artifact
xcodebuild: error: Could not resolve package dependencies
```

[Failing run](https://github.com/Ikolvi/Tracelet/actions/runs/30714133617/job/91407064925)

## Cause

`sdk/ios/Package.swift` declared the binaryTarget at `sdk/ios/TraceletCore.xcframework`, but **nothing produces it there**:

- `build-ios.sh` writes the xcframework to `sdk/rust-core/out/` (`build-ios.sh:85`) and only copies the generated Swift and header sources into `sdk/ios/Sources/TraceletSDK/` (lines 65-66)
- `*.xcframework` is gitignored (`.gitignore:143`), so the directory is absent on a fresh checkout

My machine had a stale copy sitting at that path from an earlier build, so the step passed locally and pre-merge. That's an untracked-artifact false pass — my mistake, and the reason I re-verified this one by *removing* the artifact rather than by adding it.

The manifest was also the odd one out. `TraceletSDK.podspec:14` already vendors `../rust-core/out/TraceletCore.xcframework`, which is why the `Build example iOS` step in the same job succeeds — CocoaPods was pointed at the real output all along.

## Fix

Point the binaryTarget at the same canonical output the podspec uses, so there's one source of truth and no copy step:

```swift
.binaryTarget(name: "TraceletCore", path: "../rust-core/out/TraceletCore.xcframework"),
```

Also added a guard to the CI step so a future step-ordering mistake names the missing artifact instead of surfacing SwiftPM's opaque message:

```
❌ ../rust-core/out/TraceletCore.xcframework is missing — 'Build iOS Rust Core' must run before this step.
```

Step order in the job is already correct (`Build iOS Rust Core` → … → the test step); the guard is there to keep it that way.

## Verification

Reproduced the failure locally by moving `sdk/ios/TraceletCore.xcframework` aside — identical error. With the fix in place and that directory still absent, i.e. the exact CI condition:

```
Executed 41 tests, with 0 failures (0 unexpected)
** TEST SUCCEEDED **
```

`melos run format` and `analyze` clean. No other file references the old path.

## Note

This also means the `Build iOS` job has been red since #289 merged, and #290's run would have failed the same way for the same reason — it isn't caused by anything in #290.
