### PR TITLE
test(geofence): fix flaky iOS EXIT trace test racing the async log write

### DIFF
--- a/sdk/ios/Tests/TraceletSDKTests/GeofenceManagerTransitionLogTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/GeofenceManagerTransitionLogTests.swift
@@ -78,7 +78,14 @@ final class GeofenceManagerTransitionLogTests: XCTestCase {
 
     /// iOS persists logs asynchronously on a serial queue, so poll rather than
     /// assuming the write has landed.
-    private func geofenceLines(timeout: TimeInterval = 2.0) -> [(level: String, message: String)] {
+    ///
+    /// `until` lets callers wait for a *specific* line (e.g. the EXIT, which is
+    /// written several async hops after the ENTER). Without it the poller would
+    /// return the moment any `[geofence]` line lands and race the later writes.
+    private func geofenceLines(
+        until: (([(level: String, message: String)]) -> Bool)? = nil,
+        timeout: TimeInterval = 2.0
+    ) -> [(level: String, message: String)] {
         let deadline = Date().addingTimeInterval(timeout)
         var found: [(level: String, message: String)] = []
         repeat {
@@ -87,7 +94,7 @@ final class GeofenceManagerTransitionLogTests: XCTestCase {
                 .filter { $0.message.contains("[geofence]") }
                 .map { (level: $0.level, message: $0.message) }
                 .reversed()
-            if !found.isEmpty { return found }
+            if until == nil ? !found.isEmpty : until!(found) { return found }
             usleep(25_000)
         } while Date() < deadline
         return found
@@ -98,7 +105,10 @@ final class GeofenceManagerTransitionLogTests: XCTestCase {
     }
 
     private func firstExitAtInfo() -> String? {
-        infoLines().first { $0.contains("EXIT") }
+        geofenceLines(until: { lines in
+            lines.contains { $0.level == "INFO" && $0.message.contains("EXIT") }
+        })
+        .first { $0.level == "INFO" && $0.message.contains("EXIT") }
     }
 
     // MARK: - Transitions must be visible at INFO


### PR DESCRIPTION
## What

Fixes the intermittent failure of `GeofenceManagerTransitionLogTests.testTraceSurfacesTheExitAccuracyMaxClampWhenItBinds()` (seen on the #295 merge run, [job](https://github.com/Ikolvi/Tracelet/actions/runs/30906689413/job/91984152041)).

## Why it is not a product issue

The geofence EXIT logic worked correctly — the EXIT line **was** emitted. The `XCTFail` message even printed the EXIT line it claimed was missing:

```
expected an EXIT line, got: [
  (INFO,  "[geofence] ENTER ZONE_LOG ..."),
  (DEBUG, "[geofence] no transition — accRaw=150.0 accEff=20.0 clampApplied=true ..."),
  (INFO,  "[geofence] EXIT ZONE_LOG dist=199.8 ... exitAccuracyMax=20 clampApplied=true")
]
```

The identical code passed the run immediately before, and failed only on the merge commit — a classic flake.

## Root cause

These tests read back through `DatabaseManager`, which persists logs asynchronously on a serial queue. The `geofenceLines()` helper returned the moment **any** `[geofence]` line landed. If an EXIT assertion polled after `ENTER` was written but before `EXIT` was, `firstExitAtInfo()` returned `nil` and the test failed — while `EXIT` landed a few ms later (hence the contradictory failure output).

The #294 two-fix EXIT confirmation pushed the EXIT one more async hop behind ENTER, widening the race window.

## Fix

Give the poller an optional `until` predicate and have `firstExitAtInfo()` wait specifically for the INFO EXIT line. ENTER-based checks keep the original early-return behavior. Test-only; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
