### PR TITLE
fix(ci): give the iOS XCTest waits a liveness bound a loaded runner can meet (#329)

### DIFF
--- a/sdk/ios/Package.swift
+++ b/sdk/ios/Package.swift
@@ -39,6 +39,10 @@ let package = Package(
             // Only the actively-maintained suite is wired up; the other files in
             // this directory are stale against the current SDK API.
             sources: [
+                // Shared, not a suite: the one liveness bound every
+                // `wait(for:timeout:)` below uses. A 1 s bound flaked Build iOS
+                // on a loaded runner (#329).
+                "AsyncWaitTimeout.swift",
                 "LocationEngineRuntimeProviderOptionsTests.swift",
                 "MotionDetectorTests.swift",
                 "BatteryBudgetRemoteConfigTests.swift",

--- a/sdk/ios/Tests/TraceletSDKTests/AsyncWaitTimeout.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/AsyncWaitTimeout.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// The timeout every `wait(for:timeout:)` in this suite uses (#329).
+///
+/// These timeouts are **liveness bounds, not correctness bounds**. Every
+/// expectation in the suite is fulfilled by an explicit `fulfill()` — from a
+/// delegate callback, or from a `DispatchQueue.main.asyncAfter` block that also
+/// carries the assertion — and no test uses `isInverted`. So the window a test
+/// actually observes is the `asyncAfter` deadline it schedules, never this
+/// value: raising it cannot weaken an assertion, and lowering it cannot
+/// strengthen one. All it decides is how far behind schedule the machine is
+/// allowed to fall before a correct test is reported as a failure.
+///
+/// At 1.0 second that margin was too thin for a loaded CI runner.
+/// `MotionDetectorTests.testIntermittentNoiseDuringStopTimeoutDoesNotAbort`
+/// failed on `main` with *"Exceeded timeout of 1 seconds, with unfulfilled
+/// expectations: Timeout started"* — an expectation whose only job was to wait
+/// 0.1 s, on a run where the whole `xcodebuild` operation took 181 s to execute
+/// 62 s of tests. The behaviour under test had worked: the log for that very
+/// run shows `startStopTimeoutCountdown: Starting timer for 60.0 seconds`. Only
+/// the main queue was starved past the bound.
+///
+/// Nothing is paid for the larger value in the passing case — `wait` returns as
+/// soon as the expectation is fulfilled, so this is reached only on a genuine
+/// failure, where waiting five seconds to report it costs nothing.
+let asyncWaitTimeout: TimeInterval = 5.0

--- a/sdk/ios/Tests/TraceletSDKTests/MotionDetectorTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/MotionDetectorTests.swift
@@ -73,7 +73,7 @@ final class MotionDetectorTests: XCTestCase {
             XCTAssertTrue(timeoutStarted, "Stop timeout should be started")
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     func testSustainedMotionDuringStopTimeoutAbortsStopTransition() {
@@ -95,7 +95,7 @@ final class MotionDetectorTests: XCTestCase {
             XCTAssertTrue(timeoutStarted, "Stop timeout should be started")
             startExpectation.fulfill()
         }
-        wait(for: [startExpectation], timeout: 1.0)
+        wait(for: [startExpectation], timeout: asyncWaitTimeout)
 
         // Simulate SUSTAINED motion: motionAbortCount (5) consecutive bumps
         // (magnitude 0.5 > 0.15 threshold). Only sustained motion may abort.
@@ -110,7 +110,7 @@ final class MotionDetectorTests: XCTestCase {
             XCTAssertTrue(self.stateManager.isMoving, "State should remain moving")
             cancelExpectation.fulfill()
         }
-        wait(for: [cancelExpectation], timeout: 1.0)
+        wait(for: [cancelExpectation], timeout: asyncWaitTimeout)
     }
 
     /// A single above-threshold sample (sensor noise / a stray bump) during the
@@ -126,7 +126,7 @@ final class MotionDetectorTests: XCTestCase {
 
         let startExpectation = XCTestExpectation(description: "Timeout started")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { startExpectation.fulfill() }
-        wait(for: [startExpectation], timeout: 1.0)
+        wait(for: [startExpectation], timeout: asyncWaitTimeout)
 
         // Four bumps — below motionAbortCount (5) — must not cancel.
         let bumpAcc = CMAcceleration(x: 0, y: 0, z: 1.5)
@@ -137,7 +137,7 @@ final class MotionDetectorTests: XCTestCase {
             XCTAssertFalse(timeoutCancelled, "A few stray bumps must not cancel the stop timeout")
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
     }
 
     /// A still sample arriving between stray bumps resets the motion streak, so
@@ -151,7 +151,7 @@ final class MotionDetectorTests: XCTestCase {
 
         let startExpectation = XCTestExpectation(description: "Timeout started")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { startExpectation.fulfill() }
-        wait(for: [startExpectation], timeout: 1.0)
+        wait(for: [startExpectation], timeout: asyncWaitTimeout)
 
         // Alternate bumps and still samples: the motion streak never reaches 5.
         let bumpAcc = CMAcceleration(x: 0, y: 0, z: 1.5)
@@ -166,7 +166,7 @@ final class MotionDetectorTests: XCTestCase {
             XCTAssertFalse(timeoutCancelled, "Intermittent noise must not cancel the stop timeout")
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
     }
 
     /// Issue #130: while stationary, a shake-magnitude sample must declare
@@ -185,7 +185,7 @@ final class MotionDetectorTests: XCTestCase {
                           "A shake while stationary should declare moving")
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
     }
 
     /// Issue #130: a still sample below the shake threshold while stationary
@@ -203,7 +203,7 @@ final class MotionDetectorTests: XCTestCase {
                            "Sub-threshold noise must not wake the detector")
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
     }
 }
 

--- a/sdk/ios/Tests/TraceletSDKTests/SubsystemTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/SubsystemTests.swift
@@ -597,7 +597,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onMotionChange = { exp.fulfill() }
 
         sender.sendMotionChange(["isMoving": true])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.motionChangeCalled)
     }
 
@@ -610,7 +610,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onActivityChange = { exp.fulfill() }
 
         sender.sendActivityChange(["type": "walking", "confidence": 100])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.activityChangeCalled)
     }
 
@@ -623,7 +623,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onGeofence = { exp.fulfill() }
 
         sender.sendGeofence(["identifier": "office", "action": "ENTER"])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.geofenceCalled)
     }
 
@@ -636,7 +636,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onHeartbeat = { exp.fulfill() }
 
         sender.sendHeartbeat(["location": [:]])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.heartbeatCalled)
     }
 
@@ -649,7 +649,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onHttp = { exp.fulfill() }
 
         sender.sendHttp(["status": 200])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.httpCalled)
     }
 
@@ -662,7 +662,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onSchedule = { exp.fulfill() }
 
         sender.sendSchedule(["enabled": true])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.scheduleCalled)
     }
 
@@ -675,7 +675,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onProviderChange = { exp.fulfill() }
 
         sender.sendProviderChange(["provider": "gps"])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.providerChangeCalled)
     }
 
@@ -688,7 +688,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onConnectivityChange = { exp.fulfill() }
 
         sender.sendConnectivityChange(["connected": true])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.connectivityChangeCalled)
     }
 
@@ -708,7 +708,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onGeofence = { exp.fulfill() }
         sender.delegate = delegate
 
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.geofenceCalled)
     }
 
@@ -750,7 +750,7 @@ final class DelegateEventSenderExtendedTests: XCTestCase {
         delegate.onHeartbeat = { exp.fulfill() }
 
         sender.sendHeartbeat(["location": [:]])
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: asyncWaitTimeout)
         XCTAssertTrue(delegate.heartbeatCalled)
     }
 }

--- a/sdk/ios/Tests/TraceletSDKTests/TraceletSdkTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/TraceletSdkTests.swift
@@ -242,7 +242,7 @@ final class TraceletSdkTests: XCTestCase {
         }
 
         sender.sendLocation(["latitude": 37.7749, "longitude": -122.4194])
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     func testDelegateEventSenderForwardsPowerSave() {
@@ -259,7 +259,7 @@ final class TraceletSdkTests: XCTestCase {
         }
 
         sender.sendPowerSaveChange(true)
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     func testDelegateEventSenderForwardsEnabledChange() {
@@ -276,7 +276,7 @@ final class TraceletSdkTests: XCTestCase {
         }
 
         sender.sendEnabledChange(false)
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     // MARK: - Database (in-memory)
@@ -607,7 +607,7 @@ final class TraceletSdkTests: XCTestCase {
             XCTAssertNil(location)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     func testGetLastKnownLocationBeforeReadyReturnsNil() {
@@ -658,7 +658,7 @@ final class TraceletSdkTests: XCTestCase {
             XCTAssertTrue(locations.isEmpty)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     func testLoggingMethodsBeforeReadyDoNotCrash() {
@@ -703,7 +703,7 @@ final class TraceletSdkTests: XCTestCase {
             XCTAssertNil(token)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: asyncWaitTimeout)
     }
 
     func testRouteContextMethodsBeforeReadyDoNotCrash() {


### PR DESCRIPTION
Fixes #329

### The failure

Build iOS went red on `main` at *"Run TraceletSDK unit tests (iOS Simulator)"*:

```
MotionDetectorTests.swift:154: error:
  -[MotionDetectorTests testIntermittentNoiseDuringStopTimeoutDoesNotAbort]
  Asynchronous wait failed: Exceeded timeout of 1 seconds,
  with unfulfilled expectations: "Timeout started".
```

### It is a flake, and the run's own log proves it

The expectation that timed out asserts nothing. Its only job is to wait 0.1 s:

```swift
let startExpectation = XCTestExpectation(description: "Timeout started")
DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { startExpectation.fulfill() }
wait(for: [startExpectation], timeout: 1.0)
```

The behaviour under test worked on that very run — 9 ms after the samples were fed:

```
12:07:23.316  Accelerometer detected sustained stillness (50 samples), starting stop-timeout
12:07:23.325  startStopTimeoutCountdown: Starting timer for 60.0 seconds
```

What failed was the main queue not getting scheduled inside a second. The runner was badly loaded: `xcodebuild` reported **181 s elapsed to execute 62 s of tests**, and this test alone took **4.05 s for ~0.3 s of work** — roughly a 13× slowdown, which a 1.0 s bound does not survive.

Corroborating, in order of weight:

- the merge that triggered the run touched **zero** Swift files (Dart config models, two example cards, one Kotlin test);
- the identical tree **passed** Build iOS on the PR run (31255771486) minutes earlier;
- Build iOS was green on `main` for every prior run.

### Why all 25 sites, not just the one

`wait(for:timeout:)` appears 25 times across three files, all at `timeout: 1.0`, and they share one shape:

- every expectation is fulfilled by an explicit `fulfill()` — a delegate callback, or an `asyncAfter` block that also carries the assertion;
- no test in the suite uses `isInverted`.

So these are **liveness bounds, not correctness bounds**. The window a test observes is the `asyncAfter` deadline it schedules, never the `wait` timeout. Raising it cannot weaken an assertion; it only decides how far behind schedule the machine may fall before a *correct* test is reported red. One of the 25 happened to fire; the other 24 carry the same landmine.

They now route through one documented constant at 5 s. Nothing is paid in the passing case — `wait` returns as soon as the expectation is fulfilled, so the bound is only reached on a genuine failure, where taking five seconds to report it costs nothing.

### Two things worth flagging

- **`Package.swift` had to change.** The test target uses a curated `sources:` list, so a new file is not compiled unless it is named there — that is why the first attempt failed with `cannot find 'asyncWaitTimeout' in scope`.
- **Only `MotionDetectorTests` is in that list.** `SubsystemTests` and `TraceletSdkTests` are among the files the manifest calls *"stale against the current SDK API"* and are not built, so 16 of the 25 edits are inert today. They are included so the hazard is not waiting for whoever re-enables them.

Deliberately unchanged: `GeofenceManagerTransitionLogTests`' `geofenceLines(timeout: 0.5)`. That is a polling helper behind a negative assertion, so there the timeout *is* the observation window and the claim.

### Verification

Ran the exact CI command — `xcodebuild test -scheme TraceletSDK -destination "id=$UDID"` from `sdk/ios` against a resolved simulator UDID:

```
Executed 61 tests, with 0 failures (0 unexpected) in 21.484 seconds
** TEST SUCCEEDED **
Test Case '-[MotionDetectorTests testIntermittentNoiseDuringStopTimeoutDoesNotAbort]' passed (0.210 seconds)
```

No verification card: this is test infrastructure with no runtime behaviour for a card to prove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
