### PR TITLE
fix(motion): stop filtered fixes reporting 0 m/s and stranding a drive in STATIONARY

### DIFF
--- a/example/lib/issues/issue_332_card.dart
+++ b/example/lib/issues/issue_332_card.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #332 — a location the Rust processor rejected reported
+/// `effectiveSpeed: 0.0`, so the GPS-speed motion machine was told the device
+/// had stopped once per rejected fix.
+///
+/// Both hosts feed *every* fix into `SpeedMotionManager`, accepted or not —
+/// deliberately, because a parked device's fixes are all distance-filtered and
+/// the machine would otherwise never leave MOVING. They feed it
+/// `result.effectiveSpeed`, which `LocationProcessorResult::filtered()`
+/// hardcoded to zero.
+///
+/// In a vehicle that is the common case, not a corner case: at the `vehicle`
+/// auto-tune's 30 m distance filter and ~1 Hz fixes, most of a 10 m/s drive is
+/// rejected. The machine saw a stream of zeros on a motorway, dropped
+/// MOVING → SLOWING, could never collect the three *consecutive* above-threshold
+/// fixes needed to abort (each fabricated zero reset the streak), and ran its
+/// countdown out to STATIONARY. The accelerometer had independently declared
+/// stillness — a phone held still in a smooth-riding car reads near-zero, which
+/// is the exact scenario the speed machine exists to cover — so the
+/// coordinator's logical OR collapsed and tracking downgraded to periodic
+/// mid-drive. Shaking the phone was the only way back.
+///
+/// **What this card can prove, and what it cannot.** The processor is not
+/// exposed to Dart, so the fix itself is pinned by Rust unit tests
+/// (`a_drive_never_reports_a_fabricated_zero_speed`). What this card does is
+/// observe the live consequence: it watches real fixes and the speed machine
+/// side by side, and fails if the machine leaves MOVING while the device is
+/// demonstrably above the speed threshold. That is only exercised while
+/// actually moving, so a stationary run reports **inconclusive** rather than
+/// green — see the run output.
+class Issue332Card extends StatefulWidget {
+  const Issue332Card({super.key});
+
+  @override
+  State<Issue332Card> createState() => _Issue332CardState();
+}
+
+class _Issue332CardState extends State<Issue332Card> {
+  static const _observeWindow = Duration(seconds: 45);
+
+  /// The SDK default for `speedMovingThreshold` (m/s). Fixes at or above this
+  /// are what the machine must treat as motion.
+  static const _movingThreshold = 1.5;
+
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    StreamSubscription<Location>? locSub;
+    StreamSubscription<SpeedMotionEvent>? smSub;
+
+    try {
+      final speeds = <double>[];
+      final transitions = <SpeedMotionEvent>[];
+      // Speed at the moment each transition landed, so a downgrade can be
+      // attributed to the reading that caused it rather than to the run as a
+      // whole.
+      final speedAtTransition = <double>[];
+
+      locSub = Tracelet.onLocation((l) => speeds.add(l.coords.speed));
+      smSub = Tracelet.onSpeedMotionChange((e) {
+        transitions.add(e);
+        speedAtTransition.add(speeds.isEmpty ? -1 : speeds.last);
+      });
+
+      await Tracelet.start();
+      _set(
+        'Observing for ${_observeWindow.inSeconds}s…\n\n'
+        'To exercise the regression, run this while travelling with the phone '
+        'held still or resting on a seat. Standing still can only confirm the '
+        'plumbing.',
+      );
+      await Future<void>.delayed(_observeWindow);
+
+      final moving = speeds.where((s) => s >= _movingThreshold).length;
+      final maxSpeed = speeds.isEmpty
+          ? 0.0
+          : speeds.reduce((a, b) => a > b ? a : b);
+
+      // Row 1: did anything arrive at all? Without this a silent location
+      // pipeline would make every row below vacuously green.
+      check(
+        'fixes were delivered',
+        speeds.isNotEmpty,
+        speeds.isNotEmpty
+            ? '${speeds.length} fix(es), peak ${maxSpeed.toStringAsFixed(2)} m/s'
+            : 'no fixes in ${_observeWindow.inSeconds}s — check location '
+                  'permission and that GPS has a sky view. Nothing below can be '
+                  'concluded.',
+      );
+
+      // Row 2: the actual regression. A downgrade out of MOVING is only a bug
+      // when the device was above the threshold at the time.
+      final downgrades = <String>[];
+      for (var i = 0; i < transitions.length; i++) {
+        final t = transitions[i];
+        final at = speedAtTransition[i];
+        if (t.state != SpeedMotionState.moving && at >= _movingThreshold) {
+          downgrades.add(
+            '${t.previousState.name} → ${t.state.name} at '
+            '${at.toStringAsFixed(2)} m/s',
+          );
+        }
+      }
+
+      if (moving == 0) {
+        results.add(
+          '⏭️ #332 the speed machine holds MOVING while the device moves — '
+          'INCONCLUSIVE. No fix reached the '
+          '${_movingThreshold.toStringAsFixed(1)} m/s threshold in this run '
+          '(peak ${maxSpeed.toStringAsFixed(2)} m/s), so the regression was '
+          'never given a chance to fire. Re-run while travelling. This is '
+          'reported as a skip, not a pass: a stationary device legitimately '
+          'goes STATIONARY, and calling that green would hide the bug.',
+        );
+      } else {
+        check(
+          '#332 the speed machine holds MOVING while the device moves',
+          downgrades.isEmpty,
+          downgrades.isEmpty
+              ? '$moving of ${speeds.length} fixes were at or above '
+                    '${_movingThreshold.toStringAsFixed(1)} m/s (peak '
+                    '${maxSpeed.toStringAsFixed(2)}) and the machine never left '
+                    'MOVING on one of them'
+              : 'REGRESSED — left MOVING while above the threshold: '
+                    '${downgrades.join('; ')}. A rejected fix is reporting a '
+                    'fabricated speed again.',
+        );
+      }
+
+      // Row 3: the diagnostic that makes the next report readable without a
+      // debug build (#334). Cheap to assert here and it shares this bug's
+      // subject, so a regression in either shows up on the same card.
+      final logs = await Tracelet.getLogs(300);
+      final speedMotionTrace = logs
+          .where((e) => e.level.toUpperCase() == 'LIFECYCLE')
+          .where((e) => e.message.contains('speed-motion:'))
+          .toList();
+      check(
+        'the speed machine leaves an always-on trace',
+        speedMotionTrace.isNotEmpty,
+        speedMotionTrace.isNotEmpty
+            ? '${speedMotionTrace.length} `speed-motion:` lifecycle entr'
+                  '${speedMotionTrace.length == 1 ? 'y' : 'ies'}, each carrying '
+                  'the speed it decided on — e.g. "'
+                  '${speedMotionTrace.last.message}"'
+            : 'no `speed-motion:` lifecycle entries. The machine records one on '
+                  'start and one per transition, so a run that stayed in a '
+                  'single state and was already started may legitimately show '
+                  'none; a run that changed state and shows none is a #334 '
+                  'regression.',
+      );
+
+      await Tracelet.stop();
+
+      final header = allPass
+          ? '✅ SUCCESS: no fix caused the speed machine to declare a stop '
+                'while the device was moving.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Mechanism: LocationProcessorResult::filtered() returned '
+        'effective_speed: 0.0 for every rejected fix, and both hosts feed that '
+        'value into SpeedMotionManager on every fix by design. A 30 m distance '
+        'filter rejects most of a 10 m/s drive, so the machine was told '
+        '"stopped" two times out of three on a motorway.\n\n'
+        'Why the accelerometer did not save it: a phone held still in a '
+        'smooth-riding car reads near-zero, which is precisely why the '
+        'GPS-speed machine exists. Once it was fooled too, the coordinator OR '
+        'had two false inputs and downgraded to periodic tracking.\n\n'
+        'Coverage note: the processor has no Dart entry point, so the fix '
+        'itself is pinned by Rust unit tests. This card observes the live '
+        'consequence and is only conclusive while actually moving.',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      await locSub?.cancel();
+      await smSub?.cancel();
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'speed motion stationary moving vehicle drive filtered distance '
+          'filter effective speed rust processor slowing countdown periodic '
+          'downgrade smart coordinator 332',
+      title: '#332: a filtered fix no longer reports a fabricated 0 m/s',
+      description:
+          'Watches live fixes and the GPS-speed motion machine together and '
+          'fails if the machine declares a stop while the device is above the '
+          'moving threshold. Run it while travelling — a stationary run is '
+          'reported as inconclusive rather than green.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/issue_333_card.dart
+++ b/example/lib/issues/issue_333_card.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #333 — `SmartMotionCoordinator` read the raw platform speed to decide
+/// whether to overrule a *moving* accelerometer, and an unavailable reading
+/// passed the "near zero" test.
+///
+/// The coordinator is a logical OR: continuous tracking is kept while either
+/// the accelerometer or the GPS-speed machine reports motion. When the speed
+/// machine says stationary but the accelerometer disagrees, one narrow override
+/// applies — a device physically still with the accelerometer picking up hand
+/// tremor, where GPS speed is genuinely ~0. It was gated on:
+///
+/// ```swift
+/// let lastSpeed = sdk?.locationEngine.getLastLocation()?.speed ?? 0
+/// if lastSpeed <= 0.15 { /* override the accelerometer to false */ }
+/// ```
+///
+/// `CLLocation.speed` is **-1** on a fix carrying no speed, and -1 sails
+/// through `<= 0.15`; Android's `Location.speed` reports 0.0 in the same
+/// situation. So "we don't know how fast this is" was read as "definitely
+/// parked", and the coordinator overruled the one input that was reporting
+/// motion — on missing data. The declaration of `lastEffectiveSpeed` names this
+/// hazard outright: "the cached CLLocation.speed may be stale, 0, or -1".
+///
+/// The fix reads `lastEffectiveSpeed` (the resolved value, which falls back to
+/// a distance/time derivation exactly when the platform reading is absent) and
+/// treats "no resolved speed at all" as unknown — unknown never overrules a
+/// positive motion signal.
+///
+/// **What this card can prove.** The override needs the accelerometer and the
+/// speed machine to actively disagree, which cannot be staged from Dart. What
+/// is checkable here is the decision trail: every branch now records which one
+/// it took, so the run reports whichever the device actually exercised and
+/// fails only on the branch that is unambiguously wrong.
+class Issue333Card extends StatefulWidget {
+  const Issue333Card({super.key});
+
+  @override
+  State<Issue333Card> createState() => _Issue333CardState();
+}
+
+class _Issue333CardState extends State<Issue333Card> {
+  static const _observeWindow = Duration(seconds: 20);
+
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    try {
+      await Tracelet.start();
+      _set('Observing the coordinator for ${_observeWindow.inSeconds}s…');
+      await Future<void>.delayed(_observeWindow);
+
+      final logs = await Tracelet.getLogs(400);
+      final messages = logs.map((e) => e.message).toList();
+
+      // The three branches the override can take. Only the first is a bug.
+      final overrode = messages
+          .where((m) => m.contains('overriding accel to false'))
+          .toList();
+      final trustedOnUnknown = messages
+          .where((m) => m.contains('no GPS speed resolved yet'))
+          .toList();
+      final trustedOnSpeed = messages
+          .where((m) => m.contains('above the'))
+          .where((m) => m.contains('tremor threshold'))
+          .toList();
+
+      // Row 1: the branch that must never appear again. The old build printed
+      // "GPS speed near zero (-1.00 m/s)" — a negative reading is the sentinel
+      // for "absent", never a measurement.
+      final overrodeOnSentinel = overrode
+          .where((m) => m.contains('(-'))
+          .toList();
+      check(
+        '#333 an absent speed never counts as standing still',
+        overrodeOnSentinel.isEmpty,
+        overrodeOnSentinel.isEmpty
+            ? 'no override was justified by a negative speed reading'
+            : 'REGRESSED — overrode a moving accelerometer on a sentinel '
+                  'value: ${overrodeOnSentinel.first}',
+      );
+
+      // Row 2: the misleading log text. 11.26 m/s is 40 km/h; describing it as
+      // walking made the field report actively mislead whoever read it.
+      final calledDrivingWalking = messages
+          .where((m) => m.contains('suggests walking'))
+          .toList();
+      check(
+        'the decision log states what it actually concluded',
+        calledDrivingWalking.isEmpty,
+        calledDrivingWalking.isEmpty
+            ? 'the "suggests walking" text is gone; the branch now names the '
+                  'threshold it compared against'
+            : 'REGRESSED — still describing any speed above the threshold as '
+                  'walking: ${calledDrivingWalking.first}',
+      );
+
+      // Row 3: context, not a verdict. Which branch ran depends entirely on
+      // what the device was doing, so it is reported rather than asserted.
+      final branchSummary = <String>[
+        if (trustedOnSpeed.isNotEmpty)
+          'trusted the accelerometer on a real speed (${trustedOnSpeed.length}×)',
+        if (trustedOnUnknown.isNotEmpty)
+          'trusted the accelerometer with no resolved speed, the #333 fix (${trustedOnUnknown.length}×)',
+        if (overrode.isNotEmpty)
+          'overrode the accelerometer as hand tremor (${overrode.length}×)',
+      ];
+      results.add(
+        branchSummary.isEmpty
+            ? 'ℹ️ the override was never reached in this run — it needs the '
+                  'speed machine to go stationary while the accelerometer '
+                  'still reports motion, which a short foreground run rarely '
+                  'produces. Rows above still hold: they assert the absence of '
+                  'the two wrong outcomes.'
+            : 'ℹ️ branches exercised: ${branchSummary.join('; ')}',
+      );
+
+      await Tracelet.stop();
+
+      final header = allPass
+          ? '✅ SUCCESS: no override was taken on missing data, and the '
+                'decision log describes what it decided.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Note on the log level: these branch messages are `info`, so this card '
+        'needs logLevel at info or below to see them. The lifecycle entries '
+        'that survive a release build with default settings are the '
+        '`smart-motion:` mode switches — see the #334 card.\n\n'
+        'Why it mattered: the override collapses the coordinator OR to the '
+        'speed machine alone at exactly the moment the two inputs disagree — '
+        'the moment the OR exists to arbitrate. Together with #332 this was a '
+        'second path to "tracking went stationary while I was moving".',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'smart motion coordinator accel accelerometer override hand tremor '
+          'gps speed invalid -1 unavailable walking threshold effective speed '
+          '333',
+      title:
+          '#333: an unknown GPS speed no longer overrules a moving '
+          'accelerometer',
+      description:
+          'Checks the coordinator decision trail for the two outcomes that are '
+          'unambiguously wrong: an override justified by a sentinel (absent) '
+          'speed reading, and a log line calling 40 km/h "walking". Which '
+          'branch actually runs depends on the device, so that is reported as '
+          'context.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/issue_334_card.dart
+++ b/example/lib/issues/issue_334_card.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #334 — the GPS-speed motion machine and the coordinator's mode
+/// switches were `debug`-only, so a bug report gathered at the shipped log
+/// levels could show a mid-trip downgrade with no record of what decided it.
+///
+/// A real report of tracking dropping to periodic mode mid-drive was
+/// diagnosable only because that user happened to be running with
+/// `logLevel: debug`. At the defaults — `info` for Flutter, `off` for a direct
+/// SDK consumer — every `[SpeedMotion]` line and every "Location filtered by
+/// Rust processor" line is dropped before it reaches the store.
+///
+/// `TraceletLogger.lifecycle` (#318) already exists for exactly this: a
+/// curated, low-frequency set of events that bypasses the level gate and
+/// persists to the SQLite log store, surfaced by Doctor under
+/// `## Session lifecycle`. Its own doc comment lists "motion-state transitions"
+/// and "tracking-mode switches" as belonging on the channel — and the speed
+/// machine's transitions were on neither.
+///
+/// What moved onto the always-on channel:
+///
+/// * `speed-motion: MOVING -> SLOWING — speed=0.00 < threshold=1.50` — the
+///   deciding speed is the whole story of #332, and it was invisible.
+/// * `speed-motion: restored STATIONARY …` on start, so a relaunched process
+///   inheriting STATIONARY is distinguishable from tracking having silently
+///   stopped.
+/// * `smart-motion: switching to STATIONARY_PERIODIC — accelMoving=false
+///   speedMoving=false lastSpeed=8.53m/s` — which of the OR's two inputs was
+///   false, and what the last resolved speed was.
+///
+/// State names are spelled out rather than logged as `rawValue: 2`, because the
+/// trace is read by a human in a pasted report.
+///
+/// This card verifies the persistence contract directly, and does not depend on
+/// the device moving.
+class Issue334Card extends StatefulWidget {
+  const Issue334Card({super.key});
+
+  @override
+  State<Issue334Card> createState() => _Issue334CardState();
+}
+
+class _Issue334CardState extends State<Issue334Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    try {
+      // Raise the level gate as high as it goes. Anything still reaching the
+      // store after this is on the always-on channel by definition — which is
+      // the property that has to hold in a release build.
+      await Tracelet.setConfig(
+        const Config(logger: LoggerConfig(logLevel: LogLevel.error)),
+      );
+
+      // A start/stop pair is the one boundary that fires on every run, so the
+      // card is re-runnable within a single process (#324's lesson). Starting
+      // also constructs the speed machine, which records its restored state.
+      await Tracelet.start();
+      await Future<void>.delayed(const Duration(seconds: 4));
+      await Tracelet.stop();
+      await Future<void>.delayed(const Duration(seconds: 1));
+
+      final logs = await Tracelet.getLogs(300);
+      final lifecycle = logs
+          .where((e) => e.level.toUpperCase() == 'LIFECYCLE')
+          .toList();
+
+      // Row 1: distinguishes "the always-on channel is broken" from "nothing is
+      // being logged at all" — different bugs in different layers.
+      final levels = logs.map((e) => e.level.toUpperCase()).toSet().toList()
+        ..sort();
+      check(
+        'the always-on channel survives logLevel=error',
+        lifecycle.isNotEmpty,
+        lifecycle.isNotEmpty
+            ? '${lifecycle.length} lifecycle entries persisted with the level '
+                  'gate at its maximum'
+            : logs.isEmpty
+            ? 'REGRESSED — the log table is empty entirely, so this is the log '
+                  'store rather than the lifecycle channel.'
+            : 'REGRESSED — ${logs.length} entries exist but none are LIFECYCLE '
+                  '(levels seen: ${levels.join(', ')}).',
+      );
+
+      // Row 2: the entry this issue is about. `speed-motion: restored …` is
+      // written by every start(), so it is present on any platform where the
+      // machine runs — no movement required.
+      final speedMotion = lifecycle
+          .where((e) => e.message.contains('speed-motion:'))
+          .toList();
+      check(
+        '#334 the speed machine records itself on the always-on channel',
+        speedMotion.isNotEmpty,
+        speedMotion.isNotEmpty
+            ? '${speedMotion.length} entr'
+                  '${speedMotion.length == 1 ? 'y' : 'ies'} — most recent: '
+                  '"${speedMotion.last.message}"'
+            : 'REGRESSED — no `speed-motion:` entries. start() records the '
+                  'restored state, so this should be present on any run where '
+                  'the speed machine is active.',
+      );
+
+      // Row 3: a transition entry has to carry its deciding speed. An entry
+      // that only says MOVING -> SLOWING repeats the mistake in a new place:
+      // #332 was invisible precisely because the speed was not written down.
+      final transitions = speedMotion
+          .where((e) => e.message.contains('->'))
+          .toList();
+      if (transitions.isEmpty) {
+        results.add(
+          '⏭️ transition entries carry their deciding speed — skipped, this '
+          'run produced no state change (a stationary device that starts and '
+          'stops in the same state legitimately produces none). The restored '
+          'entry asserted above proves the channel itself.',
+        );
+      } else {
+        final withEvidence = transitions
+            .where(
+              (e) =>
+                  e.message.contains('speed=') ||
+                  e.message.contains('expired') ||
+                  e.message.contains('manual pace change'),
+            )
+            .length;
+        check(
+          'transition entries carry the reason they fired',
+          withEvidence == transitions.length,
+          withEvidence == transitions.length
+              ? 'all $withEvidence transition entries name the speed or the '
+                    'timer that caused them'
+              : 'REGRESSED — ${transitions.length - withEvidence} of '
+                    '${transitions.length} transitions recorded no reason, '
+                    'which is the gap #334 was filed for.',
+        );
+      }
+
+      // Row 4: state names, not raw enum ordinals. The old motion entries read
+      // "mode=MotionDetectionMode(rawValue: 2)", which needs the source to
+      // decode — in the one output meant to be read without it.
+      final readable = speedMotion.any(
+        (e) =>
+            e.message.contains('MOVING') ||
+            e.message.contains('SLOWING') ||
+            e.message.contains('STATIONARY'),
+      );
+      check(
+        'the trace is readable without the source',
+        speedMotion.isEmpty || readable,
+        speedMotion.isEmpty
+            ? 'no entries to inspect — see the row above'
+            : readable
+            ? 'states are spelled out (MOVING/SLOWING/STATIONARY) rather than '
+                  'logged as raw ordinals'
+            : 'REGRESSED — entries carry no readable state name: '
+                  '"${speedMotion.last.message}"',
+      );
+
+      final header = allPass
+          ? '✅ SUCCESS: the speed machine now leaves a trace that survives a '
+                'release build at default log settings.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Why the level matters: this card sets logLevel=error before running, '
+        'so everything it then finds reached the store despite the gate. That '
+        'is the release-build property — `lifecycle()` writes to the SQLite '
+        'store with no level check and no debug guard on either platform.\n\n'
+        'Retention is unchanged and bounded on two axes: the row cap from '
+        'pruneOldLogs() and logMaxDays (3 days by default). These entries fire '
+        'a handful of times per trip rather than per fix, which is the '
+        'affordability bar the channel documents.\n\n'
+        'Still missing, and worth knowing when reading a report: `## Active '
+        'configuration` mirrors Tracelet.activeConfig, a Dart-side in-memory '
+        'copy, so a report generated after a background relaunch renders it as '
+        '{}. The same restart empties `## Location filter (in force vs. '
+        'configured)`. Both are process-scoped by construction and are not '
+        'addressed here.',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'lifecycle log level release build debug speed motion transition '
+          'trace bug report doctor sqlite persisted always-on diagnostics '
+          'smart motion mode switch 334 318',
+      title: '#334: speed-motion decisions are recorded in release builds',
+      description:
+          'Raises logLevel to error, runs a tracking session, and verifies the '
+          'speed machine still records its transitions — with the deciding '
+          'speed and readable state names — on the always-on lifecycle channel '
+          'that Doctor reads.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/issue_335_card.dart
+++ b/example/lib/issues/issue_335_card.dart
@@ -100,27 +100,47 @@ class _Issue335CardState extends State<Issue335Card> {
       await Future<void>.delayed(const Duration(seconds: 2));
       final afterRepeat = events.length - afterStationary.length;
 
+      final repeatWindow = events.sublist(afterStationary.length);
+
       // Back the other way: another real edge.
       await Tracelet.changePace(true);
       await Future<void>.delayed(const Duration(seconds: 2));
-      final afterMoving = events.length - afterStationary.length - afterRepeat;
+      final movingWindow = events.sublist(afterStationary.length + afterRepeat);
 
+      // Counting *everything* that lands in the window is wrong, and produced a
+      // false red on the first device run of this card. The machine is fed real
+      // fixes throughout: once changePace(true) puts it in MOVING, a stationary
+      // device's next fix reports ~0 m/s and legitimately slides it
+      // MOVING → SLOWING within a second. That is a second event, and a
+      // perfectly genuine one.
+      //
+      // The forced edge is identified by its destination instead. Within a 2 s
+      // window only the slide to SLOWING can happen spontaneously — reaching
+      // STATIONARY on its own needs the whole speedStationaryDelay (180 s by
+      // default) — so exactly one event may name each forced destination, and a
+      // true duplicate (the same payload twice, which is what #335 was) still
+      // fails this.
+      int arrivingAt(List<SpeedMotionEvent> evs, SpeedMotionState to) =>
+          evs.where((e) => e.state == to).length;
+      String describe(List<SpeedMotionEvent> evs) => evs.isEmpty
+          ? 'none'
+          : evs
+                .map((e) => '${e.previousState.name}→${e.state.name}')
+                .join(', ');
+
+      final stops = arrivingAt(afterStationary, SpeedMotionState.stationary);
       check(
         '#335 a forced stop emits one event, not two',
-        afterStationary.length == 1 &&
-            afterStationary.first.previousState != afterStationary.first.state,
-        afterStationary.length == 1 &&
-                afterStationary.first.previousState !=
-                    afterStationary.first.state
-            ? 'changePace(false) from MOVING produced exactly one '
-                  '${afterStationary.first.previousState.name} → '
-                  '${afterStationary.first.state.name} event'
-            : afterStationary.isEmpty
-            ? 'no event at all — the seeding changePace(true) above did not '
-                  'take, or the event stream is not wired. Nothing can be '
-                  'concluded from the rows below.'
-            : 'REGRESSED — ${afterStationary.length} event(s): '
-                  '${afterStationary.map((e) => '${e.previousState.name}→${e.state.name}').join(', ')}',
+        stops == 1,
+        stops == 1
+            ? 'changePace(false) produced exactly one event arriving at '
+                  'STATIONARY — observed: ${describe(afterStationary)}'
+            : stops == 0
+            ? 'no event arrived at STATIONARY — observed: '
+                  '${describe(afterStationary)}. Nothing can be concluded from '
+                  'the rows below.'
+            : 'REGRESSED — $stops events arrived at STATIONARY for one '
+                  'changePace(false) — observed: ${describe(afterStationary)}',
       );
 
       check(
@@ -130,20 +150,40 @@ class _Issue335CardState extends State<Issue335Card> {
             ? 'the second changePace(false) agreed with the current state, so '
                   'no edge was reported'
             : 'REGRESSED — $afterRepeat event(s) for a transition that changed '
-                  'nothing. Android used to emit these; iOS always suppressed '
-                  'them.',
+                  'nothing — observed: ${describe(repeatWindow)}. Android used '
+                  'to emit these; iOS always suppressed them.',
       );
 
+      final resumes = arrivingAt(movingWindow, SpeedMotionState.moving);
+      final onward = movingWindow.length - resumes;
       check(
         'a forced resume emits one event, not two',
-        afterMoving == 1,
-        afterMoving == 1
-            ? 'changePace(true) produced exactly one event'
-            : 'REGRESSED — $afterMoving events for one transition',
+        resumes == 1,
+        resumes == 1
+            ? 'changePace(true) produced exactly one event arriving at MOVING'
+                  '${onward == 0 ? '' : ', plus $onward onward transition(s) '
+                            'the fix stream drove afterwards'} — observed: '
+                  '${describe(movingWindow)}'
+            : 'REGRESSED — $resumes events arrived at MOVING for one '
+                  'changePace(true) — observed: ${describe(movingWindow)}',
       );
 
-      // No event may report itself as going nowhere. Both a duplicate emitted
-      // after the commit (#335) and a no-op transition (#337) show up here.
+      // A stationary device sliding MOVING → SLOWING after the resume is
+      // expected, not a defect. Reported so the row above is readable rather
+      // than looking like a suppressed failure.
+      if (onward > 0) {
+        results.add(
+          'ℹ️ $onward onward transition(s) after the resume: '
+          '${describe(movingWindow.where((e) => e.state != SpeedMotionState.moving).toList())}. '
+          'This device is stationary, so its next fix reports ~0 m/s and the '
+          'machine correctly begins its SLOWING countdown. Not attributable to '
+          'changePace().',
+        );
+      }
+
+      // No event may report itself as going nowhere. This catches a no-op
+      // transition (#337) but NOT a #335-style duplicate, whose two copies each
+      // name a genuine edge — the rows above are what cover that.
       final degenerate = events
           .where((e) => e.state == e.previousState)
           .toList();
@@ -151,11 +191,14 @@ class _Issue335CardState extends State<Issue335Card> {
         'no event reports a transition to the state it came from',
         degenerate.isEmpty,
         degenerate.isEmpty
-            ? 'every event names a genuine edge'
+            ? 'every event names a genuine edge (note: a duplicate would too, '
+                  'so this row alone does not rule one out)'
             : 'REGRESSED — ${degenerate.length} event(s) with '
-                  'previousState == state: a second emit after the commit '
-                  '(#335) or a no-op transition (#337)',
+                  'previousState == state, a no-op transition (#337)',
       );
+
+      // The whole sequence, so a failure above can be read without re-running.
+      results.add('ℹ️ full event sequence: ${describe(events)}');
 
       await Tracelet.stop();
 

--- a/example/lib/issues/issue_335_card.dart
+++ b/example/lib/issues/issue_335_card.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #335 — iOS emitted the `speedmotion` event twice for most transitions.
+///
+/// `SpeedMotionManager.onLocation` snapshotted the state, delegated to a
+/// handler, and then persisted-and-emitted if the state had changed. But three
+/// of the four handlers already did that for themselves, so both fired with
+/// identical payloads:
+///
+/// ```swift
+/// private func handleMoving(speed: Double, now: TimeInterval) {
+///     if speed < speedMovingThreshold {
+///         state = .slowing
+///         if state != previousState { persistState(); emitEvent(...) }   // (1)
+///     }
+/// }
+/// // …then, back in onLocation:
+/// if state != previousState { persistState(); emitEvent(...) }           // (2)
+/// ```
+///
+/// `handleStationary` was the odd one out — it emitted nothing of its own and
+/// relied solely on the outer block — which is why `STATIONARY -> MOVING` was
+/// the only transition that emitted once. The contract was therefore
+/// inconsistent with itself as well as with Android, whose single
+/// `transitionTo` choke point had always emitted once.
+///
+/// Beyond the duplicate Dart events, this blocked #334: a doubled entry would
+/// have misrepresented one transition as two in the diagnostic trace meant to
+/// settle what happened during a trip. iOS now has the same single
+/// `commitTransition` choke point, which persists, emits and records once.
+///
+/// **What this card can prove.** `changePace()` drives real transitions on
+/// demand, so the one-event-per-transition contract is checkable without
+/// waiting for GPS. It exercises the manual path specifically; the
+/// location-driven path that carried the duplicate is pinned by the Swift unit
+/// tests (`testEachTransitionEmitsExactlyOneEvent`), which is stated below
+/// rather than implied.
+class Issue335Card extends StatefulWidget {
+  const Issue335Card({super.key});
+
+  @override
+  State<Issue335Card> createState() => _Issue335CardState();
+}
+
+class _Issue335CardState extends State<Issue335Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    StreamSubscription<SpeedMotionEvent>? sub;
+
+    try {
+      // Speed mode so the machine under test is the one driving pace, rather
+      // than the accelerometer.
+      await Tracelet.setConfig(
+        const Config(
+          motion: MotionConfig(motionDetectionMode: MotionDetectionMode.speed),
+        ),
+      );
+
+      final events = <SpeedMotionEvent>[];
+      sub = Tracelet.onSpeedMotionChange(events.add);
+
+      await Tracelet.start();
+      await Future<void>.delayed(const Duration(seconds: 2));
+      events.clear(); // ignore whatever start() settled into
+
+      // Two forced transitions, each of which must produce exactly one event.
+      await Tracelet.changePace(false);
+      await Future<void>.delayed(const Duration(seconds: 2));
+      final afterStationary = List<SpeedMotionEvent>.from(events);
+
+      await Tracelet.changePace(true);
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      check(
+        '#335 a forced stop emits one event, not two',
+        afterStationary.length == 1,
+        afterStationary.length == 1
+            ? 'changePace(false) produced exactly one '
+                  '${afterStationary.first.previousState.name} → '
+                  '${afterStationary.first.state.name} event'
+            : afterStationary.isEmpty
+            ? 'no event at all — the machine may already have been stationary, '
+                  'or the event stream is not wired. Nothing can be concluded '
+                  'from the rows below.'
+            : 'REGRESSED — ${afterStationary.length} events for one '
+                  'transition: '
+                  '${afterStationary.map((e) => '${e.previousState.name}→${e.state.name}').join(', ')}',
+      );
+
+      final afterMoving = events.length - afterStationary.length;
+      check(
+        'a forced resume emits one event, not two',
+        afterMoving == 1,
+        afterMoving == 1
+            ? 'changePace(true) produced exactly one event'
+            : 'REGRESSED — $afterMoving events for one transition',
+      );
+
+      // No transition can report itself as going nowhere. A duplicate emitted
+      // after the state had already been committed would show up here.
+      final degenerate = events
+          .where((e) => e.state == e.previousState)
+          .toList();
+      check(
+        'no event reports a transition to the state it came from',
+        degenerate.isEmpty,
+        degenerate.isEmpty
+            ? 'every event names a genuine edge'
+            : 'REGRESSED — ${degenerate.length} event(s) with '
+                  'previousState == state, which is what a second emit after '
+                  'the commit looks like',
+      );
+
+      await Tracelet.stop();
+
+      final header = allPass
+          ? '✅ SUCCESS: one event per transition on the manual path.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Scope: changePace() exercises the manual path. The duplicate itself '
+        'was on the location-driven path — the inner handler emitted, then '
+        'onLocation emitted again — which needs synthetic fixes to drive and '
+        'is pinned by the Swift unit test '
+        'testEachTransitionEmitsExactlyOneEvent, now that the suite is '
+        'actually wired into Package.swift. This card checks the contract '
+        'holds end to end through the bridge.\n\n'
+        'Android was never affected: its transitionTo() has always been a '
+        'single choke point. iOS now matches it.',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      await sub?.cancel();
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'speedmotion event duplicate emit twice transition choke point '
+          'commitTransition transitionTo ios android parity changePace 335',
+      title: '#335: one speedmotion event per transition, not two',
+      description:
+          'Forces stop/resume transitions with changePace() and asserts each '
+          'produces exactly one speedmotion event. iOS used to emit most '
+          'transitions twice because both the handler and its caller emitted.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/issue_335_card.dart
+++ b/example/lib/issues/issue_335_card.dart
@@ -80,33 +80,60 @@ class _Issue335CardState extends State<Issue335Card> {
 
       await Tracelet.start();
       await Future<void>.delayed(const Duration(seconds: 2));
-      events.clear(); // ignore whatever start() settled into
 
-      // Two forced transitions, each of which must produce exactly one event.
+      // Seed a known state. Without this the first changePace() below lands on
+      // whatever the machine happened to settle into, and "one event" cannot be
+      // distinguished from "one *no-op* event" — which is exactly how the first
+      // run of this card surfaced #337: it reported a green
+      // `stationary → stationary`.
+      await Tracelet.changePace(true);
+      await Future<void>.delayed(const Duration(seconds: 2));
+      events.clear();
+
+      // A real edge: MOVING → STATIONARY.
       await Tracelet.changePace(false);
       await Future<void>.delayed(const Duration(seconds: 2));
       final afterStationary = List<SpeedMotionEvent>.from(events);
 
+      // The same call again. It changes nothing, so it must report nothing.
+      await Tracelet.changePace(false);
+      await Future<void>.delayed(const Duration(seconds: 2));
+      final afterRepeat = events.length - afterStationary.length;
+
+      // Back the other way: another real edge.
       await Tracelet.changePace(true);
       await Future<void>.delayed(const Duration(seconds: 2));
+      final afterMoving = events.length - afterStationary.length - afterRepeat;
 
       check(
         '#335 a forced stop emits one event, not two',
-        afterStationary.length == 1,
-        afterStationary.length == 1
-            ? 'changePace(false) produced exactly one '
+        afterStationary.length == 1 &&
+            afterStationary.first.previousState != afterStationary.first.state,
+        afterStationary.length == 1 &&
+                afterStationary.first.previousState !=
+                    afterStationary.first.state
+            ? 'changePace(false) from MOVING produced exactly one '
                   '${afterStationary.first.previousState.name} → '
                   '${afterStationary.first.state.name} event'
             : afterStationary.isEmpty
-            ? 'no event at all — the machine may already have been stationary, '
-                  'or the event stream is not wired. Nothing can be concluded '
-                  'from the rows below.'
-            : 'REGRESSED — ${afterStationary.length} events for one '
-                  'transition: '
+            ? 'no event at all — the seeding changePace(true) above did not '
+                  'take, or the event stream is not wired. Nothing can be '
+                  'concluded from the rows below.'
+            : 'REGRESSED — ${afterStationary.length} event(s): '
                   '${afterStationary.map((e) => '${e.previousState.name}→${e.state.name}').join(', ')}',
       );
 
-      final afterMoving = events.length - afterStationary.length;
+      check(
+        '#337 a repeat of the same changePace emits nothing',
+        afterRepeat == 0,
+        afterRepeat == 0
+            ? 'the second changePace(false) agreed with the current state, so '
+                  'no edge was reported'
+            : 'REGRESSED — $afterRepeat event(s) for a transition that changed '
+                  'nothing. Android used to emit these; iOS always suppressed '
+                  'them.',
+      );
+
       check(
         'a forced resume emits one event, not two',
         afterMoving == 1,
@@ -115,8 +142,8 @@ class _Issue335CardState extends State<Issue335Card> {
             : 'REGRESSED — $afterMoving events for one transition',
       );
 
-      // No transition can report itself as going nowhere. A duplicate emitted
-      // after the state had already been committed would show up here.
+      // No event may report itself as going nowhere. Both a duplicate emitted
+      // after the commit (#335) and a no-op transition (#337) show up here.
       final degenerate = events
           .where((e) => e.state == e.previousState)
           .toList();
@@ -126,8 +153,8 @@ class _Issue335CardState extends State<Issue335Card> {
         degenerate.isEmpty
             ? 'every event names a genuine edge'
             : 'REGRESSED — ${degenerate.length} event(s) with '
-                  'previousState == state, which is what a second emit after '
-                  'the commit looks like',
+                  'previousState == state: a second emit after the commit '
+                  '(#335) or a no-op transition (#337)',
       );
 
       await Tracelet.stop();
@@ -145,8 +172,17 @@ class _Issue335CardState extends State<Issue335Card> {
         'testEachTransitionEmitsExactlyOneEvent, now that the suite is '
         'actually wired into Package.swift. This card checks the contract '
         'holds end to end through the bridge.\n\n'
-        'Android was never affected: its transitionTo() has always been a '
-        'single choke point. iOS now matches it.',
+        'Android was never affected by the duplicate: its transitionTo() has '
+        'always been a single choke point, and iOS now matches it.\n\n'
+        'It was affected by the converse, which the first run of this card '
+        'found on a device (#337): transitionTo() had no "did the state '
+        'actually change" guard, so a changePace() that agreed with the '
+        'current state emitted a stationary → stationary event and wrote a '
+        'fabricated `speed-motion: STATIONARY -> STATIONARY` line into the '
+        '#334 trace. iOS commitTransition() had always guarded it. All five '
+        'iOS commit sites were checked; the four location-driven ones are real '
+        'edges by construction and onManualPaceChange is the one the guard '
+        'absorbs.',
       );
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -61,6 +61,10 @@ import 'package:tracelet_example/issues/issue_320_card.dart';
 import 'package:tracelet_example/issues/issue_321_card.dart';
 import 'package:tracelet_example/issues/issue_324_card.dart';
 import 'package:tracelet_example/issues/issue_326_card.dart';
+import 'package:tracelet_example/issues/issue_332_card.dart';
+import 'package:tracelet_example/issues/issue_333_card.dart';
+import 'package:tracelet_example/issues/issue_334_card.dart';
+import 'package:tracelet_example/issues/issue_335_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1733,6 +1737,10 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                   // own title/description/keywords via IssueSearchScope, so they
                   // are rendered directly. Cards with a bespoke layout (no shell)
                   // stay wrapped in _searchableCard with explicit keywords.
+                  const Issue335Card(),
+                  const Issue334Card(),
+                  const Issue333Card(),
+                  const Issue332Card(),
                   const Issue326Card(),
                   const Issue324Card(),
                   const Issue321Card(),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,6 +28,10 @@ dependencies:
   flutter_map: ^8.2.2
   latlong2: ^0.9.1
   mobile_scanner: ^7.2.0
+  # Pure-Dart QR encoder. Already present transitively via qr_flutter, but
+  # test_server.dart is a plain `dart` script rather than a Flutter app, so it
+  # needs the direct dependency to import it.
+  qr: ^3.0.2
   qr_flutter: ^4.1.0
 
 dev_dependencies:

--- a/example/test_server.dart
+++ b/example/test_server.dart
@@ -16,6 +16,8 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:qr/qr.dart';
+
 Future<void> main(List<String> args) async {
   final port = args.isNotEmpty ? int.tryParse(args.first) ?? 8099 : 8099;
 
@@ -31,18 +33,26 @@ Future<void> main(List<String> args) async {
   stdout.writeln('╚══════════════════════════════════════════════════════╝');
   stdout.writeln();
 
+  final url = 'http://$localIp:$port/locations';
+
+  // The QR code is rendered here, in process. It used to be fetched by shelling
+  // out to `curl qrenco.de/<url>`, which had two problems. The obvious one is
+  // that it stopped working the moment that third-party service became
+  // unreachable. The worse one is that every failure was swallowed — the call
+  // was wrapped in `catch (_) {}` and only printed when stdout was non-empty —
+  // so a machine with no route to it simply showed no QR code and no reason.
+  //
+  // Needing the public internet for this was backwards regardless: the URL
+  // encodes a LAN address, so the phone and the Mac are already on the same
+  // network, and that is the only network the pairing requires.
   try {
-    // Automatically generate a scannable QR code right in the terminal!
-    final result = await Process.run('curl', [
-      '-s',
-      'qrenco.de/http://$localIp:$port/locations',
-    ]);
-    if (result.stdout.toString().isNotEmpty) {
-      stdout.writeln(result.stdout);
-      stdout.writeln('^ Scan the QR Code above with the Example app! ^');
-    }
-  } catch (_) {
-    // Ignore if curl fails
+    stdout.writeln(_renderQr(url));
+    stdout.writeln('^ Scan the QR code above with the Example app ^');
+  } catch (e) {
+    // Loud, not silent: the URL above is still usable by hand, and a failure
+    // here should say so rather than leaving a blank space where a QR was.
+    stdout.writeln('⚠️  Could not render the QR code: $e');
+    stdout.writeln('    Enter the URL above manually instead: $url');
   }
 
   stdout.writeln();
@@ -190,6 +200,53 @@ void _printLocation(Map<dynamic, dynamic> loc, int reqNum, {int? index}) {
 
   stdout.writeln();
   if (ts != '') stdout.writeln('$prefix  ts=$ts');
+}
+
+/// Renders [data] as a QR code made of Unicode half-block characters.
+///
+/// Two modules are packed into each character cell — `▀` is a dark upper half
+/// over a light lower half, and so on — so the code comes out roughly square in
+/// a terminal, whose cells are about twice as tall as they are wide. Rendering
+/// one module per line would make it twice as tall as the window.
+///
+/// Colours are set explicitly (black on white) rather than relying on the
+/// terminal's own palette. Scanners need dark modules on a light field, and a
+/// developer with a dark theme would otherwise get black-on-black.
+String _renderQr(String data) {
+  final image = QrImage(
+    QrCode.fromData(data: data, errorCorrectLevel: QrErrorCorrectLevel.M),
+  );
+  final size = image.moduleCount;
+
+  // The quiet zone is part of the spec, not padding for looks: without ~4
+  // modules of clear margin many scanners will not lock on at all.
+  const quiet = 4;
+  const black = '\x1b[30;47m';
+  const reset = '\x1b[0m';
+
+  bool dark(int x, int y) =>
+      x >= 0 && y >= 0 && x < size && y < size && image.isDark(y, x);
+
+  final buffer = StringBuffer();
+  for (var y = -quiet; y < size + quiet; y += 2) {
+    buffer.write(black);
+    for (var x = -quiet; x < size + quiet; x++) {
+      final top = dark(x, y);
+      // The last row of an odd-height code has no lower half to pair with.
+      final bottom = dark(x, y + 1);
+      if (top && bottom) {
+        buffer.write('█');
+      } else if (top) {
+        buffer.write('▀');
+      } else if (bottom) {
+        buffer.write('▄');
+      } else {
+        buffer.write(' ');
+      }
+    }
+    buffer.writeln(reset);
+  }
+  return buffer.toString();
 }
 
 Future<String> _getLocalIp() async {

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
@@ -332,8 +332,17 @@ class TraceletAndroidPlugin :
     override fun requestSyncBody(locations: List<Map<String, Any?>>): String? {
         if (!hasCustomSyncBodyBuilder) {
             // No foreground builder registered in Dart. Return the sentinel
-            // immediately to bypass the 10-second channel timeout and ensure 
+            // immediately to bypass the 10-second channel timeout and ensure
             // the sync falls back to the default payload without aborting.
+            //
+            // #340: the `requestSyncBody called with N locations` line below
+            // sits after this check, so this branch returned in silence and a
+            // device posting the default payload gave no clue why. Kept in step
+            // with the iOS log of the same name.
+            sdk.logger.debug(
+                "requestSyncBody: no custom sync body builder registered " +
+                    "(setSyncBodyBuilder never reached native) — using the default payload",
+            )
             return NO_SYNC_BODY_BUILDER_SENTINEL
         }
 

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
@@ -339,7 +339,14 @@ class TraceletAndroidPlugin :
             // sits after this check, so this branch returned in silence and a
             // device posting the default payload gave no clue why. Kept in step
             // with the iOS log of the same name.
-            sdk.logger.debug(
+            //
+            // Deliberately TraceletLog, not `sdk.logger`: `sdk` resolves through
+            // `TraceletSdk.getInstance(context)` and throws before the plugin is
+            // attached to an engine. This branch must stay reachable in that
+            // state — returning the sentinel *immediately, touching nothing* is
+            // the #125 guarantee, and routing the log through the SDK broke it.
+            // TraceletLog falls back to Log.d until a logger is attached.
+            TraceletLog.debug(
                 "requestSyncBody: no custom sync body builder registered " +
                     "(setSyncBodyBuilder never reached native) — using the default payload",
             )

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
@@ -231,7 +231,15 @@ public class TraceletIosPlugin: NSObject, FlutterPlugin, DartSyncInterceptor {
             // default payload when the app had registered a builder left no
             // trace of which link had failed — this branch and a nil
             // `dartSyncInterceptor` produced byte-identical evidence.
-            TraceletSdk.shared.logger.debug(
+            //
+            // Deliberately TraceletLog, not `TraceletSdk.shared.logger`: that
+            // property is `TraceletLogger!` and traps when read before
+            // `initialize()`. This branch must stay reachable in that state —
+            // returning the sentinel *immediately, touching nothing* is the #125
+            // guarantee, and routing the log through the SDK would put a crash in
+            // its way. TraceletLog falls back to NSLog until a logger is attached.
+            // The Android counterpart broke its own regression test this way.
+            TraceletLog.debug(
                 "requestSyncBody: no custom sync body builder registered "
                     + "(setSyncBodyBuilder never reached native) — using the default payload")
             return traceletNoSyncBodyBuilderSentinel

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
@@ -224,8 +224,16 @@ public class TraceletIosPlugin: NSObject, FlutterPlugin, DartSyncInterceptor {
     public func requestSyncBody(locations: [[String: Any]]) -> String? {
         if !TraceletIosPlugin.hasCustomSyncBodyBuilder {
             // No foreground builder registered in Dart. Return the sentinel
-            // immediately to bypass the 10-second channel timeout and ensure 
+            // immediately to bypass the 10-second channel timeout and ensure
             // the sync falls back to the default payload without aborting.
+            //
+            // #340: this used to return in silence, so a device posting the
+            // default payload when the app had registered a builder left no
+            // trace of which link had failed — this branch and a nil
+            // `dartSyncInterceptor` produced byte-identical evidence.
+            TraceletSdk.shared.logger.debug(
+                "requestSyncBody: no custom sync body builder registered "
+                    + "(setSyncBodyBuilder never reached native) — using the default payload")
             return traceletNoSyncBodyBuilderSentinel
         }
         

--- a/packages/tracelet_sync/ios/tracelet_sync/Sources/tracelet_sync/TraceletSyncPlugin.swift
+++ b/packages/tracelet_sync/ios/tracelet_sync/Sources/tracelet_sync/TraceletSyncPlugin.swift
@@ -163,6 +163,36 @@ struct FallbackSyncResult {
 
 class TraceletSyncSink: LocationDataSink, SyncProvider {
     let coordinator = SyncCoordinator()
+
+    private static let syncBodySourceLock = NSLock()
+    private static var lastSyncBodySource: String?
+
+    /// Records which body the sync is posting — but only when the answer
+    /// changes (#340).
+    ///
+    /// The per-sync lines around the call sites are `debug`, so on a release
+    /// build at the shipped log levels they are dropped and a device posting
+    /// the default payload when the app registered a custom builder leaves no
+    /// trace of it. The lifecycle channel is never level-gated, which is
+    /// exactly what a release build needs.
+    ///
+    /// It cannot simply be written per sync, though: syncs fire every few
+    /// seconds while tracking, and ``TraceletLogger/lifecycle(_:)`` is
+    /// explicitly reserved for events that fire a handful of times per session
+    /// because its rows share a bounded cap with the killed-state trail. One
+    /// entry per sync would evict the trail it exists to preserve.
+    ///
+    /// Reporting only transitions costs a handful of rows per session and still
+    /// answers the whole question: which body is this app sending, and did that
+    /// ever change mid-session?
+    private static func reportSyncBodySource(_ source: String, _ detail: String) {
+        syncBodySourceLock.lock()
+        let changed = lastSyncBodySource != source
+        if changed { lastSyncBodySource = source }
+        syncBodySourceLock.unlock()
+        guard changed else { return }
+        TraceletSdk.shared.logger.lifecycle("sync-body: \(detail)")
+    }
     
     @discardableResult
     func insertLocation(_ location: [String: Any]) -> String {
@@ -232,6 +262,8 @@ class TraceletSyncSink: LocationDataSink, SyncProvider {
             }
             if let body = customBody, body != traceletNoSyncBodyBuilderSentinel {
                 TraceletSdk.shared.logger.debug("customBody from interceptor (syncBatchBlocking): \(body)")
+                TraceletSyncSink.reportSyncBodySource(
+                    "custom", "posting the app's custom sync body")
                 let sem = DispatchSemaphore(value: 0)
                 var fallbackResult: SyncCoordinator.FallbackSyncResult? = nil
 
@@ -269,6 +301,21 @@ class TraceletSyncSink: LocationDataSink, SyncProvider {
                 }
             }
             // sentinel → no builder → fall through to the default sync below.
+            TraceletSyncSink.reportSyncBodySource(
+                "no-builder",
+                "posting the DEFAULT payload — no custom sync body builder reached native "
+                    + "(setSyncBodyBuilder registered in Dart?)")
+        } else {
+            // #340: a nil interceptor and a registered-but-unreported builder
+            // both ended up here posting the default payload, and neither said
+            // so. Naming this branch is what separates "the plugin never
+            // attached itself to the SDK" from "Dart never registered a
+            // builder" — see the matching log in `requestSyncBody`.
+            TraceletSdk.shared.logger.debug(
+                "syncBatchBlocking: no dartSyncInterceptor attached — using the default payload")
+            TraceletSyncSink.reportSyncBodySource(
+                "no-interceptor",
+                "posting the DEFAULT payload — no dartSyncInterceptor attached to the SDK")
         }
 
         let syncHttp = tracelet_sync.SyncHttpConfig(

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationEngine.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationEngine.kt
@@ -1078,7 +1078,32 @@ class LocationEngine(
         } else {
             0.0
         }
-        val computedSpeed = if (distance > 0 && timeDelta > 0) distance / timeDelta else 0.0
+        val rawComputedSpeed = if (distance > 0 && timeDelta > 0) distance / timeDelta else 0.0
+
+        // A derived speed is only as good as its time base, and `timeDelta > 0` is
+        // satisfied by one millisecond. Two fixes delivered back to back — routine
+        // when a session starts and a cached fix arrives alongside a fresh one —
+        // divide a real distance by an almost-zero interval, which produced
+        // thousands of m/s from a stationary device, enough to wake the speed
+        // motion machine out of STATIONARY since speedWakeConfirmCount is 1 by
+        // default (#342).
+        //
+        // `maxImpliedSpeed` already encodes what counts as credible movement; above
+        // it this is an artefact, not a measurement. Report *no* speed rather than a
+        // fabricated one. That is not #332 in reverse: this branch is only reached
+        // when the platform supplied no speed at all, so 0 is the pre-existing
+        // meaning of "unknown" rather than a value invented in place of a real
+        // reading. A genuinely moving device has a Doppler speed and never gets here.
+        val maxImplied = config.getMaxImpliedSpeed().toDouble()
+        val computedSpeed = if (maxImplied > 0 && rawComputedSpeed > maxImplied) {
+            TraceletLog.debug(
+                "Discarding implausible derived speed $rawComputedSpeed m/s " +
+                    "(${distance}m over ${timeDelta}s, max $maxImplied m/s) — reporting no speed",
+            )
+            0.0
+        } else {
+            rawComputedSpeed
+        }
 
         // Use platform speed if available, otherwise use computed speed
         val effectiveSpeed = if (location.hasSpeed() && location.speed > 0) {

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationEngine.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/location/LocationEngine.kt
@@ -1144,6 +1144,11 @@ class LocationEngine(
         // MOVING → SLOWING → STATIONARY. Without this, a stationary device
         // whose locations are filtered (e.g. same lat/lng, no distance change)
         // will never transition out of MOVING state.
+        //
+        // `result.effectiveSpeed` is the speed the processor resolved for this
+        // fix whether or not it accepted it — it used to be hardcoded to 0 on
+        // every rejection, which fed the machine a fabricated "stopped" for
+        // most of every drive (#332).
         speedMotionSpeedSink?.invoke(result.effectiveSpeed)
 
         var isForcedAccept = false
@@ -1153,7 +1158,14 @@ class LocationEngine(
                 isForcedAccept = true
                 forcePersistNextFilteredLocation = false
             } else {
-                TraceletLog.debug("Location filtered by Rust processor: ${result.reason}")
+                // #334: the speed handed to the motion machine belongs on this
+                // line. Without it, a rejected fix's contribution to a
+                // stationary decision can only be inferred by cross-reading the
+                // speed-motion entries.
+                TraceletLog.debug(
+                    "Location filtered by Rust processor: ${result.reason} " +
+                        "(speed=${result.effectiveSpeed} m/s fed to speed motion)",
+                )
                 // Still update odometer if the processor computed a delta
                 if (result.odometerDelta > 0) {
                     state.addOdometer(result.odometerDelta)

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinator.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinator.kt
@@ -51,6 +51,17 @@ class SmartMotionCoordinator(
     }
 
     /**
+     * The last speed this process actually resolved, or `null` if it has not
+     * resolved one yet.
+     *
+     * [LocationEngine.lastEffectiveSpeed] and `lastLocation` are written
+     * together on every accepted fix, so a null location is exactly "no fix has
+     * been accepted in this process" — which is *unknown*, not zero.
+     */
+    private val resolvedSpeed: Double?
+        get() = locationEngine.getLastLocation()?.let { locationEngine.lastEffectiveSpeed }
+
+    /**
      * Called when the GPS speed state changes.
      */
     fun onSpeedStateChange(isMoving: Boolean) {
@@ -61,12 +72,24 @@ class SmartMotionCoordinator(
             //   b) Walking slowly (GPS speed 0.3-0.5 m/s, below speed threshold)
             // Only override accel for case (a) — truly near-zero GPS speed.
             // For case (b), trust the accelerometer: the user IS moving.
-            val lastSpeed = locationEngine.getLastLocation()?.speed ?: 0f
-            if (lastSpeed <= 0.15f) {
-                logger.info("SmartMotionCoordinator: GPS speed near zero (${lastSpeed} m/s) but accel moving — overriding accel to false (hand tremor).")
-                coreCoordinator.onAccelStateChange(false)
-            } else {
-                logger.info("SmartMotionCoordinator: GPS speed ${lastSpeed} m/s suggests walking — trusting accel, staying continuous.")
+            //
+            // #333: this used to read the raw `Location.speed`, which reports
+            // 0.0 on a fix that carries no speed at all, so an unknown speed
+            // passed the near-zero test and overruled a positive motion signal
+            // on missing data. `lastEffectiveSpeed` is the resolved value — it
+            // falls back to a distance/time derivation exactly when the platform
+            // reading is absent — and no resolved speed at all now leaves the
+            // accelerometer standing rather than silently siding against it.
+            val lastSpeed = resolvedSpeed
+            when {
+                lastSpeed == null ->
+                    logger.info("SmartMotionCoordinator: no GPS speed resolved yet — trusting accel, staying continuous.")
+                lastSpeed <= TREMOR_SPEED_THRESHOLD -> {
+                    logger.info("SmartMotionCoordinator: GPS speed near zero ($lastSpeed m/s) but accel moving — overriding accel to false (hand tremor).")
+                    coreCoordinator.onAccelStateChange(false)
+                }
+                else ->
+                    logger.info("SmartMotionCoordinator: GPS speed $lastSpeed m/s is above the $TREMOR_SPEED_THRESHOLD m/s tremor threshold — trusting accel, staying continuous.")
             }
         }
         val action = coreCoordinator.onSpeedStateChange(isMoving)
@@ -101,10 +124,28 @@ class SmartMotionCoordinator(
         )
     }
 
+    /**
+     * Records a tracking-mode switch on the always-on lifecycle channel, naming
+     * both inputs of the OR (#334).
+     *
+     * The coordinator is a logical OR of the accelerometer and the GPS-speed
+     * machine, so a downgrade means *both* said stationary. Which one flipped
+     * last — and what the other was doing at the time — is the first question
+     * asked of any "it stopped tracking while I was moving" report, and at the
+     * shipped log levels the answer was not recorded anywhere.
+     */
+    private fun recordModeSwitch(mode: String) {
+        val speedText = resolvedSpeed?.toString() ?: "unknown"
+        com.ikolvi.tracelet.sdk.util.TraceletLog.lifecycle(
+            "smart-motion: switching to $mode — accelMoving=${coreCoordinator.isAccelMoving()} " +
+                "speedMoving=${coreCoordinator.isSpeedMoving()} lastSpeed=${speedText}m/s",
+        )
+    }
+
     private fun handleAction(action: uniffi.tracelet_core.CoordinatorAction) {
         when (action) {
             uniffi.tracelet_core.CoordinatorAction.SWITCH_TO_CONTINUOUS -> {
-                logger.info("SmartMotionCoordinator: Switching to CONTINUOUS")
+                recordModeSwitch("CONTINUOUS")
                 val useForeground = configManager.isForegroundServiceEnabled()
                 logger.debug("SmartMotionCoordinator: SWITCH_TO_CONTINUOUS — useForeground=$useForeground")
                 if (useForeground) {
@@ -124,7 +165,7 @@ class SmartMotionCoordinator(
                 events.sendMotionChange(locationMap)
             }
             uniffi.tracelet_core.CoordinatorAction.SWITCH_TO_STATIONARY_GEOFENCES -> {
-                logger.info("SmartMotionCoordinator: Switching to STATIONARY_GEOFENCES")
+                recordModeSwitch("STATIONARY_GEOFENCES")
                 val useForeground = configManager.isForegroundServiceEnabled()
                 if (useForeground) {
                     LocationService.switchToStationaryGeofences(locationEngine, stateManager, configManager)
@@ -144,7 +185,7 @@ class SmartMotionCoordinator(
                 events.sendMotionChange(locationMap)
             }
             uniffi.tracelet_core.CoordinatorAction.SWITCH_TO_STATIONARY_PERIODIC -> {
-                logger.info("SmartMotionCoordinator: Switching to STATIONARY_PERIODIC")
+                recordModeSwitch("STATIONARY_PERIODIC")
                 val useForeground = configManager.isForegroundServiceEnabled()
                 logger.debug("SmartMotionCoordinator: SWITCH_TO_STATIONARY_PERIODIC — useForeground=$useForeground")
                 if (useForeground) {
@@ -180,5 +221,13 @@ class SmartMotionCoordinator(
                 // Do nothing
             }
         }
+    }
+
+    private companion object {
+        /**
+         * GPS speed at or below which a *moving* accelerometer is read as hand
+         * tremor on a physically still device rather than as real motion.
+         */
+        const val TREMOR_SPEED_THRESHOLD = 0.15
     }
 }

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManager.kt
@@ -388,8 +388,22 @@ class SpeedMotionManager(
         state.speedWakeCount = wakeCount
         state.speedLastTransition = SystemClock.elapsedRealtime()
 
-        // Update isMoving for compatibility with existing consumers
+        // Update isMoving for compatibility with existing consumers.
+        //
+        // Deliberately outside the no-op guard below: this is also where
+        // isMoving is re-synced, and SmartMotionCoordinator.handleAction writes
+        // the same field directly, so a changePace() that agrees with the
+        // current state is a legitimate re-assertion of it.
         state.isMoving = newState != SpeedMotionState.STATIONARY
+
+        // #337: a "transition" that changes nothing is not a transition. An
+        // event whose previousState equals its state tells a consumer nothing
+        // while still driving every listener that reacts to one, and
+        // `speed-motion: STATIONARY -> STATIONARY` is a fabricated edge in the
+        // one trace meant to settle what actually happened during a trip
+        // (#334). iOS's `commitTransition` has always guarded this; Android had
+        // no equivalent, so the two platforms disagreed on the same call.
+        if (newState == previousState) return
 
         // Emit speed motion change event
         val eventData = mapOf<String, Any>(

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManager.kt
@@ -141,7 +141,13 @@ class SpeedMotionManager(
             state.isMoving = true
             TraceletLog.debug("start() — forced to MOVING state")
         } else {
-            TraceletLog.debug("start() — restored state=$currentState, lowCount=$lowSpeedCount, wakeCount=$wakeCount")
+            // #334: a relaunched process inherits this state, and inheriting
+            // STATIONARY is indistinguishable from "tracking silently stopped"
+            // unless the trace says so. Once per session, so it belongs on the
+            // always-on channel.
+            TraceletLog.lifecycle(
+                "speed-motion: restored $currentState (lowSpeedCount=$lowSpeedCount, wakeCount=$wakeCount)"
+            )
 
             if (currentState == SpeedMotionState.STATIONARY) {
                 switchToStationary()
@@ -170,14 +176,14 @@ class SpeedMotionManager(
             wakeCount = 0
             highSpeedCount = 0
             stopSlowingTimer()
-            transitionTo(SpeedMotionState.MOVING)
+            transitionTo(SpeedMotionState.MOVING, "manual pace change")
             callback.switchToContinuous()
         } else {
             lowSpeedCount = 0
             wakeCount = 0
             highSpeedCount = 0
             stopSlowingTimer()
-            transitionTo(SpeedMotionState.STATIONARY)
+            transitionTo(SpeedMotionState.STATIONARY, "manual pace change")
             switchToStationary()
         }
     }
@@ -229,7 +235,10 @@ class SpeedMotionManager(
             lowSpeedCount = 1
             highSpeedCount = 0
             slowingStartTimeMs = SystemClock.elapsedRealtime()
-            transitionTo(SpeedMotionState.SLOWING)
+            transitionTo(
+                SpeedMotionState.SLOWING,
+                "speed=${formatSpeed(speed)} < threshold=$speedMovingThreshold",
+            )
             startSlowingTimer()
         }
     }
@@ -246,7 +255,10 @@ class SpeedMotionManager(
                 TraceletLog.debug("SLOWING timer expired -> STATIONARY")
                 lowSpeedCount = 0
                 wakeCount = 0
-                transitionTo(SpeedMotionState.STATIONARY)
+                transitionTo(
+                    SpeedMotionState.STATIONARY,
+                    "SLOWING countdown of ${speedStationaryDelay}s expired",
+                )
                 switchToStationary()
             }
         }
@@ -292,7 +304,11 @@ class SpeedMotionManager(
             lowSpeedCount = 0
             highSpeedCount = 0
             stopSlowingTimer()
-            transitionTo(SpeedMotionState.MOVING)
+            transitionTo(
+                SpeedMotionState.MOVING,
+                "sustained speed=${formatSpeed(speed)} >= threshold=$speedMovingThreshold " +
+                    "for $SPEED_ABORT_FIX_COUNT fixes",
+            )
             return
         }
 
@@ -311,7 +327,10 @@ class SpeedMotionManager(
             lowSpeedCount = 0
             wakeCount = 0
             stopSlowingTimer()
-            transitionTo(SpeedMotionState.STATIONARY)
+            transitionTo(
+                SpeedMotionState.STATIONARY,
+                "speed=${formatSpeed(speed)}, elapsed=${elapsedMs}ms >= delay=${delayMs}ms",
+            )
             switchToStationary()
         }
     }
@@ -325,7 +344,11 @@ class SpeedMotionManager(
             if (wakeCount >= speedWakeConfirmCount) {
                 TraceletLog.debug("STATIONARY -> MOVING (wakeCount=$wakeCount >= confirm=$speedWakeConfirmCount)")
                 wakeCount = 0
-                transitionTo(SpeedMotionState.MOVING)
+                transitionTo(
+                    SpeedMotionState.MOVING,
+                    "woke on speed=${formatSpeed(speed)} >= threshold=$speedMovingThreshold " +
+                        "($speedWakeConfirmCount confirming fixes)",
+                )
                 callback.switchToContinuous()
             }
         } else {
@@ -342,7 +365,20 @@ class SpeedMotionManager(
     // State transition + persistence + event emission
     // =========================================================================
 
-    private fun transitionTo(newState: SpeedMotionState) {
+    /**
+     * Commits a state change: persists it, emits the event, and records it on
+     * the always-on lifecycle channel.
+     *
+     * #334: this machine decides whether a moving vehicle keeps continuous
+     * tracking, and at the shipped log levels (`info` for Flutter, `off` for a
+     * direct SDK consumer) its reasoning left no trace at all — a bug report
+     * showed the downgrade with nothing to say why. [reason] carries the speed
+     * the decision was made on, which is the whole story in the case that
+     * motivated it: a fabricated `speed=0.00` while the car was doing 10 m/s
+     * (#332). Transitions fire a handful of times per trip, not per fix, which
+     * is the bar [TraceletLogger.lifecycle] sets for the channel.
+     */
+    private fun transitionTo(newState: SpeedMotionState, reason: String) {
         val previousState = currentState
         currentState = newState
 
@@ -366,7 +402,7 @@ class SpeedMotionManager(
         )
         events.sendSpeedMotionChange(eventData)
 
-        TraceletLog.debug("State transition: ${previousState.name} -> ${newState.name}")
+        TraceletLog.lifecycle("speed-motion: ${previousState.name} -> ${newState.name} — $reason")
     }
 
     private fun formatSpeed(speed: Double): String = "%.2f m/s".format(speed)

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinatorTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/motion/SmartMotionCoordinatorTest.kt
@@ -50,6 +50,13 @@ class SmartMotionCoordinatorTest {
         coordinator.syncCurrentMode()
     }
 
+    /** Makes [LocationEngine] report a resolved effective speed of [speed] m/s. */
+    private fun resolveSpeed(speed: Double) {
+        org.mockito.Mockito.`when`(locationEngine.getLastLocation())
+            .thenReturn(android.location.Location("test"))
+        org.mockito.Mockito.`when`(locationEngine.lastEffectiveSpeed).thenReturn(speed)
+    }
+
     @Test
     fun `initial state is Accel=false, Speed=true`() {
         assertFalse(coordinator.isAccelMoving)
@@ -94,7 +101,12 @@ class SmartMotionCoordinatorTest {
         state.trackingMode = TrackingMode.CONTINUOUS
         state.isMoving = true
         coordinator.syncCurrentMode()
-        
+
+        // #333: "GPS confirms still" has to mean GPS actually resolved a
+        // near-zero speed. This used to pass with no fix at all, because an
+        // absent reading reported 0.0 and was accepted as confirmation.
+        resolveSpeed(0.0)
+
         // Accel is true (hand tremor), Speed becomes false (GPS confirms still)
         coordinator.onAccelStateChange(true)
         coordinator.onSpeedStateChange(false)
@@ -173,8 +185,9 @@ class SmartMotionCoordinatorAccelSeedTest {
         // trusts the accelerometer instead of overriding it to false. That leaves the
         // accelerometer as the last input to settle — the exact case that was inert
         // when the flag started at false.
-        val walking = android.location.Location("test").apply { speed = 0.5f }
-        org.mockito.Mockito.`when`(locationEngine.getLastLocation()).thenReturn(walking)
+        // #333: the resolved speed is what the coordinator reads now, not the raw
+        // `Location.speed` — that reports 0.0 when the fix carries no speed at all.
+        resolveSpeed(0.5)
 
         // What start() now does when it starts in MOVING.
         coordinator.onAccelStateChange(true)
@@ -205,5 +218,60 @@ class SmartMotionCoordinatorAccelSeedTest {
 
         assertEquals(uniffi.tracelet_core.CoordinatorAction.NONE, action)
         assertTrue(state.isMoving)
+    }
+
+    // =========================================================================
+    // #333: an unresolved speed is "unknown", not "parked"
+    // =========================================================================
+
+    /** Makes [LocationEngine] report a resolved effective speed of [speed] m/s. */
+    private fun resolveSpeed(speed: Double) {
+        org.mockito.Mockito.`when`(locationEngine.getLastLocation())
+            .thenReturn(android.location.Location("test"))
+        org.mockito.Mockito.`when`(locationEngine.lastEffectiveSpeed).thenReturn(speed)
+    }
+
+    @Test
+    fun `an unresolved speed does not overrule a moving accelerometer`() {
+        // No fix has been accepted, so there is no speed to judge by. The old code
+        // read the raw `Location.speed`, got the 0.0 an absent reading reports, and
+        // treated "we don't know" as proof the device was parked — overriding the
+        // one input that was reporting motion.
+        coordinator.onAccelStateChange(true)
+        assertTrue(coordinator.isAccelMoving)
+
+        coordinator.onSpeedStateChange(false)
+
+        assertTrue(
+            coordinator.isAccelMoving,
+            "missing data is not evidence of standing still",
+        )
+        assertEquals(TrackingMode.CONTINUOUS, state.trackingMode)
+        assertTrue(state.isMoving)
+    }
+
+    @Test
+    fun `a vehicle speed does not overrule a moving accelerometer`() {
+        resolveSpeed(10.0)
+        coordinator.onAccelStateChange(true)
+
+        coordinator.onSpeedStateChange(false)
+
+        assertTrue(coordinator.isAccelMoving)
+        assertEquals(TrackingMode.CONTINUOUS, state.trackingMode)
+        assertTrue(state.isMoving)
+    }
+
+    @Test
+    fun `a genuinely near-zero speed still overrules hand tremor`() {
+        // The case the override exists for: the device is physically still and the
+        // accelerometer is reading tremor. That must keep working.
+        resolveSpeed(0.05)
+        coordinator.onAccelStateChange(true)
+
+        coordinator.onSpeedStateChange(false)
+
+        assertFalse(coordinator.isAccelMoving)
+        assertFalse(state.isMoving)
     }
 }

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManagerTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManagerTest.kt
@@ -291,6 +291,61 @@ class SpeedMotionManagerTest {
     }
 
     // =========================================================================
+    // A moving vehicle stays MOVING (#332)
+    // =========================================================================
+
+    /**
+     * The failure this guards: `LocationProcessorResult::filtered` reported a
+     * hardcoded `effective_speed = 0.0`, and [LocationEngine] feeds *every* fix
+     * — accepted or not — into this machine. At a 30 m vehicle distance filter
+     * and ~1 Hz fixes, most of a 10 m/s drive is rejected, so the machine saw a
+     * stream of zeros on a motorway and ran its SLOWING countdown to completion.
+     * Given truthful speeds it must never leave MOVING.
+     */
+    @Test
+    fun `sustained vehicle speed never leaves MOVING`() {
+        configure(stationaryDelaySeconds = 0)
+
+        repeat(30) { manager.onLocation(10.0) }
+
+        assertEquals("moving", manager.getCurrentState())
+        assertTrue(events.speedMotionEvents.isEmpty(), "a steady drive is not a state change")
+        assertFalse(callback.switchedToStationaryPeriodic)
+    }
+
+    /**
+     * The shape the bug took on the wire: real fixes at vehicle speed
+     * interleaved with the fabricated zeros the rejected ones contributed. Two
+     * filtered fixes per accepted one is the ratio a 30 m filter produces at
+     * 10 m/s. Each zero reset the high-speed streak, so the abort counter never
+     * reached `SPEED_ABORT_FIX_COUNT` and the countdown expired mid-drive.
+     *
+     * Kept as a characterisation of the *input* contract: if anything ever feeds
+     * this machine a zero per rejected fix again, this fails.
+     */
+    @Test
+    fun `interleaved fabricated zeros would strand the machine in SLOWING`() {
+        configure(stationaryDelaySeconds = 600)
+
+        manager.onLocation(10.0)
+        manager.onLocation(0.0) // the first fabricated zero: MOVING -> SLOWING
+        assertEquals("slowing", manager.getCurrentState())
+
+        repeat(10) {
+            manager.onLocation(10.0) // accepted fix, genuinely driving
+            manager.onLocation(0.0) // rejected fix, fabricated
+            manager.onLocation(0.0) // rejected fix, fabricated
+        }
+
+        assertEquals(
+            "slowing",
+            manager.getCurrentState(),
+            "10 fixes at 10 m/s could not rescue the machine — which is why the " +
+                "fabricated zeros had to stop at the source (#332)",
+        )
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManagerTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/motion/SpeedMotionManagerTest.kt
@@ -346,6 +346,88 @@ class SpeedMotionManagerTest {
     }
 
     // =========================================================================
+    // A no-op transition is not a transition (#337)
+    // =========================================================================
+
+    /**
+     * Found by the #335 verification card on a device: `changePace(false)` on a
+     * machine that was already STATIONARY emitted a `stationary → stationary`
+     * event. iOS's `commitTransition` has always guarded this; Android had no
+     * equivalent, so the same call behaved differently on the two platforms.
+     */
+    @Test
+    fun `a changePace that changes nothing emits no event`() {
+        configure()
+
+        manager.onManualPaceChange(false)
+        assertEquals("stationary", manager.getCurrentState())
+        val afterFirst = events.speedMotionEvents.size
+
+        manager.onManualPaceChange(false)
+
+        assertEquals("stationary", manager.getCurrentState())
+        assertEquals(
+            afterFirst,
+            events.speedMotionEvents.size,
+            "the second call agreed with the current state, so there was no edge to report",
+        )
+    }
+
+    /** Every emitted event must name a real edge. */
+    @Test
+    fun `no emitted event reports a transition to the state it came from`() {
+        configure()
+
+        manager.onManualPaceChange(false)
+        manager.onManualPaceChange(false)
+        manager.onManualPaceChange(true)
+        manager.onManualPaceChange(true)
+
+        val degenerate = events.speedMotionEvents.filter {
+            it["state"] == it["previousState"]
+        }
+        assertTrue(
+            degenerate.isEmpty(),
+            "events reporting previousState == state: $degenerate",
+        )
+    }
+
+    /**
+     * The counterpart, and the reason the two rows above are not vacuous: a
+     * guard that suppressed everything would satisfy them both.
+     */
+    @Test
+    fun `a changePace that does change the state still emits`() {
+        configure()
+
+        manager.onManualPaceChange(false)
+        val stops = events.speedMotionEvents.size
+        manager.onManualPaceChange(true)
+
+        assertEquals("moving", manager.getCurrentState())
+        assertEquals(stops + 1, events.speedMotionEvents.size)
+    }
+
+    /**
+     * `isMoving` is re-synced inside `transitionTo` and is written directly by
+     * `SmartMotionCoordinator` too, so the no-op guard must not skip it.
+     */
+    @Test
+    fun `a no-op transition still re-asserts isMoving`() {
+        configure()
+
+        manager.onManualPaceChange(false)
+        assertFalse(state.isMoving)
+
+        // Something else moved the flag out from under the machine.
+        state.isMoving = true
+
+        manager.onManualPaceChange(false)
+
+        assertFalse(state.isMoving, "the re-assertion must survive the no-op guard")
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 

--- a/sdk/android/tracelet-sync-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/sync/NativeSyncProvider.kt
+++ b/sdk/android/tracelet-sync-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/sync/NativeSyncProvider.kt
@@ -24,6 +24,41 @@ class NativeSyncProvider(private val sdk: TraceletSdk) : LocationDataSink, Trace
     private var syncJob: kotlinx.coroutines.Job? = null
     private val DEBOUNCE_MS = 10_000L
 
+    @Volatile
+    private var lastSyncBodySource: String? = null
+
+    /**
+     * Records which body the sync is posting — but only when the answer
+     * changes (#340).
+     *
+     * The per-sync lines around the call sites are `debug`, so on a release
+     * build at the shipped log levels they are dropped and a device posting the
+     * default payload when the app registered a custom builder leaves no trace
+     * of it. The lifecycle channel is never level-gated, which is exactly what
+     * a release build needs.
+     *
+     * It cannot simply be written per sync, though: syncs fire every few
+     * seconds while tracking, and [TraceletLogger.lifecycle] is explicitly
+     * reserved for events that fire a handful of times per session because its
+     * rows share a bounded cap with the killed-state trail. One entry per sync
+     * would evict the trail it exists to preserve.
+     *
+     * Reporting only transitions costs a handful of rows per session and still
+     * answers the whole question: which body is this app sending, and did that
+     * ever change mid-session?
+     */
+    private fun reportSyncBodySource(source: String, detail: String) {
+        val changed = synchronized(this) {
+            if (lastSyncBodySource == source) {
+                false
+            } else {
+                lastSyncBodySource = source
+                true
+            }
+        }
+        if (changed) sdk.logger.lifecycle("sync-body: $detail")
+    }
+
     override fun insertLocation(location: Map<String, Any?>) {
         val delayMs = sdk.rustEngineState?.getConfig()?.http?.autoSyncDelay?.toLong() ?: 10_000L
         if (syncJob?.isActive == true) return
@@ -111,7 +146,20 @@ class NativeSyncProvider(private val sdk: TraceletSdk) : LocationDataSink, Trace
                     return
                 }
 
+                if (customBody == null || customBody == NO_SYNC_BODY_BUILDER_SENTINEL) {
+                    reportSyncBodySource(
+                        if (interceptor == null) "no-interceptor" else "no-builder",
+                        if (interceptor == null) {
+                            "posting the DEFAULT payload — no dartSyncInterceptor attached to the SDK"
+                        } else {
+                            "posting the DEFAULT payload — no custom sync body builder reached " +
+                                "native (setSyncBodyBuilder registered in Dart?)"
+                        },
+                    )
+                }
+
                 if (customBody != null && customBody != NO_SYNC_BODY_BUILDER_SENTINEL) {
+                    reportSyncBodySource("custom", "posting the app's custom sync body")
                     val result = executeFallbackHttpSync(coreHttp, customBody, interceptor)
                     if (result.success) {
                         records.lastOrNull()?.id?.let { lastId ->

--- a/sdk/ios/Package.swift
+++ b/sdk/ios/Package.swift
@@ -70,6 +70,12 @@ let package = Package(
                 // still be delivered fixes (distanceFilter=None) and crossings
                 // must evaluate on the raw stream, before the persistence filter.
                 "LocationEngineGeofenceStarvationTests.swift",
+                // #332/#335: the GPS-speed motion machine decides whether a
+                // moving vehicle keeps continuous tracking. Its suite was
+                // written but never wired up here, so nothing caught it emitting
+                // every transition twice, and nothing pinned the behaviour that
+                // a drive at vehicle speed must stay MOVING.
+                "SpeedMotionManagerTests.swift",
             ]
         ),
     ]

--- a/sdk/ios/Sources/TraceletSDK/SmartMotionCoordinator.swift
+++ b/sdk/ios/Sources/TraceletSDK/SmartMotionCoordinator.swift
@@ -53,17 +53,49 @@ public class TraceletSmartMotionCoordinator {
         return action
     }
     
+    /// GPS speed at or below which a *moving* accelerometer is read as hand
+    /// tremor on a physically still device rather than as real motion.
+    private static let tremorSpeedThreshold: Double = 0.15
+
+    /// The last speed this process actually resolved, or `nil` if it has not
+    /// resolved one yet.
+    ///
+    /// `lastEffectiveSpeed` and `lastLocation` are written together on every
+    /// accepted fix, so a nil location is exactly "no fix has been accepted in
+    /// this process" — which is *unknown*, not zero.
+    private var resolvedSpeed: Double? {
+        guard let engine = sdk?.locationEngine, engine.getLastLocation() != nil else { return nil }
+        return engine.lastEffectiveSpeed
+    }
+
     public func onSpeedStateChange(isMoving: Bool) {
         if !isMoving && isAccelMoving {
-            // Speed SM declared stationary but accel reports moving.
-            // Only override accel when GPS speed is truly near zero (hand tremor).
-            // If speed suggests walking (> 0.15 m/s), trust the accelerometer.
-            let lastSpeed = sdk?.locationEngine.getLastLocation()?.speed ?? 0
-            if lastSpeed <= 0.15 {
-                TraceletLog.debug(String(format: "[Tracelet] SmartMotionCoordinator: GPS speed near zero (%.2f m/s) — overriding accel to false (hand tremor).", lastSpeed))
+            // The speed machine says stationary and the accelerometer disagrees.
+            // Two situations look like this:
+            //   a) the device is physically still and the accelerometer is
+            //      picking up hand tremor — GPS speed is genuinely ~0;
+            //   b) the user is walking slowly, below the speed threshold — the
+            //      accelerometer is the one telling the truth.
+            // Only (a) justifies overruling a positive motion signal.
+            //
+            // #333: this used to read `getLastLocation()?.speed`, the raw
+            // CLLocation value, which is **-1** on a fix that carries no speed —
+            // and -1 sails through a `<= 0.15` test. An unknown speed was
+            // therefore treated as proof the device was parked, and the
+            // accelerometer got overridden on missing data. `lastEffectiveSpeed`
+            // is the resolved value (documented on its declaration as existing
+            // precisely because the cached CLLocation.speed "may be stale, 0, or
+            // -1"), and no resolved speed at all now leaves the accelerometer
+            // standing rather than silently siding against it.
+            switch resolvedSpeed {
+            case .none:
+                TraceletLog.debug("[Tracelet] SmartMotionCoordinator: no GPS speed resolved yet — trusting accel, staying continuous.")
+            case .some(let speed) where speed <= TraceletSmartMotionCoordinator.tremorSpeedThreshold:
+                TraceletLog.debug(String(format: "[Tracelet] SmartMotionCoordinator: GPS speed near zero (%.2f m/s) — overriding accel to false (hand tremor).", speed))
                 _ = coreCoordinator?.onAccelStateChange(isMoving: false)
-            } else {
-                TraceletLog.debug(String(format: "[Tracelet] SmartMotionCoordinator: GPS speed %.2f m/s suggests walking — trusting accel, staying continuous.", lastSpeed))
+            case .some(let speed):
+                TraceletLog.debug(String(format: "[Tracelet] SmartMotionCoordinator: GPS speed %.2f m/s is above the %.2f m/s tremor threshold — trusting accel, staying continuous.",
+                                         speed, TraceletSmartMotionCoordinator.tremorSpeedThreshold))
             }
         }
         guard let action = coreCoordinator?.onSpeedStateChange(isMoving: isMoving) else { return }
@@ -83,25 +115,40 @@ public class TraceletSmartMotionCoordinator {
     
     private func handleAction(_ action: CoordinatorAction) {
         guard let sdk = sdk else { return }
-        
+
         switch action {
         case .switchToContinuous:
-            TraceletLog.debug("[Tracelet] SmartMotionCoordinator: Switching to CONTINUOUS")
+            recordModeSwitch("CONTINUOUS")
             sdk.switchToContinuousForce()
             sdk.motionDetector.onManualPaceChange(true)
-            
+
         case .switchToStationaryGeofences:
-            TraceletLog.debug("[Tracelet] SmartMotionCoordinator: Switching to STATIONARY_GEOFENCES")
+            recordModeSwitch("STATIONARY_GEOFENCES")
             sdk.switchToStationaryGeofencesForce()
             sdk.motionDetector.onManualPaceChange(false)
-            
+
         case .switchToStationaryPeriodic:
-            TraceletLog.debug("[Tracelet] SmartMotionCoordinator: Switching to STATIONARY_PERIODIC")
+            recordModeSwitch("STATIONARY_PERIODIC")
             sdk.switchToStationaryPeriodicForce()
             sdk.motionDetector.onManualPaceChange(false)
-            
+
         case .none:
             break
         }
+    }
+
+    /// Records a tracking-mode switch on the always-on lifecycle channel,
+    /// naming both inputs of the OR (#334).
+    ///
+    /// The coordinator is a logical OR of the accelerometer and the GPS-speed
+    /// machine, so a downgrade means *both* said stationary. Which one flipped
+    /// last — and what the other was doing at the time — is the first question
+    /// asked of any "it stopped tracking while I was moving" report, and at the
+    /// shipped log levels the answer was not recorded anywhere.
+    private func recordModeSwitch(_ mode: String) {
+        let speedText = resolvedSpeed.map { String(format: "%.2f", $0) } ?? "unknown"
+        TraceletLog.lifecycle(
+            "smart-motion: switching to \(mode) — accelMoving=\(isAccelMoving) "
+                + "speedMoving=\(isSpeedMoving) lastSpeed=\(speedText)m/s")
     }
 }

--- a/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
+++ b/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
@@ -1221,10 +1221,19 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
         // MOVING → SLOWING → STATIONARY. Without this, a stationary device
         // whose locations are filtered (e.g. same lat/lng, no distance change)
         // will never transition out of MOVING state.
+        //
+        // `result.effectiveSpeed` is the speed the processor resolved for this
+        // fix whether or not it accepted it — it used to be hardcoded to 0 on
+        // every rejection, which fed the machine a fabricated "stopped" for
+        // most of every drive (#332).
         speedSink?(result.effectiveSpeed)
 
         if !result.accepted {
-            TraceletLog.debug(String(format: "[Tracelet] Location filtered by Rust processor: %@", result.reason ?? "unknown"))
+            // #334: the speed handed to the motion machine belongs on this line.
+            // Without it, a rejected fix's contribution to a stationary decision
+            // can only be inferred by cross-reading the [SpeedMotion] entries.
+            TraceletLog.debug(String(format: "[Tracelet] Location filtered by Rust processor: %@ (speed=%.2f m/s fed to speed motion)",
+                                     result.reason ?? "unknown", result.effectiveSpeed))
             if result.odometerDelta > 0 {
                 stateManager.addOdometer(distance: result.odometerDelta)
             }

--- a/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
+++ b/sdk/ios/Sources/TraceletSDK/location/LocationEngine.swift
@@ -1151,6 +1151,29 @@ public final class LocationEngine: NSObject, CLLocationManagerDelegate {
             distance = location.distance(from: last)
             let timeDelta = location.timestamp.timeIntervalSince(last.timestamp)
             computedSpeed = (distance > 0 && timeDelta > 0) ? distance / timeDelta : 0.0
+
+            // A derived speed is only as good as its time base, and `timeDelta > 0`
+            // is satisfied by one millisecond. A session start where CoreLocation
+            // flushes a cached fix alongside a fresh one divides a real distance by
+            // an almost-zero interval, which produced 10073 m/s from a phone on a
+            // desk — enough to wake the speed motion machine out of STATIONARY,
+            // since speedWakeConfirmCount is 1 by default (#342).
+            //
+            // `maxImpliedSpeed` already encodes what counts as credible movement;
+            // above it this is an artefact, not a measurement. Report *no* speed
+            // rather than a fabricated one. That is not #332 in reverse: this
+            // branch is only reached when the platform supplied no speed at all,
+            // so 0 is the pre-existing meaning of "unknown" rather than a value
+            // invented in place of a real reading. A genuinely moving device has a
+            // Doppler speed and never gets here.
+            let maxImplied = Double(configManager.getMaxImpliedSpeed())
+            if maxImplied > 0 && computedSpeed > maxImplied {
+                TraceletLog.debug(String(
+                    format: "[Tracelet] Discarding implausible derived speed %.2f m/s "
+                        + "(%.2fm over %.3fs, max %.0f m/s) — reporting no speed",
+                    computedSpeed, distance, timeDelta, maxImplied))
+                computedSpeed = 0.0
+            }
         } else if isPeriodicTracking {
             // Fallback: when the app was killed and relaunched by
             // BGAppRefreshTask, lastLocation is nil. Use persisted periodic

--- a/sdk/ios/Sources/TraceletSDK/motion/SpeedMotionManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/motion/SpeedMotionManager.swift
@@ -39,6 +39,16 @@ public final class SpeedMotionManager {
         case moving = 0
         case slowing = 1
         case stationary = 2
+
+        /// Readable name for logs. The lifecycle trace is read by humans in bug
+        /// reports, where a bare `rawValue: 2` means nothing without the source.
+        var name: String {
+            switch self {
+            case .moving: return "MOVING"
+            case .slowing: return "SLOWING"
+            case .stationary: return "STATIONARY"
+            }
+        }
     }
 
     public private(set) var state: SpeedMotionState = .moving
@@ -151,9 +161,14 @@ public final class SpeedMotionManager {
             stateManager.isMoving = true
             TraceletLog.debug("[SpeedMotion] start() — forced to MOVING state")
         } else {
-            TraceletLog.debug(String(format: "[SpeedMotion] start: restored state=%d, lowSpeedCount=%d, wakeCount=%d",
-                  state.rawValue, lowSpeedCount, wakeCount))
-            
+            // #334: a relaunched process inherits this state, and inheriting
+            // STATIONARY is indistinguishable from "tracking silently stopped"
+            // unless the trace says so. Once per session, so it belongs on the
+            // always-on channel.
+            TraceletLog.lifecycle(String(
+                format: "speed-motion: restored %@ (lowSpeedCount=%d, wakeCount=%d)",
+                state.name, lowSpeedCount, wakeCount))
+
             if state == .stationary {
                 switchToStationary()
             } else if state == .slowing {
@@ -175,33 +190,17 @@ public final class SpeedMotionManager {
     public func onManualPaceChange(isMoving: Bool) {
         guard isRunning else { return }
         TraceletLog.debug("[SpeedMotion] onManualPaceChange(isMoving=\(isMoving))")
+        lowSpeedCount = 0
+        wakeCount = 0
+        highSpeedCount = 0
+        stopSlowingTimer()
+        let previousState = state
+        state = isMoving ? .moving : .stationary
+        if previousState == .slowing { delegate?.speedMotionDidCancelSlowing() }
+        commitTransition(from: previousState, because: "manual pace change")
         if isMoving {
-            lowSpeedCount = 0
-            wakeCount = 0
-            highSpeedCount = 0
-            stopSlowingTimer()
-            let previousState = state
-            state = .moving
-            if previousState == .slowing { delegate?.speedMotionDidCancelSlowing() }
-            
-            if state != previousState {
-                persistState()
-                emitEvent(previous: previousState, current: state)
-            }
             delegate?.switchToContinuous()
         } else {
-            lowSpeedCount = 0
-            wakeCount = 0
-            highSpeedCount = 0
-            stopSlowingTimer()
-            let previousState = state
-            state = .stationary
-            if previousState == .slowing { delegate?.speedMotionDidCancelSlowing() }
-            
-            if state != previousState {
-                persistState()
-                emitEvent(previous: previousState, current: state)
-            }
             switchToStationary()
         }
     }
@@ -217,8 +216,10 @@ public final class SpeedMotionManager {
 
         let now = ProcessInfo.processInfo.systemUptime
         let effectiveSpeed = max(speed, 0)
-        let previousState = state
 
+        // Each handler commits its own transition through `commitTransition`.
+        // A second, outer commit used to run here as well, which emitted most
+        // transitions twice (#335).
         switch state {
         case .moving:
             handleMoving(speed: effectiveSpeed, now: now)
@@ -229,12 +230,31 @@ public final class SpeedMotionManager {
         }
 
         lastFixTime = now
+    }
 
-        // Persist and emit if state changed
-        if state != previousState {
-            persistState()
-            emitEvent(previous: previousState, current: state)
-        }
+    /// Commits a state change that has already been written to ``state``:
+    /// persists it, emits exactly one event, and records it on the always-on
+    /// lifecycle channel. No-op when the state did not actually change.
+    ///
+    /// Every edge used to hand-roll this sequence and ``onLocation`` re-ran it
+    /// afterwards, so `MOVING -> SLOWING`, `SLOWING -> MOVING` and
+    /// `SLOWING -> STATIONARY` each emitted twice while `STATIONARY -> MOVING`
+    /// emitted once (#335). This mirrors Android's `transitionTo`.
+    ///
+    /// The lifecycle entry exists because this machine decides whether a moving
+    /// vehicle keeps continuous tracking, and at the shipped log levels its
+    /// reasoning left no trace at all — a bug report showed the downgrade with
+    /// nothing to say why (#334). `reason` carries the speed the decision was
+    /// made on, which is the whole story in the case that motivated it: a
+    /// fabricated `speed=0.00` while the car was doing 10 m/s (#332). These
+    /// fire a handful of times per trip, not per fix, which is the bar
+    /// ``TraceletLogger/lifecycle(_:)`` sets for the channel.
+    private func commitTransition(from previousState: SpeedMotionState, because reason: String) {
+        guard state != previousState else { return }
+        persistState()
+        emitEvent(previous: previousState, current: state)
+        TraceletLog.lifecycle(
+            "speed-motion: \(previousState.name) -> \(state.name) — \(reason)")
     }
 
     // MARK: - State Handlers
@@ -249,16 +269,12 @@ public final class SpeedMotionManager {
             wakeCount = 0
             highSpeedCount = 0
             slowingStartTime = now
-            TraceletLog.debug(String(format: "[SpeedMotion] MOVING -> SLOWING (speed=%.2f < threshold=%.2f)",
-                  speed, speedMovingThreshold))
             startSlowingTimer()
-            
+
             delegate?.speedMotionDidStartSlowing()
-            
-            if state != previousState {
-                persistState()
-                emitEvent(previous: previousState, current: state)
-            }
+
+            commitTransition(from: previousState, because: String(
+                format: "speed=%.2f < threshold=%.2f", speed, speedMovingThreshold))
         }
     }
 
@@ -271,18 +287,15 @@ public final class SpeedMotionManager {
             let workItem = DispatchWorkItem { [weak self] in
                 guard let self = self else { return }
                 if self.state == .slowing {
-                    TraceletLog.debug("[SpeedMotion] SLOWING timer expired -> STATIONARY")
                     let previousState = self.state
                     self.state = .stationary
                     self.wakeCount = 0
                     self.lowSpeedCount = 0
                     self.delegate?.speedMotionDidCancelSlowing()
                     self.switchToStationary()
-                    
-                    if self.state != previousState {
-                        self.persistState()
-                        self.emitEvent(previous: previousState, current: self.state)
-                    }
+                    self.commitTransition(
+                        from: previousState,
+                        because: "SLOWING countdown of \(self.speedStationaryDelay)s expired")
                 }
             }
             self.slowingTimerWorkItem = workItem
@@ -319,18 +332,16 @@ public final class SpeedMotionManager {
             // Back to moving
             let previousState = state
             state = .moving
+            let abortCount = SpeedMotionManager.speedAbortFixCount
             lowSpeedCount = 0
             highSpeedCount = 0
             stopSlowingTimer()
-            TraceletLog.debug(String(format: "[SpeedMotion] SLOWING -> MOVING (sustained speed=%.2f >= threshold=%.2f for %d fixes)",
-                  speed, speedMovingThreshold, SpeedMotionManager.speedAbortFixCount))
 
             delegate?.speedMotionDidCancelSlowing()
 
-            if state != previousState {
-                persistState()
-                emitEvent(previous: previousState, current: state)
-            }
+            commitTransition(from: previousState, because: String(
+                format: "sustained speed=%.2f >= threshold=%.2f for %d fixes",
+                speed, speedMovingThreshold, abortCount))
             return
         }
 
@@ -343,16 +354,13 @@ public final class SpeedMotionManager {
             state = .stationary
             wakeCount = 0
             stopSlowingTimer()
-            TraceletLog.debug(String(format: "[SpeedMotion] SLOWING -> STATIONARY (elapsed=%.0fs >= delay=%ds, lowCount=%d)",
-                  elapsed, speedStationaryDelay, lowSpeedCount))
 
             delegate?.speedMotionDidCancelSlowing()
             switchToStationary()
-            
-            if state != previousState {
-                persistState()
-                emitEvent(previous: previousState, current: state)
-            }
+
+            commitTransition(from: previousState, because: String(
+                format: "speed=%.2f, elapsed=%.0fs >= delay=%ds, lowCount=%d",
+                speed, elapsed, speedStationaryDelay, lowSpeedCount))
         }
     }
 
@@ -362,11 +370,15 @@ public final class SpeedMotionManager {
             TraceletLog.debug(String(format: "[SpeedMotion] STATIONARY: wake fix (speed=%.2f, wakeCount=%d/%d)",
                   speed, wakeCount, speedWakeConfirmCount))
             if wakeCount >= speedWakeConfirmCount {
+                let previousState = state
+                let confirmCount = speedWakeConfirmCount
                 state = .moving
                 lowSpeedCount = 0
                 wakeCount = 0
-                TraceletLog.debug("[SpeedMotion] STATIONARY -> MOVING (wakeConfirm reached)")
                 delegate?.switchToContinuous()
+                commitTransition(from: previousState, because: String(
+                    format: "woke on speed=%.2f >= threshold=%.2f (%d confirming fixes)",
+                    speed, speedMovingThreshold, confirmCount))
             }
         } else {
             // Reset wake count on low-speed fix

--- a/sdk/ios/Tests/TraceletSDKTests/SpeedMotionManagerTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/SpeedMotionManagerTests.swift
@@ -308,6 +308,69 @@ final class SpeedMotionManagerTests: XCTestCase {
         XCTAssertEqual(delegate.speedMotionEvents.last?["state"], "0")
     }
 
+    // MARK: - A no-op transition is not a transition (#337)
+
+    /// Android emitted a `stationary → stationary` event for a `changePace(false)`
+    /// on an already-stationary machine, because its `transitionTo` had no
+    /// equivalent of `commitTransition`'s guard. iOS was correct; this pins it so
+    /// the platforms cannot drift apart again.
+    func testChangePaceThatChangesNothingEmitsNoEvent() {
+        makeManager()
+
+        manager.onManualPaceChange(isMoving: false)
+        XCTAssertEqual(manager.state, .stationary)
+        let afterFirst = delegate.speedMotionEvents.count
+
+        manager.onManualPaceChange(isMoving: false)
+
+        XCTAssertEqual(manager.state, .stationary)
+        XCTAssertEqual(
+            delegate.speedMotionEvents.count, afterFirst,
+            "the second call agreed with the current state, so there was no edge to report")
+    }
+
+    func testNoEmittedEventReportsATransitionToTheStateItCameFrom() {
+        makeManager()
+
+        manager.onManualPaceChange(isMoving: false)
+        manager.onManualPaceChange(isMoving: false)
+        manager.onManualPaceChange(isMoving: true)
+        manager.onManualPaceChange(isMoving: true)
+
+        let degenerate = delegate.speedMotionEvents.filter { $0["state"] == $0["previousState"] }
+        XCTAssertTrue(
+            degenerate.isEmpty,
+            "events reporting previousState == state: \(degenerate)")
+    }
+
+    /// The counterpart, and the reason the two above are not vacuous: a guard
+    /// that suppressed everything would satisfy them both.
+    func testChangePaceThatDoesChangeTheStateStillEmits() {
+        makeManager()
+
+        manager.onManualPaceChange(isMoving: false)
+        let stops = delegate.speedMotionEvents.count
+        manager.onManualPaceChange(isMoving: true)
+
+        XCTAssertEqual(manager.state, .moving)
+        XCTAssertEqual(delegate.speedMotionEvents.count, stops + 1)
+    }
+
+    /// A no-op still re-asserts the tracking mode: an explicit `changePace()`
+    /// should re-issue the switch even when the state machine already agreed.
+    func testNoOpChangePaceStillReAssertsTheTrackingMode() {
+        makeManager()
+
+        manager.onManualPaceChange(isMoving: false)
+        delegate.switchedToStationaryPeriodic = false
+
+        manager.onManualPaceChange(isMoving: false)
+
+        XCTAssertTrue(
+            delegate.switchedToStationaryPeriodic,
+            "suppressing the event must not suppress the mode switch")
+    }
+
     // MARK: - Recording doubles
 
     private final class RecordingDelegate: SpeedMotionDelegate {

--- a/sdk/ios/Tests/TraceletSDKTests/SpeedMotionManagerTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/SpeedMotionManagerTests.swift
@@ -221,17 +221,108 @@ final class SpeedMotionManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .slowing)
     }
 
+    // MARK: - A moving vehicle stays MOVING (#332)
+
+    /// The failure this guards: `LocationProcessorResult::filtered` reported a
+    /// hardcoded `effective_speed: 0.0`, and both hosts feed *every* fix —
+    /// accepted or not — into this machine. At a 30 m vehicle distance filter
+    /// and ~1 Hz fixes, most of a 10 m/s drive is rejected, so the machine saw
+    /// a stream of zeros on a motorway and ran its SLOWING countdown to
+    /// completion. Given truthful speeds it must never leave MOVING.
+    func testSustainedVehicleSpeedNeverLeavesMoving() {
+        makeManager(stationaryDelaySeconds: 0)
+
+        for _ in 0..<30 {
+            manager.onLocation(speed: 10.0)
+        }
+
+        XCTAssertEqual(manager.state, .moving)
+        XCTAssertTrue(delegate.speedMotionEvents.isEmpty, "a steady drive is not a state change")
+        XCTAssertFalse(delegate.switchedToStationaryPeriodic)
+    }
+
+    /// The shape the bug actually took on the wire: real fixes at vehicle speed
+    /// interleaved with the fabricated zeros the rejected ones contributed. Two
+    /// filtered fixes per accepted one is the ratio a 30 m filter produces at
+    /// 10 m/s. Each zero reset the high-speed streak, so the abort counter never
+    /// reached `speedAbortFixCount` and the countdown expired mid-drive.
+    ///
+    /// Kept as a characterisation of the *input* contract: if anything ever
+    /// feeds this machine a zero per rejected fix again, this fails.
+    func testInterleavedFabricatedZerosWouldStrandTheMachineInSlowing() {
+        makeManager(stationaryDelaySeconds: 60)
+
+        manager.onLocation(speed: 10.0)
+        manager.onLocation(speed: 0.0)   // the first fabricated zero: MOVING -> SLOWING
+        XCTAssertEqual(manager.state, .slowing)
+
+        for _ in 0..<10 {
+            manager.onLocation(speed: 10.0)  // accepted fix, genuinely driving
+            manager.onLocation(speed: 0.0)   // rejected fix, fabricated
+            manager.onLocation(speed: 0.0)   // rejected fix, fabricated
+        }
+
+        XCTAssertEqual(
+            manager.state, .slowing,
+            "10 fixes at 10 m/s could not rescue the machine — which is why the "
+                + "fabricated zeros had to stop at the source (#332)")
+    }
+
+    // MARK: - One event per transition (#335)
+
+    /// Every edge used to hand-roll persist+emit and `onLocation` re-ran it
+    /// afterwards, so most transitions emitted twice while `STATIONARY -> MOVING`
+    /// emitted once.
+    func testEachTransitionEmitsExactlyOneEvent() {
+        makeManager(stationaryDelaySeconds: 0)
+
+        manager.onLocation(speed: 5.0)
+        XCTAssertEqual(delegate.speedMotionEvents.count, 0, "no transition, no event")
+
+        manager.onLocation(speed: 0.1)   // MOVING -> SLOWING
+        XCTAssertEqual(delegate.speedMotionEvents.count, 1)
+
+        manager.onLocation(speed: 0.1)   // SLOWING -> STATIONARY
+        XCTAssertEqual(delegate.speedMotionEvents.count, 2)
+
+        manager.onLocation(speed: 5.0)   // STATIONARY -> MOVING
+        XCTAssertEqual(delegate.speedMotionEvents.count, 3)
+
+        XCTAssertEqual(
+            delegate.speedMotionEvents.map { $0["previousState"]! + "->" + $0["state"]! },
+            ["0->1", "1->2", "2->0"])
+    }
+
+    func testSlowingBackToMovingEmitsExactlyOneEvent() {
+        makeManager(stationaryDelaySeconds: 60)
+
+        manager.onLocation(speed: 5.0)
+        manager.onLocation(speed: 0.5)   // MOVING -> SLOWING
+        for _ in 0..<SpeedMotionManager.speedAbortFixCount {
+            manager.onLocation(speed: 3.0)
+        }
+
+        XCTAssertEqual(manager.state, .moving)
+        XCTAssertEqual(delegate.speedMotionEvents.count, 2, "one in, one out")
+        XCTAssertEqual(delegate.speedMotionEvents.last?["previousState"], "1")
+        XCTAssertEqual(delegate.speedMotionEvents.last?["state"], "0")
+    }
+
     // MARK: - Recording doubles
 
     private final class RecordingDelegate: SpeedMotionDelegate {
         var switchedToContinuous = false
         var switchedToStationaryPeriodic = false
         var switchedToStationaryGeofences = false
+        var slowingStartedCount = 0
+        var slowingCancelledCount = 0
         var speedMotionEvents: [[String: String]] = []
 
         func switchToContinuous() { switchedToContinuous = true }
         func switchToStationaryPeriodic() { switchedToStationaryPeriodic = true }
         func switchToStationaryGeofences() { switchedToStationaryGeofences = true }
+        func speedMotionDidStartSlowing() { slowingStartedCount += 1 }
+        func speedMotionDidCancelSlowing() { slowingCancelledCount += 1 }
         func emitSpeedMotionEvent(state: Int, previousState: Int, trackingMode: Int) {
             speedMotionEvents.append([
                 "state": String(state),

--- a/sdk/rust-core/core/src/algorithms/location_processor.rs
+++ b/sdk/rust-core/core/src/algorithms/location_processor.rs
@@ -184,10 +184,26 @@ impl LocationProcessorResult {
         }
     }
 
-    fn filtered(reason: &str) -> Self {
+    /// A fix we decline to store still answers "how fast is this device?", and
+    /// `effective_speed` is the only channel that answer travels on (#332).
+    ///
+    /// Both hosts feed *every* fix into the GPS-speed motion state machine,
+    /// accepted or not — deliberately, because a parked device's fixes are all
+    /// distance-filtered and the machine would otherwise never leave MOVING.
+    /// Hardcoding `0.0` here therefore reported "stopped" once per rejected fix.
+    /// That is the common case in a vehicle, not a corner case: at a 30 m
+    /// distance filter and ~1 Hz fixes, most of a 10 m/s drive is rejected, so
+    /// the machine saw a stream of zeros on a motorway, ran its SLOWING
+    /// countdown to completion and downgraded the host to periodic tracking
+    /// mid-trip.
+    ///
+    /// Callers pass the speed they still trust from the fix. Rejections that
+    /// impugn the fix itself — a spoofed location, a teleport — pass `0.0`
+    /// rather than lending credibility to a reading they just refused.
+    fn filtered(reason: &str, effective_speed: f64) -> Self {
         Self {
             accepted: false,
-            effective_speed: 0.0,
+            effective_speed,
             odometer_delta: 0.0,
             distance: 0.0,
             reason: Some(reason.to_string()),
@@ -196,10 +212,11 @@ impl LocationProcessorResult {
         }
     }
 
-    fn error(reason: &str, message: &str) -> Self {
+    /// As [`Self::filtered`], for rejections the host surfaces as errors.
+    fn error(reason: &str, message: &str, effective_speed: f64) -> Self {
         Self {
             accepted: false,
-            effective_speed: 0.0,
+            effective_speed,
             odometer_delta: 0.0,
             distance: 0.0,
             reason: Some(reason.to_string()),
@@ -383,14 +400,18 @@ impl LocationProcessor {
         let mut state = self.state.lock().unwrap();
         let tuning = state.tuning;
 
+        // Mock rejections report 0.0: a fix the platform flagged as spoofed is
+        // untrusted in full, and its speed must not be able to hold the motion
+        // state machine awake (#332).
         if self.reject_mock_locations && is_mock {
             return if self.filter_policy == 2 {
                 LocationProcessorResult::error(
                     "MOCK_LOCATION",
                     "Location rejected: flagged as mock/spoofed by the platform",
+                    0.0,
                 )
             } else {
-                LocationProcessorResult::filtered("MOCK_LOCATION")
+                LocationProcessorResult::filtered("MOCK_LOCATION", 0.0)
             };
         }
 
@@ -406,9 +427,10 @@ impl LocationProcessor {
                         "Location rejected: timestamp {} is before previous {} (non-monotonic)",
                         timestamp_ms, state.last_timestamp_ms
                     ),
+                    0.0,
                 )
             } else {
-                LocationProcessorResult::filtered("MOCK_LOCATION_TIMESTAMP")
+                LocationProcessorResult::filtered("MOCK_LOCATION_TIMESTAMP", 0.0)
             };
         }
 
@@ -441,8 +463,10 @@ impl LocationProcessor {
             effective_distance = tuning.distance_filter * speed_factor * multiplier;
         }
 
+        // The fix is merely too close to the last one to be worth storing —
+        // nothing about it makes its speed less true (#332).
         if state.last_latitude.is_some() && distance < effective_distance {
-            return LocationProcessorResult::filtered("DISTANCE_FILTER");
+            return LocationProcessorResult::filtered("DISTANCE_FILTER", effective_speed);
         }
 
         if tuning.tracking_accuracy_threshold > 0
@@ -456,12 +480,19 @@ impl LocationProcessor {
                             "Location accuracy {}m exceeds threshold {}m",
                             accuracy, tuning.tracking_accuracy_threshold
                         ),
+                        effective_speed,
                     )
                 }
-                1 => return LocationProcessorResult::filtered("ACCURACY_FILTER"),
+                // A coarse fix is a poor position but not a poor speedometer:
+                // the platform's reading is Doppler-derived, independent of
+                // horizontal accuracy (#332).
+                1 => return LocationProcessorResult::filtered("ACCURACY_FILTER", effective_speed),
                 _ => {
                     if state.last_latitude.is_some() {
-                        return LocationProcessorResult::filtered("ACCURACY_FILTER");
+                        return LocationProcessorResult::filtered(
+                            "ACCURACY_FILTER",
+                            effective_speed,
+                        );
                     }
                 }
             }
@@ -470,6 +501,12 @@ impl LocationProcessor {
         if tuning.max_implied_speed > 0 && state.last_latitude.is_some() && time_delta > 0.0 {
             let implied_speed = distance / time_delta;
             if implied_speed > tuning.max_implied_speed as f64 {
+                // The jump between the two positions is what failed, so the
+                // position-derived fallback in `effective_speed` *is* the
+                // rejected quantity and must not be reported onward. The
+                // platform's own reading is unaffected by the teleport, so pass
+                // it when there is one and 0.0 when there is not (#332).
+                let reported_speed = if speed > 0.0 { speed } else { 0.0 };
                 return if self.filter_policy == 2 {
                     LocationProcessorResult::error(
                         "SPEED_FILTER",
@@ -477,9 +514,10 @@ impl LocationProcessor {
                             "Implied speed {:.1}m/s exceeds max {}m/s",
                             implied_speed, tuning.max_implied_speed
                         ),
+                        reported_speed,
                     )
                 } else {
-                    LocationProcessorResult::filtered("SPEED_FILTER")
+                    LocationProcessorResult::filtered("SPEED_FILTER", reported_speed)
                 };
             }
         }
@@ -522,7 +560,10 @@ impl LocationProcessor {
                     state.last_longitude = Some(longitude);
                     state.last_timestamp_ms = timestamp_ms;
                     state.last_effective_speed = effective_speed;
-                    return LocationProcessorResult::filtered("SPARSE_FILTER");
+                    // This fix passed every quality gate and advanced the
+                    // anchor; it is suppressed only to thin the stream, so its
+                    // speed is as good as an accepted one's (#332).
+                    return LocationProcessorResult::filtered("SPARSE_FILTER", effective_speed);
                 }
             }
             state.sparse_last_lat = Some(latitude);
@@ -820,5 +861,133 @@ mod tests {
 
         assert!(!p.has_last_location());
         assert_eq!(p.current_tuning(), vehicle(), "reset forgets where, not which mode");
+    }
+
+    // -- #332: a rejected fix must still report the speed it was travelling at --
+    //
+    // Both hosts feed `effective_speed` into the GPS-speed motion state machine
+    // on every fix, accepted or not. A hardcoded 0.0 on the reject paths meant
+    // most of a drive was reported to that machine as "stopped".
+
+    /// A fix `metres` north of the base point, carrying a platform speed.
+    fn fix_at_speed(
+        p: &LocationProcessor,
+        metres: f64,
+        accuracy: f64,
+        speed: f64,
+        ts_ms: i64,
+    ) -> LocationProcessorResult {
+        p.process(
+            BASE_LAT + metres / M_PER_DEG_LAT,
+            BASE_LNG,
+            accuracy,
+            speed,
+            ts_ms,
+            false,
+            None,
+        )
+    }
+
+    #[test]
+    fn distance_filtered_fix_reports_the_speed_it_was_travelling_at() {
+        let p = processor(vehicle());
+        assert!(fix_at_speed(&p, 0.0, 5.0, 10.0, 1_000).accepted);
+
+        // 10 m of travel is inside the 30 m vehicle filter, so this is rejected
+        // for storage — but the car is still doing 10 m/s.
+        let r = fix_at_speed(&p, 10.0, 5.0, 10.0, 2_000);
+
+        assert!(!r.accepted);
+        assert_eq!(r.reason.as_deref(), Some("DISTANCE_FILTER"));
+        assert_eq!(
+            r.effective_speed, 10.0,
+            "a fix too close to store is not a fix that stopped moving",
+        );
+    }
+
+    #[test]
+    fn a_drive_never_reports_a_fabricated_zero_speed() {
+        // The reported failure: 30 m filter, ~1 Hz fixes at 10 m/s. Two of every
+        // three fixes are distance-filtered, and each used to hand the motion
+        // machine a 0.00 while the car was on a motorway.
+        let p = processor(vehicle());
+        assert!(fix_at_speed(&p, 0.0, 5.0, 10.0, 0).accepted);
+
+        let mut rejected = 0;
+        for second in 1..=30_i64 {
+            let r = fix_at_speed(&p, 10.0 * second as f64, 5.0, 10.0, second * 1_000);
+            if !r.accepted {
+                rejected += 1;
+            }
+            assert_eq!(
+                r.effective_speed, 10.0,
+                "fix at t={second}s reported {} m/s while driving at 10 m/s",
+                r.effective_speed,
+            );
+        }
+        assert!(
+            rejected > 0,
+            "the scenario is only meaningful if fixes are actually being rejected",
+        );
+    }
+
+    #[test]
+    fn accuracy_filtered_fix_reports_the_speed_it_was_travelling_at() {
+        let p = processor(vehicle());
+        assert!(fix_at_speed(&p, 0.0, 5.0, 10.0, 1_000).accepted);
+
+        // Past the distance filter but too coarse to store. A poor position is
+        // not a poor speedometer — the platform reading is Doppler-derived.
+        let r = fix_at_speed(&p, 100.0, 80.0, 10.0, 2_000);
+
+        assert!(!r.accepted);
+        assert_eq!(r.reason.as_deref(), Some("ACCURACY_FILTER"));
+        assert_eq!(r.effective_speed, 10.0);
+    }
+
+    #[test]
+    fn mock_rejection_reports_no_speed() {
+        let p = LocationProcessor::new(
+            30.0, true, 1.0, false, 50, 0, 60, 30, /* reject_mock */ true, 1, false, 0.0, 0,
+        );
+
+        let r = p.process(BASE_LAT, BASE_LNG, 5.0, 30.0, 1_000, true, None);
+
+        assert!(!r.accepted);
+        assert_eq!(r.reason.as_deref(), Some("MOCK_LOCATION"));
+        assert_eq!(
+            r.effective_speed, 0.0,
+            "a spoofed fix is untrusted in full — its speed must not hold the \
+             motion machine awake",
+        );
+    }
+
+    #[test]
+    fn speed_filter_does_not_propagate_the_rejected_implied_speed() {
+        let p = processor(vehicle());
+        assert!(fix_at_speed(&p, 0.0, 5.0, 10.0, 1_000).accepted);
+
+        // A 5 km jump in one second: ~5000 m/s implied, far past the 60 m/s cap.
+        // With no platform speed to fall back on, `effective_speed` *is* the
+        // absurd derived value, which must not travel onward.
+        let r = fix_at_speed(&p, 5_000.0, 5.0, 0.0, 2_000);
+
+        assert!(!r.accepted);
+        assert_eq!(r.reason.as_deref(), Some("SPEED_FILTER"));
+        assert_eq!(r.effective_speed, 0.0);
+    }
+
+    #[test]
+    fn speed_filter_keeps_a_valid_platform_reading() {
+        let p = processor(vehicle());
+        assert!(fix_at_speed(&p, 0.0, 5.0, 10.0, 1_000).accepted);
+
+        // Same teleport, but the chip reported a plausible speed of its own.
+        // The jump is what failed, not the speedometer.
+        let r = fix_at_speed(&p, 5_000.0, 5.0, 12.0, 2_000);
+
+        assert!(!r.accepted);
+        assert_eq!(r.reason.as_deref(), Some("SPEED_FILTER"));
+        assert_eq!(r.effective_speed, 12.0);
     }
 }


### PR DESCRIPTION
## The report

Driving with the phone held in hand. Tracking dropped to STATIONARY mid-journey; shaking the phone brought it back. iOS 26.5.2, `motionDetectionMode: smart`. Odometer confirms 28.8 km travelled.

The root cause is in the shared Rust core, so Android had it too.

## Root cause (#332)

`LocationProcessorResult::filtered()` hardcoded `effective_speed: 0.0`. Both hosts feed **every** fix into the GPS-speed motion state machine — accepted or not, deliberately, because a parked device's fixes are all distance-filtered and the machine would otherwise never leave MOVING — and they feed it `result.effectiveSpeed`. So every rejection injected a fabricated *"stopped"* sample.

In a vehicle that is the majority of fixes. At the `vehicle` auto-tune's 30 m distance filter and ~1 Hz fixes, roughly two of every three fixes at 10 m/s are rejected.

From the reporter's log, device doing 8–11 m/s throughout:

```
14:06:45 [SpeedMotion] MOVING -> SLOWING (speed=0.00 < threshold=1.50)
14:06:45 [Tracelet] Location filtered by Rust processor: DISTANCE_FILTER
```

The accepted fix immediately before it carried `speed=8.75`.

`handleSlowing` needs `speedAbortFixCount = 3` **consecutive** above-threshold fixes to return to MOVING. The interleaved zeros hit the low-speed branch and reset `highSpeedCount = 0` every time, so the counter never advanced past 1 — the same `1/3` five times in a row while the car was on a highway:

```
14:07:00 SLOWING: ignoring high-speed fix 1/3 (speed=9.73 >= threshold=1.50)
14:07:03 SLOWING: ignoring high-speed fix 1/3 (speed=10.48 >= threshold=1.50)
14:07:06 SLOWING: ignoring high-speed fix 1/3 (speed=10.58 >= threshold=1.50)
14:07:10 SLOWING: ignoring high-speed fix 1/3 (speed=8.77 >= threshold=1.50)
14:07:14 SLOWING: ignoring high-speed fix 1/3 (speed=8.53 >= threshold=1.50)
14:07:15 [SpeedMotion] SLOWING timer expired -> STATIONARY
```

Meanwhile the accelerometer independently declared stillness — a phone held still in a smooth-riding car reads near-zero, which is the exact scenario `SpeedMotionManager` exists to cover, per its own class comment:

> Designed for vehicle tracking where accelerometer-based stop detection is unreliable (phone on a smooth dashboard reads near-zero even at highway speed).

With both inputs false the coordinator's logical OR collapsed:

```
14:07:15 SmartMotionCoordinator: onSpeedStateChange -> isMoving=false, action=switchToStationaryPeriodic
14:07:15 [Tracelet] switchToStationaryPeriodic: stopping continuous, starting periodic timer
```

### Fix

`filtered()`/`error()` take the resolved speed. Rejections that impugn the fix itself still report `0.0` — a spoofed location, and a teleport, where the position-derived speed *is* the quantity that just failed the check.

## Also fixed, found in the same path

**#333 — an unknown speed counted as standing still.** `SmartMotionCoordinator` read `getLastLocation()?.speed` to decide whether to overrule a *moving* accelerometer. `CLLocation.speed` is `-1` when the fix carries no speed, and `-1` sails through `<= 0.15`; Android's `Location.speed` reports `0.0` in the same situation. Missing data was treated as proof the device was parked, and the one input reporting motion got overridden. It now reads the resolved `lastEffectiveSpeed` — whose declaration names this hazard outright ("the cached CLLocation.speed may be stale, 0, or -1") — and treats "no speed resolved yet" as unknown, which never overrules a positive motion signal. The log line that described 11.26 m/s as "suggests walking" now names the threshold it compared against.

**#334 — the trace could not explain the downgrade.** Every `[SpeedMotion]` line is `debug`. At the shipped defaults (`info` for Flutter, `off` for a direct SDK consumer) none of them reach the store, so this was only diagnosable because the reporter happened to be running with `logLevel: debug`. `TraceletLogger.lifecycle` (#318) already exists for exactly this and its doc comment lists "motion-state transitions" and "tracking-mode switches" as belonging on it. Now on the always-on channel:

```
speed-motion: MOVING -> SLOWING — speed=0.00 < threshold=1.50
speed-motion: restored STATIONARY (lowSpeedCount=0, wakeCount=0)
smart-motion: switching to STATIONARY_PERIODIC — accelMoving=false speedMoving=false lastSpeed=8.53m/s
```

State names are spelled out rather than logged as `rawValue: 2`, since the trace is read by a human in a pasted report. The per-fix `debug` filter line now carries the speed handed to the machine, so accepted and rejected fixes can be compared directly. These fire a handful of times per trip, not per fix — the affordability bar the channel documents — and retention is unchanged.

**#335 — iOS emitted `speedmotion` twice per transition.** The inner handler persisted-and-emitted, then `onLocation` did it again; `handleStationary` was the odd one out and relied only on the outer block, which is why `STATIONARY -> MOVING` was the only edge that emitted once. Replaced with a single `commitTransition` choke point mirroring Android's `transitionTo`. A doubled entry would also have misrepresented one transition as two in the new trace.

## Tests

- **Rust (6 new, 16 in file passing):** the reject-path speed contract per filter reason, including `a_drive_never_reports_a_fabricated_zero_speed` — 30 fixes at 10 m/s through a 30 m filter, asserting every result reports 10.0 and that fixes are genuinely being rejected so the scenario is not vacuous.
- **Swift (8 new, 82 passing):** `SpeedMotionManagerTests.swift` was written but never listed in `Package.swift`'s test `sources`, so **none of it had ever run**. Wired in, its delegate double brought up to date against the current `SpeedMotionDelegate`, plus one-event-per-transition coverage and the drive scenario.
- **Kotlin (9 new, 335 passing):** the coordinator's unknown/near-zero/vehicle-speed branches and the drive scenario. Two existing tests asserted the old behaviour — overriding a moving accelerometer with no GPS fix at all — and were migrated to assert what they said they meant.

`melos format` and `melos analyze` clean.

## Verification cards

`example/lib/issues/issue_33{2,3,4,5}_card.dart`, registered newest-first in the issues tab. #334 and #335 verify their contracts outright (#334 raises `logLevel` to `error` first, so anything it then finds reached the store despite the gate). #332 and #333 observe the live consequence and report **inconclusive** rather than green when the device never moved — a stationary device legitimately goes STATIONARY, and calling that a pass would hide the bug.


## Found by running the card (#337)

The #335 card, run on a device, reported its count rows green and its degenerate-edge row red:

```
✅ #335 a forced stop emits one event, not two — changePace(false) produced
   exactly one stationary → stationary event
❌ no event reports a transition to the state it came from — REGRESSED — 1
   event(s) with previousState == state
```

Android's `transitionTo` had no "did the state actually change" guard, so a `changePace()` agreeing with the current state emitted a phantom event and wrote a fabricated `speed-motion: STATIONARY -> STATIONARY` line into the trace this PR adds. iOS's `commitTransition` has always guarded it — verified across all five commit sites, and the four new Swift tests pass with no iOS source change.

`state.isMoving` stays outside the guard: `transitionTo` is where that field is re-synced and `SmartMotionCoordinator.handleAction` writes it directly too, so a no-op call is a legitimate re-assertion. The mode-switch callbacks are likewise unaffected.

The card now seeds a known state with `changePace(true)` first — without it, "one event" could not be told apart from "one no-op event", which is how this got past the first pass — and asserts the repeat call emits nothing.

Fixes #337

## Known gaps, not addressed here

`## Active configuration` in a bug report renders as `{}` because it mirrors `Tracelet.activeConfig`, a Dart-side in-memory copy of the last `Config` passed in; a report generated after a background relaunch shows nothing. The same restart empties `## Location filter (in force vs. configured)`. Both are process-scoped by construction. Noted on the #334 card.

Fixes #332
Fixes #333
Fixes #334
Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

