### PR TITLE
fix(filter): auto-tune must not override an explicit distanceFilter of 0

### DIFF
--- a/example/lib/issues/issue_346_card.dart
+++ b/example/lib/issues/issue_346_card.dart
@@ -1,0 +1,246 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #346 — transport-mode auto-tuning overwrote an explicit
+/// `distanceFilter: 0`, so a parked device recorded nothing and never synced.
+///
+/// `distanceFilter` defaults to `10.0` and is documented as "the minimum
+/// distance the device must move horizontally before a new location update is
+/// recorded", so `0` is not an unset value — it is a deliberate "record every
+/// fix", matching the `<= 0 disables` convention its three sibling thresholds
+/// already document.
+///
+/// Auto-tuning replaced it like any other value:
+///
+/// ```rust
+/// pub fn retune(&self, tuning: LocationTuning) {
+///     self.state.lock().unwrap().tuning = tuning;   // whole-record swap
+/// }
+/// ```
+///
+/// and `TransportMode::Still` — which is what commits on a device sitting on a
+/// desk — carries the widest non-vehicle gate in the table:
+///
+/// ```rust
+/// TransportMode::Still => LocationTuning {
+///     distance_filter: 25.0, tracking_accuracy_threshold: 15,
+///     odometer_accuracy_threshold: 10, max_implied_speed: 3,
+/// },
+/// ```
+///
+/// A parked device never travels 25 m, so every fix came back
+/// `DISTANCE_FILTER`, the database stayed empty, and the host experienced it as
+/// sync having stopped. The field report shows ~120 consecutive
+/// `DISTANCE_FILTER` results, `Pending locations | 0`, and a filter table
+/// reading `Distance filter (m) | configured 0.0 | in force 25.0`.
+///
+/// It was also expensive while it was wrong: the pace state machine had
+/// switched *into* continuous tracking over the same window, so the SDK held a
+/// background location session open and took a fix roughly twice a second while
+/// discarding all of them.
+///
+/// The fix preserves a configured `0` across a retune. The other three
+/// thresholds still tune — they answer "is this fix trustworthy?", which the
+/// committed mode genuinely knows better than a static config.
+///
+/// **What this card can prove.** `getCurrentLocationTuning()` reads the
+/// thresholds back from the processor rather than from config, so it reports
+/// what the filter is really using. The card leaves tracking running long
+/// enough for the classifier to commit a mode, then checks the distance gate
+/// survived and that fixes were actually recorded.
+///
+/// **Run it with the device sitting still**, which is the reported scenario. If
+/// no mode commits within the window the card says so and reports the rows as
+/// inconclusive rather than claiming a pass it did not earn.
+class Issue346Card extends StatefulWidget {
+  const Issue346Card({super.key});
+
+  @override
+  State<Issue346Card> createState() => _Issue346CardState();
+}
+
+class _Issue346CardState extends State<Issue346Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    StreamSubscription<ModeChangeEvent>? modeSub;
+    StreamSubscription<Location>? locSub;
+
+    try {
+      await Tracelet.setConfig(
+        const Config(
+          geo: GeoConfig(distanceFilter: 0),
+          classifier: ClassifierConfig(
+            enableFusedClassifier: true,
+            autoTuneFromTransportMode: true,
+          ),
+        ),
+      );
+
+      final commits = <ModeChangeEvent>[];
+      modeSub = Tracelet.onModeChange(commits.add);
+      var recorded = 0;
+      locSub = Tracelet.onLocation((_) => recorded++);
+
+      await Tracelet.start();
+      // Continuous pace, so fixes actually flow and the distance gate is the
+      // only thing that could be stopping them.
+      await Tracelet.changePace(true);
+
+      final before = await Tracelet.getCurrentLocationTuning();
+      check(
+        'the configured distance filter reaches the processor',
+        before?.distanceFilter == 0,
+        before == null
+            ? 'no processor yet — nothing below is conclusive'
+            : before.distanceFilter == 0
+            ? 'in force: distanceFilter=${before.distanceFilter}m, as configured'
+            : 'in force: distanceFilter=${before.distanceFilter}m but 0 was '
+                  'configured — a mode had already committed, or the config '
+                  'never arrived',
+      );
+
+      // The classifier needs its confidence gate plus an 8 s dwell before it
+      // commits, and it only sees a mode once it has accelerometer windows to
+      // work with.
+      await Future<void>.delayed(const Duration(seconds: 25));
+
+      final after = await Tracelet.getCurrentLocationTuning();
+      final tuned = commits.where((e) => e.appliedTuning != null).toList();
+
+      if (tuned.isEmpty) {
+        results.add(
+          'ℹ️ no transport mode committed in 25 s, so auto-tuning never ran and '
+          'the rows below did not exercise #346. Re-run with the device '
+          'resting still — "still" needs speed under 2 km/h and low accel '
+          'variance, plus the 8 s dwell. Modes seen: '
+          '${commits.isEmpty ? 'none' : commits.map((e) => e.mode).join(', ')}.',
+        );
+      } else {
+        final names = tuned
+            .map((e) => '${e.mode}(df=${e.appliedTuning!.distanceFilter}m)')
+            .join(', ');
+        results.add('ℹ️ modes committed with a tuning: $names');
+      }
+
+      check(
+        '#346 an auto-tune does not impose a distance filter on a host that '
+        'switched it off',
+        after?.distanceFilter == 0,
+        after == null
+            ? 'no processor — inconclusive'
+            : after.distanceFilter == 0
+            ? 'still distanceFilter=0m after ${tuned.length} tuned commit(s); '
+                  'the host asked for every fix and still gets every fix'
+            : 'REGRESSED — distanceFilter is now ${after.distanceFilter}m. '
+                  'A parked device cannot travel that, so every fix will be '
+                  'DISTANCE_FILTERed and nothing will be persisted or synced.',
+      );
+
+      // The other three must still tune — the fix is deliberately narrow.
+      if (tuned.isNotEmpty && after != null) {
+        final t = tuned.last.appliedTuning!;
+        final othersApplied =
+            after.trackingAccuracyThreshold == t.trackingAccuracyThreshold &&
+            after.odometerAccuracyThreshold == t.odometerAccuracyThreshold &&
+            after.maxImpliedSpeed == t.maxImpliedSpeed;
+        check(
+          'the accuracy and implied-speed thresholds still auto-tune',
+          othersApplied,
+          othersApplied
+              ? 'trackingAccuracy=${after.trackingAccuracyThreshold}m, '
+                    'odometerAccuracy=${after.odometerAccuracyThreshold}m, '
+                    'maxImpliedSpeed=${after.maxImpliedSpeed}m/s — all from the '
+                    'committed mode, so the fix stayed narrow'
+              : 'the mode applied '
+                    '(${t.trackingAccuracyThreshold}/${t.odometerAccuracyThreshold}/'
+                    '${t.maxImpliedSpeed}) but in force is '
+                    '(${after.trackingAccuracyThreshold}/'
+                    '${after.odometerAccuracyThreshold}/${after.maxImpliedSpeed}) '
+                    '— the guard is suppressing more than the distance gate',
+        );
+      }
+
+      // The user-visible consequence, and the reason this was reported as a
+      // sync failure: with the gate imposed, a still device records nothing.
+      check(
+        'a still device still records fixes',
+        recorded > 0,
+        recorded > 0
+            ? '$recorded location(s) recorded while stationary — there is '
+                  'something for sync to send'
+            : 'no locations recorded in 25 s of continuous tracking. This is '
+                  'the reported symptom: sync looks broken because persistence '
+                  'produced nothing.',
+      );
+
+      await Tracelet.changePace(false);
+      await Tracelet.stop();
+
+      final header = allPass
+          ? '✅ SUCCESS: an explicit distanceFilter:0 survives auto-tuning.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Scope: this checks the thresholds actually in force — '
+        'getCurrentLocationTuning() reads back from the processor, not from '
+        'config, so a regression cannot hide behind the config still saying 0. '
+        'It depends on the classifier committing a mode during the window; '
+        'when none commits the run is reported as inconclusive above rather '
+        'than as a pass.\n\n'
+        'Not covered here, and worth knowing: while "still" is committed, '
+        'maxImpliedSpeed is 3 m/s. When the device does start moving, fixes '
+        'are rejected as SPEED_FILTER teleports until the classifier commits a '
+        'faster mode, which needs its own confidence gate and 8 s dwell. That '
+        'is the same "auto-tune outlives the situation it was chosen for" '
+        'tension and is tracked separately.\n\n'
+        "The guard lives in the Rust processor's retune(), the single point "
+        'where an incoming tuning meets the configured base, so iOS and '
+        'Android are covered by the one change and by the Rust unit tests '
+        '(retune_preserves_a_configured_zero_distance_filter and neighbours).',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      await modeSub?.cancel();
+      await locSub?.cancel();
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'distance filter auto-tune transport mode still retune tuning '
+          'not syncing no locations recorded parked stationary distanceFilter '
+          'zero 346',
+      title: '#346: auto-tune must not override an explicit distanceFilter:0',
+      description:
+          'A committed "still" mode swapped in a 25 m distance filter over a '
+          'configured 0, so a parked device filtered out every fix and had '
+          'nothing to sync. Checks the gate in force and that fixes still land.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -65,6 +65,7 @@ import 'package:tracelet_example/issues/issue_332_card.dart';
 import 'package:tracelet_example/issues/issue_333_card.dart';
 import 'package:tracelet_example/issues/issue_334_card.dart';
 import 'package:tracelet_example/issues/issue_335_card.dart';
+import 'package:tracelet_example/issues/issue_346_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1737,6 +1738,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                   // own title/description/keywords via IssueSearchScope, so they
                   // are rendered directly. Cards with a bespoke layout (no shell)
                   // stay wrapped in _searchableCard with explicit keywords.
+                  const Issue346Card(),
                   const Issue335Card(),
                   const Issue334Card(),
                   const Issue333Card(),

--- a/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/uniffi/tracelet_core/tracelet_core.kt
@@ -1431,7 +1431,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_tracelet_core_checksum_method_locationprocessor_restore_base_tuning() != 17132.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tracelet_core_checksum_method_locationprocessor_retune() != 24775.toShort()) {
+    if (lib.uniffi_tracelet_core_checksum_method_locationprocessor_retune() != 24226.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tracelet_core_checksum_method_locationprocessor_set_base_tuning() != 15053.toShort()) {
@@ -6331,6 +6331,21 @@ public interface LocationProcessorInterface {
      * rebuilding the processor to change thresholds would drop the anchor point
      * and silently forfeit one inter-fix delta from the odometer every time the
      * transport mode changed.
+     * A configured `distance_filter` of 0 survives the swap (#346).
+     *
+     * Zero is not "unset" — the hosts default it to 10 m, so reaching 0 takes a
+     * deliberate "record every fix", the same opt-out the sibling thresholds
+     * document as `<= 0 disables`. Auto-tuning used to overwrite it like any
+     * other value, and `Still` carries the widest non-vehicle gate in the table
+     * at 25 m. A parked device never travels 25 m, so every fix came back
+     * `DISTANCE_FILTER`, nothing was persisted, and the host saw it as sync
+     * having stopped — while the pace machine, which has its own idea of when a
+     * device is parked, was meanwhile holding continuous GPS open and throwing
+     * away roughly two fixes a second.
+     *
+     * Only the distance gate is preserved. The accuracy and implied-speed
+     * thresholds are about whether a fix is *trustworthy*, which the mode
+     * genuinely knows better than a static config, so those still tune.
      */
     fun `retune`(`tuning`: LocationTuning)
     
@@ -6563,6 +6578,21 @@ open class LocationProcessor: Disposable, AutoCloseable, LocationProcessorInterf
      * rebuilding the processor to change thresholds would drop the anchor point
      * and silently forfeit one inter-fix delta from the odometer every time the
      * transport mode changed.
+     * A configured `distance_filter` of 0 survives the swap (#346).
+     *
+     * Zero is not "unset" — the hosts default it to 10 m, so reaching 0 takes a
+     * deliberate "record every fix", the same opt-out the sibling thresholds
+     * document as `<= 0 disables`. Auto-tuning used to overwrite it like any
+     * other value, and `Still` carries the widest non-vehicle gate in the table
+     * at 25 m. A parked device never travels 25 m, so every fix came back
+     * `DISTANCE_FILTER`, nothing was persisted, and the host saw it as sync
+     * having stopped — while the pace machine, which has its own idea of when a
+     * device is parked, was meanwhile holding continuous GPS open and throwing
+     * away roughly two fixes a second.
+     *
+     * Only the distance gate is preserved. The accuracy and implied-speed
+     * thresholds are about whether a fix is *trustworthy*, which the mode
+     * genuinely knows better than a static config, so those still tune.
      */override fun `retune`(`tuning`: LocationTuning)
         = 
     callWithHandle {

--- a/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
+++ b/sdk/ios/Sources/TraceletSDK/tracelet_core.swift
@@ -3167,6 +3167,21 @@ public protocol LocationProcessorProtocol: AnyObject, Sendable {
      * rebuilding the processor to change thresholds would drop the anchor point
      * and silently forfeit one inter-fix delta from the odometer every time the
      * transport mode changed.
+     * A configured `distance_filter` of 0 survives the swap (#346).
+     *
+     * Zero is not "unset" — the hosts default it to 10 m, so reaching 0 takes a
+     * deliberate "record every fix", the same opt-out the sibling thresholds
+     * document as `<= 0 disables`. Auto-tuning used to overwrite it like any
+     * other value, and `Still` carries the widest non-vehicle gate in the table
+     * at 25 m. A parked device never travels 25 m, so every fix came back
+     * `DISTANCE_FILTER`, nothing was persisted, and the host saw it as sync
+     * having stopped — while the pace machine, which has its own idea of when a
+     * device is parked, was meanwhile holding continuous GPS open and throwing
+     * away roughly two fixes a second.
+     *
+     * Only the distance gate is preserved. The accuracy and implied-speed
+     * thresholds are about whether a fix is *trustworthy*, which the mode
+     * genuinely knows better than a static config, so those still tune.
      */
     func retune(tuning: LocationTuning) 
     
@@ -3342,6 +3357,21 @@ open func restoreBaseTuning()  {try! rustCall() {
      * rebuilding the processor to change thresholds would drop the anchor point
      * and silently forfeit one inter-fix delta from the odometer every time the
      * transport mode changed.
+     * A configured `distance_filter` of 0 survives the swap (#346).
+     *
+     * Zero is not "unset" — the hosts default it to 10 m, so reaching 0 takes a
+     * deliberate "record every fix", the same opt-out the sibling thresholds
+     * document as `<= 0 disables`. Auto-tuning used to overwrite it like any
+     * other value, and `Still` carries the widest non-vehicle gate in the table
+     * at 25 m. A parked device never travels 25 m, so every fix came back
+     * `DISTANCE_FILTER`, nothing was persisted, and the host saw it as sync
+     * having stopped — while the pace machine, which has its own idea of when a
+     * device is parked, was meanwhile holding continuous GPS open and throwing
+     * away roughly two fixes a second.
+     *
+     * Only the distance gate is preserved. The accuracy and implied-speed
+     * thresholds are about whether a fix is *trustworthy*, which the mode
+     * genuinely knows better than a static config, so those still tune.
      */
 open func retune(tuning: LocationTuning)  {try! rustCall() {
     uniffi_tracelet_core_fn_method_locationprocessor_retune(
@@ -9998,7 +10028,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_tracelet_core_checksum_method_locationprocessor_restore_base_tuning() != 17132) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_tracelet_core_checksum_method_locationprocessor_retune() != 24775) {
+    if (uniffi_tracelet_core_checksum_method_locationprocessor_retune() != 24226) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_tracelet_core_checksum_method_locationprocessor_set_base_tuning() != 15053) {

--- a/sdk/rust-core/core/src/algorithms/location_processor.rs
+++ b/sdk/rust-core/core/src/algorithms/location_processor.rs
@@ -342,8 +342,28 @@ impl LocationProcessor {
     /// rebuilding the processor to change thresholds would drop the anchor point
     /// and silently forfeit one inter-fix delta from the odometer every time the
     /// transport mode changed.
+    /// A configured `distance_filter` of 0 survives the swap (#346).
+    ///
+    /// Zero is not "unset" — the hosts default it to 10 m, so reaching 0 takes a
+    /// deliberate "record every fix", the same opt-out the sibling thresholds
+    /// document as `<= 0 disables`. Auto-tuning used to overwrite it like any
+    /// other value, and `Still` carries the widest non-vehicle gate in the table
+    /// at 25 m. A parked device never travels 25 m, so every fix came back
+    /// `DISTANCE_FILTER`, nothing was persisted, and the host saw it as sync
+    /// having stopped — while the pace machine, which has its own idea of when a
+    /// device is parked, was meanwhile holding continuous GPS open and throwing
+    /// away roughly two fixes a second.
+    ///
+    /// Only the distance gate is preserved. The accuracy and implied-speed
+    /// thresholds are about whether a fix is *trustworthy*, which the mode
+    /// genuinely knows better than a static config, so those still tune.
     pub fn retune(&self, tuning: LocationTuning) {
-        self.state.lock().unwrap().tuning = tuning;
+        let mut state = self.state.lock().unwrap();
+        let mut tuning = tuning;
+        if state.base_tuning.distance_filter == 0.0 {
+            tuning.distance_filter = 0.0;
+        }
+        state.tuning = tuning;
     }
 
     /// Restores the thresholds the processor was constructed with, undoing any
@@ -691,6 +711,95 @@ mod tests {
         // realistic 1 m/s so they clear walking's own implied-speed ceiling.
         assert!(fix_at(&p, 0.0, 5.0, 1_000).accepted);
         assert!(fix_at(&p, 10.0, 5.0, 11_000).accepted, "10 m clears walking's 8 m filter");
+    }
+
+    /// A host that switched distance filtering off entirely.
+    fn no_distance_filter() -> LocationTuning {
+        LocationTuning {
+            distance_filter: 0.0,
+            tracking_accuracy_threshold: 100,
+            odometer_accuracy_threshold: 50,
+            max_implied_speed: 80,
+        }
+    }
+
+    /// `TransportMode::Still` — the widest non-vehicle distance gate in the
+    /// table, and the one that produced #346 in the field.
+    fn still() -> LocationTuning {
+        LocationTuning {
+            distance_filter: 25.0,
+            tracking_accuracy_threshold: 15,
+            odometer_accuracy_threshold: 10,
+            max_implied_speed: 3,
+        }
+    }
+
+    /// #346: auto-tuning must not impose a distance gate on a host that
+    /// deliberately switched distance filtering off.
+    ///
+    /// The failure was total rather than partial: `Still` commits on a parked
+    /// device, a parked device never travels 25 m, so *every* fix came back
+    /// DISTANCE_FILTER and nothing was ever persisted or synced.
+    #[test]
+    fn retune_preserves_a_configured_zero_distance_filter() {
+        let p = processor(no_distance_filter());
+        p.retune(still());
+
+        assert_eq!(
+            p.current_tuning().distance_filter,
+            0.0,
+            "the host asked for every fix; the mode may not overrule that"
+        );
+    }
+
+    /// The other three thresholds are about whether a fix is *trustworthy*,
+    /// which the committed mode does know better — they must still tune.
+    #[test]
+    fn retune_still_applies_the_other_thresholds_when_distance_filtering_is_off() {
+        let p = processor(no_distance_filter());
+        p.retune(still());
+
+        let t = p.current_tuning();
+        assert_eq!(t.tracking_accuracy_threshold, 15);
+        assert_eq!(t.odometer_accuracy_threshold, 10);
+        assert_eq!(t.max_implied_speed, 3);
+    }
+
+    /// The behaviour that actually matters: consecutive fixes from a parked
+    /// device keep being accepted instead of vanishing.
+    #[test]
+    fn a_parked_device_still_records_fixes_when_distance_filtering_is_off() {
+        let p = processor(no_distance_filter());
+        p.retune(still());
+
+        assert!(fix_at(&p, 0.0, 2.6, 1_000).accepted);
+        // Jitter-sized moves, nothing close to Still's 25 m gate.
+        assert!(fix_at(&p, 1.0, 2.6, 11_000).accepted, "1 m must still be recorded");
+        assert!(fix_at(&p, 1.5, 2.6, 21_000).accepted, "0.5 m must still be recorded");
+    }
+
+    /// The guard keys off the *configured* value, so a host that did ask for a
+    /// distance filter still gets the mode's.
+    #[test]
+    fn retune_still_overrides_a_nonzero_configured_distance_filter() {
+        let p = processor(walking());
+        p.retune(still());
+
+        assert_eq!(p.current_tuning().distance_filter, 25.0);
+    }
+
+    /// Reconfiguring *to* zero must take effect on the next retune too — the
+    /// guard reads `base_tuning`, which `set_base_tuning` owns (#303).
+    #[test]
+    fn reconfiguring_to_zero_disables_the_gate_for_later_retunes() {
+        let p = processor(walking());
+        p.retune(still());
+        assert_eq!(p.current_tuning().distance_filter, 25.0);
+
+        p.set_base_tuning(no_distance_filter());
+        p.retune(still());
+
+        assert_eq!(p.current_tuning().distance_filter, 0.0);
     }
 
     /// #303: a host reconfiguration must reach the live thresholds when nothing


### PR DESCRIPTION
Fixes #346

## The bug

Sync was reported as broken. It isn't — **persistence** is, and the missing sync is the downstream symptom.

Transport-mode auto-tuning overwrote an explicitly configured `distanceFilter: 0.0` with the committed mode's own value. When the mode is `Still` — what commits on a device sitting on a desk — that value is **25 m**, which a parked device never travels, so every fix came back `DISTANCE_FILTER`, nothing was written to the database, and there was nothing left for sync to send.

The Doctor report says it outright:

| Threshold | Configured | In force |
|---|---|---|
| Distance filter (m) | **0.0** | **25.0** |
| Tracking accuracy (m) | 100 | 15 |
| Odometer accuracy (m) | 50 | 10 |
| Max implied speed (m/s) | 80 | 3 |

Those are exactly `TransportMode::Still`. The trace then shows ~120 consecutive `DISTANCE_FILTER` results with no other outcome, `Pending locations | 0`, and a single `sync-body:` line in the whole session — before the mode committed.

It was also expensive while it was wrong. Over the same window the pace state machine switched *into* continuous tracking:

```
20:46:43 smart-motion: switching to CONTINUOUS — accelMoving=true speedMoving=false
20:46:43 switchToContinuous: stopping periodic, resuming continuous
20:46:43 CLBackgroundActivitySession started (iOS 17+)
```

so the SDK held a background location session open and took a fix roughly twice a second, discarding all of them. The pace machine and the classifier each decide independently whether the device is parked, and nothing reconciles them.

## Why 0 is special

`distanceFilter` defaults to `10.0`, and `GeoConfig.distanceFilter` documents it as "the minimum distance (in meters) the device must move horizontally before a new location update is recorded". So `0` is not an unset value — reaching it takes a deliberate "record every fix", and it matches the `<= 0 disables` convention its three sibling thresholds already document on `LocationTuning`.

## The fix

`retune` preserves a configured `distance_filter` of 0:

```rust
pub fn retune(&self, tuning: LocationTuning) {
    let mut state = self.state.lock().unwrap();
    let mut tuning = tuning;
    if state.base_tuning.distance_filter == 0.0 {
        tuning.distance_filter = 0.0;
    }
    state.tuning = tuning;
}
```

`retune` is the one point where an incoming tuning meets the configured base, so this single change covers iOS and Android and documents the invariant once.

Deliberately narrow: **only** the distance gate is preserved. The accuracy and implied-speed thresholds answer "is this fix trustworthy?", which the committed mode genuinely does know better than a static config, so those still tune. Hosts who left `distanceFilter` alone get the default `10.0` and are completely unaffected.

## Tests

Five new Rust tests in `location_processor`: the guard itself, that the other three thresholds still tune, that a parked device keeps recording fixes end-to-end through `process()`, that a *non-zero* configured filter is still overridden, and that reconfiguring to zero via `set_base_tuning` takes effect on later retunes.

**Verified by reverting the guard**: three of the five fail, including `a_parked_device_still_records_fixes_when_distance_filtering_is_off`.

Example app: `issue_346_card.dart`. `getCurrentLocationTuning()` reads back from the processor rather than from config, so a regression cannot hide behind the config still saying 0. The card runs tracking long enough for the classifier to commit, then checks the gate survived, that the other thresholds did tune, and that fixes were actually recorded. If no mode commits in the window it reports the run as **inconclusive** rather than claiming a pass it didn't earn.

## Bindings

uniffi hashes docstrings into the per-method checksum, so documenting the guard on the exported `retune` moved it from 24775 to 24226. Both committed binding files are regenerated (`build-ios.sh`, `build-android.sh`) — stale Kotlin bindings would fail Android at init with a `UniffiInternalError` pointing nowhere near this change. The binding diff is the docstring plus that one constant.

## Verification

* `cargo test -p tracelet_core` — 125 passed, 0 failed.
* iOS `xcodebuild test -scheme TraceletSDK` against the rebuilt xcframework — 82 tests, 0 failures.
* Android `./gradlew :tracelet-sdk:testDebugUnitTest` against the regenerated bindings — BUILD SUCCESSFUL.
* `melos format` and `melos analyze` clean.

## Not fixed here

While `Still` is committed, `max_implied_speed` is **3 m/s**. When the device does start moving, fixes are rejected as `SPEED_FILTER` teleports until the classifier commits a faster mode, which needs its own confidence gate plus an 8 s dwell. Same "auto-tune outlives the situation it was chosen for" tension, worth its own issue.

Separately, whether `Still` should influence the *distance* filter at all is a design question rather than a defect. The SDK already parks a stationary device through the motion pipeline (`STATIONARY_PERIODIC`), so suppressing persistence in the filter as well is a second, independent mechanism for the same goal — and, as the log above shows, the two can disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
