### PR TITLE
fix(motion): only a resume inherits the previous session's pace

### DIFF
--- a/example/lib/demo_config.dart
+++ b/example/lib/demo_config.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+import 'package:tracelet/tracelet.dart' as tl;
+
+bool get _isAndroid =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+/// The canonical Tracelet configuration for this demo app.
+///
+/// Used by the home page's `ready()` **and** by the issue cards' run harness
+/// (`prepareIssueRun`), which is the reason it lives here rather than on
+/// `_MyHomePageState`.
+///
+/// Config is *merged*, not replaced — `ready()` and `setConfig()` both land in
+/// the same `ConfigManager.setConfig`, and a field the caller leaves null keeps
+/// whatever was there before. So whatever was applied last stays in force, and
+/// a card that sets two keys inherits every other key from whoever configured
+/// the SDK before it. When that was "the home page, if the user happened to
+/// press Initialize" the cards were reading a different SDK depending on how
+/// the app had been driven — and after a card that changed a key, depending on
+/// which cards had already been run. Handing every run this one baseline first
+/// makes each card start from the same documented state; cards that need
+/// something else still say so afterwards and win.
+tl.Config buildDemoConfig() {
+  return tl.Config(
+    classifier: const tl.ClassifierConfig(
+      enableFusedClassifier: true, // required — classifier must be running
+      autoTuneFromTransportMode: true,
+    ),
+    geo: const tl.GeoConfig(
+      distanceFilter: 0,
+      resolveAddress: true,
+      filter: tl.LocationFilter(
+        useKalmanFilter: true,
+        mockDetectionLevel: 2, // 2 = HEURISTIC
+      ),
+      // ── Battery budget (auto-adjusts tracking to save battery) ──
+      batteryBudgetPerHour: 3, // 3% max drain per hour
+    ),
+    app: const tl.AppConfig(
+      stopOnTerminate: false,
+      startOnBoot: true,
+      heartbeatInterval: 10,
+    ),
+    android: tl.AndroidConfig(
+      periodicUseForegroundService: true, // KEEP NOTIFICATION ALIVE
+      locationUpdateInterval: 2000, // 2s
+      deferTime: 1000, // 10s — batches ~5 locations every 10s
+      foregroundService: _isAndroid
+          ? const tl.ForegroundServiceConfig(
+              notificationTitle: '📍 Tracelet Demo Active',
+              notificationText:
+                  'Smart Notifications — disappears when app is open!',
+              channelId: 'tracelet_demo_channel',
+              channelName: 'Tracelet Demo Background',
+              notificationPriority: tl.NotificationPriority.high,
+              showNotificationOnPauseOnly:
+                  true, // ✨ Smart Visibility — hide while app is foregrounded
+            )
+          : const tl.ForegroundServiceConfig(enabled: false),
+      scheduleUseAlarmManager: _isAndroid, // Android-only: exact alarms
+    ),
+    ios: tl.IosConfig(
+      activityType: _isAndroid
+          ? tl.LocationActivityType.other
+          : tl.LocationActivityType.otherNavigation,
+      preventSuspend: !_isAndroid, // iOS-only: silent-audio keep-alive
+      useBackgroundActivitySession: !_isAndroid, // iOS 17+: Dynamic Island
+      liveActivityConfig: !_isAndroid
+          ? const tl.LiveActivityConfig(
+              title: 'Tracelet Active',
+              body: 'Tracking your route in background',
+            )
+          : null,
+    ),
+    motion: const tl.MotionConfig(
+      stopTimeout: 1, // 1 minute for fast stop-timeout testing
+      motionDetectionMode: tl.MotionDetectionMode.smart,
+      shakeThreshold: 2, // prevent ultra-sensitive motion triggering
+      speedStationaryDelay: 30, // Make it quicker for demo testing
+      stationaryPeriodicInterval: 60, // Quick checks when stationary
+    ),
+    http: tl.HttpConfig(
+      url:
+          tl.Tracelet.activeConfig.http.url ??
+          'http://192.168.20.103:8099/locations',
+      autoSyncDelay: 5000,
+    ),
+    audit: const tl.AuditConfig(enabled: true),
+    security: const tl.SecurityConfig(encryptDatabase: true),
+    persistence: const tl.PersistenceConfig(
+      maxDaysToPersist: 7,
+      maxRecordsToPersist: 5000,
+    ),
+    logger: const tl.LoggerConfig(logLevel: tl.LogLevel.verbose, debug: true),
+  );
+}

--- a/example/lib/issues/issue_344_card.dart
+++ b/example/lib/issues/issue_344_card.dart
@@ -58,6 +58,22 @@ import 'package:tracelet_example/issues/issue_card_shell.dart';
 /// pinned by `SmartMotionCoordinatorSyncModeTests` (iOS) and
 /// `SmartMotionCoordinatorStationaryStartTest` (Android), both of which drive
 /// the real core through the same sequence.
+///
+/// **The precondition is checked, not assumed.** A run on a device that is
+/// genuinely moving cannot set the precondition up: the speed machine wakes on
+/// the last known GPS speed, or the accelerometer wakes the coordinator during
+/// the settle window, and either way the switch this card looks for has already
+/// happened before it can be measured. That is reported as *inconclusive*. It
+/// used to be reported as a red failure whose advice — check that
+/// `motion.isMoving:false` reached the platform — pointed at the wrong thing,
+/// followed by a vacuous green row and a second red one, all three of which
+/// were artefacts of the unmet precondition rather than a regression.
+///
+/// One real defect did hide behind that: a fresh `start()` adopted the previous
+/// session's persisted speed-motion state, so a session that had been left
+/// MOVING overruled an explicit `motion.isMoving: false` outright. Only a
+/// resume inherits the pace now — see `adoptSpeedMotionPace` (Android) and
+/// `startSpeedMotionManager(forceMoving:isResume:)` (iOS).
 class Issue344Card extends StatefulWidget {
   const Issue344Card({super.key});
 
@@ -117,15 +133,44 @@ class _Issue344CardState extends State<Issue344Card> {
       final started = await Tracelet.start();
       await Future<void>.delayed(const Duration(seconds: 2));
 
+      // The precondition is a session that is *actually* parked. Two things can
+      // deny it, and neither is a defect in #344:
+      //
+      //  * a GPS speed at or above speedMovingThreshold (1.5 m/s) — start()
+      //    feeds the last known speed into the speed machine, which wakes on it;
+      //  * real movement of the device during the settle window — a shake, a
+      //    significant-motion trigger or an activity transition all reach the
+      //    coordinator and legitimately switch it to continuous.
+      //
+      // Both leave the coordinator already continuous with both inputs true, so
+      // the changePace(true) below has nothing left to do and dedupes to none.
+      // Reported as inconclusive rather than failed: the run proves nothing
+      // either way, and a red row here used to be read as a regression.
+      final settled = await Tracelet.getState();
+      if (started.isMoving || settled.isMoving) {
+        final when = started.isMoving
+            ? 'start() itself returned isMoving=true'
+            : 'the session woke during the two-second settle window';
+        await Tracelet.stop();
+        _set(
+          '⚠️ INCONCLUSIVE: the session never parked, so #344 was not exercised.'
+          '\n\n'
+          '$when, so the wake-up this card checks for had already happened '
+          'before it could be measured. The device is moving, or GPS is '
+          'reporting a speed at or above the 1.5 m/s moving threshold.\n\n'
+          'This is not a failure of the fix and not a sign that '
+          'motion.isMoving:false was dropped — a fresh start() commits that '
+          'pace, but live motion still outranks it, which is what SMART mode '
+          'is for. Re-run with the device sitting still.',
+        );
+        return;
+      }
+
       check(
         'the fresh session starts stationary',
-        !started.isMoving,
-        !started.isMoving
-            ? 'isMoving=false after start(), as motion.isMoving:false asks for '
-                  '— this is the state that used to wedge the coordinator'
-            : 'isMoving=true after start(), so the precondition for #344 was '
-                  'never set up. Nothing below is conclusive; check that '
-                  'motion.isMoving:false actually reached the platform.',
+        true,
+        'isMoving=false after start(), as motion.isMoving:false asks for — '
+            'this is the state that used to wedge the coordinator',
       );
 
       motionEvents.clear();
@@ -189,7 +234,10 @@ class _Issue344CardState extends State<Issue344Card> {
         'The precondition matters: session 1 exists only to leave both '
         'coordinator inputs stationary. Running the wake-up on a first-ever '
         'start can pass even on a broken build, because the speed machine may '
-        'still flip its flag and repair the posture on the way through.\n\n'
+        'still flip its flag and repair the posture on the way through. A run '
+        'on a device that is actually moving is reported as inconclusive '
+        'rather than failed — the wake-up lands during start() and there is '
+        'nothing left for the card to observe.\n\n'
         'Both platforms had the identical mapping and both are fixed. The core '
         'state machine is driven through this exact sequence by '
         'SmartMotionCoordinatorSyncModeTests (iOS, newly wired into '

--- a/example/lib/issues/issue_card_shell.dart
+++ b/example/lib/issues/issue_card_shell.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tracelet_example/issues/issue_run_harness.dart';
 
 /// Propagates the current issue-search query down to every [IssueCardShell] so
 /// each card can filter itself against its own on-screen text (title +
@@ -37,6 +38,11 @@ class IssueSearchScope extends InheritedWidget {
 /// and its query matches neither the [title], [description], nor [keywords],
 /// the card hides itself. This makes free-text search work against the real
 /// text shown on the card, with no per-card wiring.
+///
+/// Tapping Run calls [prepareIssueRun] before [onRun] (unless [prepare] is
+/// false), which is what makes a card runnable straight from a cold start
+/// instead of only after the home page's Initialize, and pins the config every
+/// card begins from. See that function for what each of those was costing.
 class IssueCardShell extends StatelessWidget {
   const IssueCardShell({
     required this.title,
@@ -47,6 +53,7 @@ class IssueCardShell extends StatelessWidget {
     super.key,
     this.runLabel = 'Run Test',
     this.keywords = '',
+    this.prepare = true,
   });
 
   final String title;
@@ -63,6 +70,12 @@ class IssueCardShell extends StatelessWidget {
   /// (e.g. API names or symptoms a user might search for). Matched in addition
   /// to the visible text.
   final String keywords;
+
+  /// Whether to run [prepareIssueRun] before [onRun] — `ready()` plus the demo
+  /// baseline config, so the card does not depend on the home page having been
+  /// initialized, nor on whichever card ran before it. Set false only for a
+  /// card that must observe an unconfigured SDK.
+  final bool prepare;
 
   @override
   Widget build(BuildContext context) {
@@ -110,7 +123,21 @@ class IssueCardShell extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             FilledButton.icon(
-              onPressed: running ? null : onRun,
+              onPressed: running
+                  ? null
+                  : () async {
+                      if (prepare) {
+                        try {
+                          await prepareIssueRun();
+                        } catch (e) {
+                          // Best effort: run the card anyway so it reports the
+                          // failure in its own status box, where it is visible,
+                          // rather than the tap doing nothing at all.
+                          debugPrint('prepareIssueRun failed: $e');
+                        }
+                      }
+                      onRun();
+                    },
               icon: const Icon(Icons.play_arrow),
               label: Text(runLabel),
             ),

--- a/example/lib/issues/issue_run_harness.dart
+++ b/example/lib/issues/issue_run_harness.dart
@@ -1,0 +1,44 @@
+import 'package:tracelet/tracelet.dart';
+import 'package:tracelet_example/demo_config.dart';
+
+/// Puts the SDK into the state every issue card is written against, before the
+/// card's own body runs. [IssueCardShell] calls this for you on every Run tap.
+///
+/// Two things went wrong without it.
+///
+/// **The SDK was not ready.** A card that calls `start()`, `setConfig()` or any
+/// location API on an SDK that has never had `ready()` gets
+/// `PlatformException(NOT_READY, "Call ready() before start()")`, which the
+/// card reports as a red failure of the issue it is testing. The workaround was
+/// to go back to the home page and press Initialize first — so a card's result
+/// depended on how the app had been driven before it, and the failure it
+/// printed named the wrong thing.
+///
+/// **The config was whatever ran last.** `ready()` and `setConfig()` both merge
+/// into the persisted config rather than replacing it, so a card that sets two
+/// keys inherits every other key from the last thing that configured the SDK:
+/// the home page if Initialize was pressed, otherwise SDK defaults, plus
+/// anything a previously-run card changed. That is a real difference in what
+/// the card is testing — the demo config, for one, runs a more trigger-happy
+/// motion setup than the defaults do (`shakeThreshold: 2` against 2.5,
+/// `stopTimeout: 1`, `speedStationaryDelay: 30`) — and it moved depending on
+/// run order.
+///
+/// Applying [buildDemoConfig] first pins both: the cards keep the exact
+/// configuration they were written and verified against, and they get it
+/// whether or not the home page was ever visited and whichever card ran before.
+/// A card that needs something else still says so in its own body afterwards
+/// and wins, because the merge is applied in that order.
+Future<void> prepareIssueRun() async {
+  // Location permission is the SDK's own precondition, not config: ready()
+  // succeeds without it but start() answers PERMISSION_DENIED. Only asked for
+  // when it has never been decided — a denial is the user's answer and
+  // re-prompting on every Run tap would be obnoxious. Cards that need
+  // background ("always") still check and report that themselves.
+  final status = await Tracelet.getLocationAuthorization();
+  if (status == AuthorizationStatus.notDetermined) {
+    await Tracelet.requestLocationAuthorization();
+  }
+
+  await Tracelet.ready(buildDemoConfig());
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' as tl;
 import 'package:tracelet_doctor/tracelet_doctor.dart';
 import 'package:tracelet_example/behavior_page.dart';
+import 'package:tracelet_example/demo_config.dart';
 import 'package:tracelet_example/provider_options_page.dart';
 import 'package:tracelet_example/map_page.dart';
 import 'package:tracelet_example/issues_page.dart';
@@ -579,80 +580,9 @@ class _DashboardPageState extends State<DashboardPage>
   /// the native runtime instead of assuming it's still ready (see #187 repro:
   /// `flutter run` again → start() failed with NOT_READY because the restore
   /// path set `_isReady = true` without ever calling `ready()`).
-  tl.Config _buildConfig() {
-    return tl.Config(
-      classifier: const tl.ClassifierConfig(
-        enableFusedClassifier: true, // required — classifier must be running
-        autoTuneFromTransportMode: true,
-      ),
-      geo: const tl.GeoConfig(
-        distanceFilter: 0,
-        resolveAddress: true,
-        filter: tl.LocationFilter(
-          useKalmanFilter: true,
-          mockDetectionLevel: 2, // 2 = HEURISTIC
-        ),
-        // ── Battery budget (auto-adjusts tracking to save battery) ──
-        batteryBudgetPerHour: 3, // 3% max drain per hour
-      ),
-      app: const tl.AppConfig(
-        stopOnTerminate: false,
-        startOnBoot: true,
-        heartbeatInterval: 10,
-      ),
-      android: tl.AndroidConfig(
-        periodicUseForegroundService: true, // KEEP NOTIFICATION ALIVE
-        locationUpdateInterval: 2000, // 2s
-        deferTime: 1000, // 10s — batches ~5 locations every 10s
-        foregroundService: _isAndroid
-            ? const tl.ForegroundServiceConfig(
-                notificationTitle: '📍 Tracelet Demo Active',
-                notificationText:
-                    'Smart Notifications — disappears when app is open!',
-                channelId: 'tracelet_demo_channel',
-                channelName: 'Tracelet Demo Background',
-                notificationPriority: tl.NotificationPriority.high,
-                showNotificationOnPauseOnly:
-                    true, // ✨ Smart Visibility — hide while app is foregrounded
-              )
-            : const tl.ForegroundServiceConfig(enabled: false),
-        scheduleUseAlarmManager: _isAndroid, // Android-only: exact alarms
-      ),
-      ios: tl.IosConfig(
-        activityType: _isAndroid
-            ? tl.LocationActivityType.other
-            : tl.LocationActivityType.otherNavigation,
-        preventSuspend: !_isAndroid, // iOS-only: silent-audio keep-alive
-        useBackgroundActivitySession: !_isAndroid, // iOS 17+: Dynamic Island
-        liveActivityConfig: !_isAndroid
-            ? const tl.LiveActivityConfig(
-                title: 'Tracelet Active',
-                body: 'Tracking your route in background',
-              )
-            : null,
-      ),
-      motion: const tl.MotionConfig(
-        stopTimeout: 1, // 1 minute for fast stop-timeout testing
-        motionDetectionMode: tl.MotionDetectionMode.smart,
-        shakeThreshold: 2, // prevent ultra-sensitive motion triggering
-        speedStationaryDelay: 30, // Make it quicker for demo testing
-        stationaryPeriodicInterval: 60, // Quick checks when stationary
-      ),
-      http: tl.HttpConfig(
-        url:
-            tl.Tracelet.activeConfig.http.url ??
-            'http://192.168.20.103:8099/locations',
-        autoSyncDelay: 5000,
-      ),
-      audit: const tl.AuditConfig(enabled: true),
-      security: const tl.SecurityConfig(encryptDatabase: true),
-      persistence: const tl.PersistenceConfig(
-        maxDaysToPersist: 7,
-        maxRecordsToPersist: 5000,
-      ),
-      logger: const tl.LoggerConfig(logLevel: tl.LogLevel.verbose, debug: true),
-    );
-  }
+  /// Lives in `demo_config.dart` because the issue cards' run harness applies
+  /// the same baseline before every card run — see [buildDemoConfig].
+  tl.Config _buildConfig() => buildDemoConfig();
 
   Future<void> _initialize() async {
     try {

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -839,6 +839,39 @@ class TraceletSdk private constructor(private val context: Context) {
     // =========================================================================
 
     /**
+     * Reconciles the speed-motion machine with the pace this `start()` is
+     * committed to, for a start that did *not* force MOVING.
+     *
+     * [SpeedMotionManager.start] restores whatever the last session persisted,
+     * and anything but STATIONARY means "moving". Adopting that is right for a
+     * **resume**: a relaunched process has no other record of the pace it was
+     * killed in. It is wrong for a **fresh start()**, which committed a pace from
+     * `motion.isMoving` a few lines earlier — adopting the restored value there
+     * let a previous session's MOVING silently overrule an explicit
+     * `motion.isMoving: false`, and the caller was handed `isMoving=true` from a
+     * start it had asked to begin stationary. `syncCurrentMode()` (#344) has
+     * already read the committed pace by this point, so the seeded
+     * `onAccelStateChange(true)` below then woke the coordinator too — a whole
+     * session in the wrong pace, from stale state the app never asked for.
+     *
+     * A fresh start therefore keeps its committed pace and pushes it *into* the
+     * machine. That has to happen before the last-known-speed seed further down:
+     * a restored MOVING left in place falls to SLOWING on the first low-speed
+     * sample, and SLOWING is still "moving", so it writes `isMoving` back to true.
+     */
+    private fun adoptSpeedMotionPace(isResume: Boolean) {
+        val restoredMoving = speedMotionManager.getCurrentState() != "stationary"
+        if (isResume) {
+            stateManager.isMoving = restoredMoving
+        } else if (restoredMoving) {
+            speedMotionManager.onManualPaceChange(false)
+        }
+        if (::smartMotionCoordinator.isInitialized) {
+            smartMotionCoordinator.onSpeedStateChange(stateManager.isMoving)
+        }
+    }
+
+    /**
      * Starts continuous location tracking.
      *
      * @return Error string if not ready or permission denied, null on success.
@@ -921,13 +954,7 @@ class TraceletSdk private constructor(private val context: Context) {
         
         if (motionMode == com.ikolvi.tracelet.sdk.model.MotionDetectionMode.SPEED) {
             speedMotionManager.start(forceMoving = shouldForceMoving)
-            if (!shouldForceMoving) {
-                val restoredMoving = speedMotionManager.getCurrentState() != "stationary"
-                if (::smartMotionCoordinator.isInitialized) {
-                    smartMotionCoordinator.onSpeedStateChange(restoredMoving)
-                }
-                stateManager.isMoving = restoredMoving
-            }
+            if (!shouldForceMoving) adoptSpeedMotionPace(isResume)
             locationEngine.speedMotionSpeedSink = { speed -> speedMotionManager.onLocation(speed) }
             
             // Feed the last known GPS speed immediately on startup to prevent deadlocks when physically stationary
@@ -949,13 +976,7 @@ class TraceletSdk private constructor(private val context: Context) {
             // MOVING again until the process was killed.
             smartMotionCoordinator.syncCurrentMode()
             speedMotionManager.start(forceMoving = shouldForceMoving)
-            if (!shouldForceMoving) {
-                val restoredMoving = speedMotionManager.getCurrentState() != "stationary"
-                if (::smartMotionCoordinator.isInitialized) {
-                    smartMotionCoordinator.onSpeedStateChange(restoredMoving)
-                }
-                stateManager.isMoving = restoredMoving
-            }
+            if (!shouldForceMoving) adoptSpeedMotionPace(isResume)
             locationEngine.speedMotionSpeedSink = { speed -> speedMotionManager.onLocation(speed) }
             
             // Feed the last known GPS speed immediately on startup to prevent deadlocks when physically stationary

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/StartCommittedPaceTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/StartCommittedPaceTest.kt
@@ -1,0 +1,169 @@
+package com.ikolvi.tracelet.sdk
+
+import android.Manifest
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.model.SpeedMotionState
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A fresh `start()` commits a pace from `motion.isMoving`, and the previous
+ * session's persisted speed-motion state must not overrule it.
+ *
+ * [SpeedMotionManager.start] restores that state and treats anything but
+ * STATIONARY as moving. `start()` adopted the restored value unconditionally, so
+ * a session left MOVING — by a real wake-up, or simply by the MOVING default on
+ * a machine that had never transitioned — came back as `isMoving=true` from a
+ * `start()` the app had explicitly asked to begin stationary. Nothing surfaced
+ * the override: the caller saw the state it did not ask for and no reason for
+ * it, and the SMART coordinator had already been synced (#344) against the
+ * committed pace it was about to disagree with.
+ *
+ * Only a *resume* inherits the pace now; a relaunched process has no other
+ * record of what it was killed in, which is what the restore is for.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class StartCommittedPaceTest {
+
+    private lateinit var context: Context
+    private lateinit var sdk: TraceletSdk
+
+    @Before
+    fun setUp() {
+        org.robolectric.shadows.ShadowLog.stream = System.out
+        context = ApplicationProvider.getApplicationContext()
+
+        // start()/stop() touch WorkManager (PeriodicLocationWorker.cancel) — stand
+        // up the in-memory test scheduler so those calls don't throw.
+        androidx.work.testing.WorkManagerTestInitHelper.initializeTestWorkManager(
+            context,
+            androidx.work.Configuration.Builder()
+                .setExecutor(androidx.work.testing.SynchronousExecutor())
+                .build(),
+        )
+
+        shadowOf(context as android.app.Application).grantPermissions(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+            Manifest.permission.ACTIVITY_RECOGNITION,
+        )
+
+        sdk = TraceletSdk.getInstance(context)
+        sdk.setEventSender(ListenerEventSender())
+        sdk.initialize()
+    }
+
+    @After
+    fun tearDown() {
+        try { sdk.stop() } catch (_: Exception) {}
+        idle()
+        ConfigManager.resetInstance()
+    }
+
+    private fun idle() = shadowOf(Looper.getMainLooper()).idle()
+
+    /** ready() with a committed pace of [isMoving], in [mode] (1=SPEED, 2=SMART). */
+    private fun ready(mode: Int, isMoving: Boolean) {
+        var done = false
+        sdk.ready(
+            mapOf(
+                "motionDetectionMode" to mode,
+                "foregroundService" to false,
+                "stopOnStationary" to false,
+                "isMoving" to isMoving,
+            ),
+        ) { done = true }
+        idle()
+        assertTrue(done, "ready() callback should fire")
+
+        // The SMART coordinator is process-scoped: it outlives stop() and the SDK
+        // is a singleton, so its accelerometer flag survives from whichever test
+        // ran before this one. A leftover accel=true makes any speed input read as
+        // "still moving" and wakes the session for reasons this test is not about.
+        // Park both inputs explicitly — the same thing a previous session settling
+        // to stationary does in the field.
+        sdk.changePace(false)
+        idle()
+    }
+
+    /** What a previous session that ended moving leaves behind. */
+    private fun leaveSpeedMachineMoving() {
+        sdk.stateManager.speedMotionState = SpeedMotionState.MOVING
+    }
+
+    @Test
+    fun `SMART start does not inherit a restored moving pace`() {
+        ready(mode = 2, isMoving = false)
+        leaveSpeedMachineMoving()
+
+        sdk.start()
+        idle()
+
+        assertFalse(
+            sdk.stateManager.isMoving,
+            "motion.isMoving:false was committed by start(); a stale MOVING must not override it",
+        )
+        assertEquals(
+            SpeedMotionState.STATIONARY,
+            sdk.stateManager.speedMotionState,
+            "the machine itself must be brought in line, not just the flag — a " +
+                "MOVING machine falls to SLOWING on the first low-speed fix and " +
+                "writes isMoving back to true",
+        )
+    }
+
+    @Test
+    fun `SPEED start does not inherit a restored moving pace`() {
+        ready(mode = 1, isMoving = false)
+        leaveSpeedMachineMoving()
+
+        sdk.start()
+        idle()
+
+        assertFalse(sdk.stateManager.isMoving)
+        assertEquals(SpeedMotionState.STATIONARY, sdk.stateManager.speedMotionState)
+    }
+
+    @Test
+    fun `a resume still inherits the restored moving pace`() {
+        ready(mode = 2, isMoving = false)
+        leaveSpeedMachineMoving()
+        // A resume does not re-read motion.isMoving; the persisted machine is the
+        // only record of the pace the killed process was in.
+        sdk.stateManager.isMoving = false
+
+        sdk.start(isResume = true)
+        idle()
+
+        assertTrue(
+            sdk.stateManager.isMoving,
+            "a relaunched process must come back up in the pace it was killed in",
+        )
+    }
+
+    @Test
+    fun `a moving committed pace is unaffected`() {
+        ready(mode = 2, isMoving = true)
+        sdk.stateManager.speedMotionState = SpeedMotionState.STATIONARY
+
+        sdk.start()
+        idle()
+
+        assertTrue(
+            sdk.stateManager.isMoving,
+            "motion.isMoving:true forces MOVING — the restore path is skipped entirely",
+        )
+    }
+}

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -482,9 +482,9 @@ public final class TraceletSdk {
         let motionMode = configManager.getMotionDetectionMode()
 
         if motionMode == .speed {
-            startSpeedMotionManager(forceMoving: shouldForceMoving)
+            startSpeedMotionManager(forceMoving: shouldForceMoving, isResume: isResume)
         } else if motionMode == .smart {
-            startSpeedMotionManager(forceMoving: shouldForceMoving)
+            startSpeedMotionManager(forceMoving: shouldForceMoving, isResume: isResume)
             // Seed the coordinator's accelerometer flag to the state we are
             // actually starting in. The Rust coordinator initialises
             // is_accel_moving = false and on_accel_state_change() early-returns on
@@ -3510,9 +3510,9 @@ public final class TraceletSdk {
             locationEngine.start()
             let motionMode = configManager.getMotionDetectionMode()
             if motionMode == .speed {
-                startSpeedMotionManager(forceMoving: stateManager.isMoving)
+                startSpeedMotionManager(forceMoving: stateManager.isMoving, isResume: true)
             } else if motionMode == .smart {
-                startSpeedMotionManager(forceMoving: stateManager.isMoving)
+                startSpeedMotionManager(forceMoving: stateManager.isMoving, isResume: true)
                 motionDetector.start()
             } else {
                 motionDetector.start()
@@ -3705,7 +3705,11 @@ public final class TraceletSdk {
         }
     }
 
-    private func startSpeedMotionManager(forceMoving: Bool = false) {
+    /// - Parameter isResume: true when the SDK is picking a session back up
+    ///   (relaunch / auto-resume) rather than the app asking for a fresh one.
+    ///   Only a resume inherits the previous session's pace — see the reconcile
+    ///   step below.
+    private func startSpeedMotionManager(forceMoving: Bool = false, isResume: Bool = false) {
         let smm = SpeedMotionManager(stateManager: stateManager)
         smm.speedMovingThreshold = configManager.getSpeedMovingThreshold()
         smm.speedStationaryDelay = configManager.getSpeedStationaryDelay()
@@ -3715,6 +3719,26 @@ public final class TraceletSdk {
         smm.delegate = self
         smm.start(forceMoving: forceMoving)
         speedMotionManager = smm
+
+        // The machine outlives a session: start() above restored whatever the
+        // last one persisted, and anything but .stationary means "moving".
+        // Inheriting that is right for a resume — a relaunched process has no
+        // other record of the pace it was killed in — and wrong for a fresh
+        // start(), which committed a pace from `motion.isMoving` a few lines
+        // earlier. Adopting the restored value there let a previous session's
+        // MOVING silently overrule an explicit `motion.isMoving: false`, so the
+        // caller was handed isMoving=true from a start it had asked to begin
+        // stationary, with syncCurrentMode() (#344) having already read the
+        // committed pace.
+        //
+        // This must precede the last-known-speed seed below: a restored .moving
+        // left in place falls to .slowing on the first low-speed fix, and
+        // .slowing is still "moving", so it writes isMoving back to true.
+        if !forceMoving && !isResume && smm.state != .stationary {
+            TraceletLog.debug(
+                "[Tracelet] start() committed a stationary pace — overriding restored \(smm.state.name)")
+            smm.onManualPaceChange(isMoving: false)
+        }
 
         // Feed CLLocation.speed to the state machine on every fix
         locationEngine.speedSink = { [weak smm] speed in


### PR DESCRIPTION
Started from a report that the #344 example card was failing on Android. It turned out to be three separate things, one of them a real SDK bug.

## `start()` adopted the previous session's pace — fixes #348

`SpeedMotionManager.start()` restores whatever the last session persisted, and anything but `STATIONARY` counts as moving. `start()` took that value unconditionally, so a session left MOVING — or one that never transitioned, since the machine defaults to MOVING — made the next `start()` return `isMoving=true` even though the app had committed `motion.isMoving: false` two lines earlier. Nothing reported the override.

It compounds with #344: `syncCurrentMode()` runs *before* that block and reads the committed (stationary) pace, so the coordinator was left on the stationary posture while `isMoving` said moving, and the seeded `onAccelStateChange(true)` below then switched the session to continuous — a whole session in a pace the app never asked for.

A **resume** still inherits; a relaunched process has no other record of what it was killed in, which is what the restore is for. A fresh `start()` keeps its committed pace and pushes it into the machine, which has to happen before the last-known-speed seed: a restored MOVING left in place falls to SLOWING on the first low-speed fix, and SLOWING is still "moving", so it would write `isMoving` back to true. Both platforms had the identical mapping; both are fixed, and the two copies of the block (SPEED and SMART) are now one `adoptSpeedMotionPace()`.

## The #344 card checks its precondition

The card needs a session that is *actually* parked, and a device that is genuinely moving denies it. That used to print a red row whose advice — check that `motion.isMoving:false` reached the platform — named the wrong thing, followed by a vacuous green row and a second red one, all three artefacts of the unmet precondition rather than a regression. It now reports **inconclusive** and says which of the two denied it.

## Issue cards no longer depend on the home page

Two things a card could not rely on:

- **The SDK was not ready.** Cards that never call `ready()` get `PlatformException(NOT_READY)` and report it as a failure of the issue under test. The workaround was pressing Initialize on the home page first.
- **The config was whatever ran last.** `ready()` and `setConfig()` both *merge*, so a card that sets two keys inherits every other key from the home page (if Initialize was pressed), from SDK defaults (if not), plus anything a previously-run card changed. The demo config is a materially different SDK from the defaults — `shakeThreshold: 2` against 2.5, `stopTimeout: 1`, `speedStationaryDelay: 30` — which is exactly the kind of skew that makes a spurious motion wake more likely.

`IssueCardShell` now runs `prepareIssueRun()` before the card body: request location authorization if it has never been decided, then `ready()` with the demo config. Cards keep the configuration they were written and verified against, get it from a cold start, and get the same one regardless of run order. A card needing something else still says so afterwards and wins. Opt out with `prepare: false`.

## Verification

- New `StartCommittedPaceTest` (4 cases: SMART and SPEED ignore a restored MOVING — asserting the *machine* lands on STATIONARY, not just the flag — resume still inherits, `isMoving: true` unaffected). Negative control: reverting the guard fails the two new-behaviour cases and leaves the other two passing.
- Full Android unit suite green. iOS `xcodebuild test`: 98 tests, 0 failures. `melos format` + `melos analyze` clean.
- On device (Android, sitting still): the #344 card passes all three rows, with `session: start … isMoving=false` → `speed-motion: STATIONARY -> MOVING` → `smart-motion: switching to CONTINUOUS` in the trace.

**Not yet verified on device:** the `prepareIssueRun()` harness — the phone disconnected before the cold-start run (open the Issues page without pressing Initialize and run any card). Worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
