### PR TITLE
fix(headless): a spawn that does not complete must say so, and the headless sync body must be reachable (#331, #340)

### DIFF
--- a/example/lib/issues/issue_331_card.dart
+++ b/example/lib/issues/issue_331_card.dart
@@ -1,0 +1,292 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #331 — after task removal the headless Dart task was intermittently
+/// never invoked, and the failure was completely silent.
+///
+/// Native tracking kept running and kept producing fixes every 2–4 s; the
+/// registered callback simply never fired, on roughly half of the attempts,
+/// with no error at any log level. The reporter's two runs came from the same
+/// PID four minutes apart and differed only in whether a headless FlutterEngine
+/// ever attached.
+///
+/// The routing itself was fine — `LocationService.startBootTracking` builds an
+/// `EventDispatcher` whose `headlessFallback` reaches
+/// `HeadlessTaskService.dispatchEvent`. Everything past that point was
+/// unobservable. Between `dispatchEvent` and `FlutterEngine(context)` there was
+/// exactly **one** log line — "No headless callbacks registered" — and the
+/// report confirmed it was absent, which left "no engine, no error" as the
+/// whole of the evidence.
+///
+/// Four defects sat behind that silence, all fixed here:
+///
+/// * `ensureEngine()` opened with `if (flutterEngine != null) return`. An
+///   engine that was created but whose Dart side never signalled `initialized`
+///   made every later event a no-op **forever** — no timeout, no retry, no log.
+/// * The spawn ran a **fresh** `FlutterLoader()` on the main thread and blocked
+///   it in `ensureInitializationComplete()`. That re-runs full Flutter
+///   initialization (the "FlutterJNI.loadLibrary called more than once" warning
+///   visible in the reporter's *working* run) and waits on its init future. It
+///   now uses the process-wide `FlutterInjector.instance().flutterLoader()`,
+///   which is already initialized in a process that has run the app, so both
+///   calls return immediately.
+/// * The failure handler caught `Exception`, so an `Error` — an
+///   `UnsatisfiedLinkError` from a native load, for one — escaped it unseen.
+///   It catches `Throwable` now.
+/// * `pendingEvents` was unbounded and a failed spawn called `destroy()`, which
+///   cleared it. So events either accumulated without limit or were thrown away
+///   wholesale. The queue is capped at 200 with oldest-first eviction, and a
+///   failed spawn keeps what it buffered for the next attempt.
+///
+/// A stalled spawn is now abandoned after 30 s and retried, and every branch
+/// records itself on the **lifecycle** channel, which is never level-gated —
+/// the reports that motivated this are release builds where every debug line is
+/// dropped before it reaches the store. The stage it reached is in the message,
+/// so one run names the broken link:
+///
+/// ```text
+/// headless: spawning a FlutterEngine (3 event(s) queued)
+/// headless: engine ready — draining 3 queued event(s)
+/// headless: engine spawn STALLED at stage POSTED after 30001ms — retrying
+/// headless: engine spawn FAILED at stage LOADER_READY — <cause>
+/// ```
+///
+/// **What this card can prove.** Only a real task removal exercises the
+/// headless path, and no foreground card can swipe itself out of recents. So it
+/// runs in two phases and tells you which one it is in:
+///
+/// 1. **Arm** — clears the log, starts tracking, and asks you to swipe the app
+///    away, leave it a minute, then reopen and press Run again.
+/// 2. **Verify** — reads the lifecycle trail the killed-state process left and
+///    classifies it: the engine came up, or it failed and *said so*, or the
+///    #331 signature (a spawn with no outcome at all) is back.
+///
+/// It reports what the trail contains rather than inferring a pass from
+/// tracking having survived, and an absent `boot-tracking: bootstrapping`
+/// anchor is reported as "the background pipeline never came up" — a different
+/// bug from this one, in a different layer.
+///
+/// Android only: iOS has no headless FlutterEngine, and its background
+/// relaunch runs the app's own handlers.
+class Issue331Card extends StatefulWidget {
+  const Issue331Card({super.key});
+
+  @override
+  State<Issue331Card> createState() => _Issue331CardState();
+}
+
+class _Issue331CardState extends State<Issue331Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  static const _spawning = 'headless: spawning a FlutterEngine';
+  static const _ready = 'headless: engine ready';
+  static const _stalled = 'headless: engine spawn STALLED';
+  static const _failed = 'headless: engine spawn FAILED';
+  static const _bootTracking = 'boot-tracking: bootstrapping';
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    try {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+        _set(
+          'ℹ️ Not applicable on this platform. #331 is the Android headless '
+          'FlutterEngine spawn; iOS relaunches the app itself and runs its own '
+          'handlers, and web has no headless isolate at all.',
+        );
+        return;
+      }
+
+      // The precondition, checked rather than assumed: main() registers the
+      // task before runApp, but a build that skipped it would produce the
+      // reported symptom for an entirely ordinary reason.
+      check(
+        'a headless task is registered in this isolate',
+        Tracelet.isHeadlessRegistered,
+        Tracelet.isHeadlessRegistered
+            ? 'registerHeadlessTask() ran at startup — the native side has a '
+                  'callback handle to invoke'
+            : 'no headless task registered, so nothing below can fire. This is '
+                  'the ordinary explanation for "headless never runs" and it '
+                  'is not #331.',
+      );
+
+      final logs = await Tracelet.getLogs(500);
+      final lifecycle = logs
+          .where((e) => e.level.toUpperCase() == 'LIFECYCLE')
+          .toList();
+      bool sawLifecycle(String needle) =>
+          lifecycle.any((e) => e.message.contains(needle));
+
+      // Phase detection from the trail itself: the arm phase clears the log, so
+      // a boot-tracking entry can only have come from a killed-state run since
+      // then. No extra state to persist, and no way to be in the wrong phase
+      // because of how the app was driven before.
+      if (!sawLifecycle(_bootTracking)) {
+        await Tracelet.clearLogs();
+        await Tracelet.start();
+        _set(
+          'ARMED — now do the task removal.\n\n'
+          '${results.join('\n')}\n\n'
+          '1. Swipe this app away from recents (do NOT force-stop it).\n'
+          '2. Leave the device for ~60 s. Move it if you can: fixes are what '
+          'drive a headless dispatch.\n'
+          '3. Reopen the app and press Run again.\n\n'
+          'The log was cleared just now, so everything the verify phase reads '
+          'was written by the killed-state process. Tracking is running and '
+          'stopOnTerminate is false, so the foreground service survives the '
+          'swipe — that is the state the report was filed from.\n\n'
+          'What you are reproducing: the reporter saw this fail on roughly '
+          'half of the attempts on an API 36 emulator, in a release build, in '
+          'an app with several other Flutter engines (firebase_messaging, '
+          'flutter_local_notifications, background_downloader). A single '
+          'successful run here does not disprove the intermittency — what the '
+          'fix guarantees is that a failed one now says so.',
+        );
+        return;
+      }
+
+      // ── Verify phase ─────────────────────────────────────────────────────
+      check(
+        'the background pipeline came up after task removal',
+        true,
+        'boot-tracking: bootstrapping is in the trail, so the foreground '
+            'service restarted tracking natively — the precondition for any '
+            'headless dispatch',
+      );
+
+      final spawning = sawLifecycle(_spawning);
+      final ready = sawLifecycle(_ready);
+      final stalled = sawLifecycle(_stalled);
+      final failed = sawLifecycle(_failed);
+
+      if (!spawning) {
+        // Nothing asked for an engine. That is upstream of #331: the event
+        // never reached HeadlessTaskService.dispatchEvent at all.
+        check(
+          'a headless dispatch was attempted',
+          false,
+          'no "spawning a FlutterEngine" entry. The killed-state pipeline ran '
+              'but no event reached the headless service — so routing broke '
+              'before it, not the spawn. Check that the boot EventDispatcher '
+              'has its headlessFallback wired and that the run produced '
+              'location fixes at all (a stationary device under a distance '
+              'filter may simply have had nothing to dispatch).',
+        );
+      } else if (ready) {
+        check(
+          '#331 the headless engine came up and drained its queue',
+          true,
+          'spawn → ready, with the queued events delivered. This is the '
+              'working path; the events buffered during the spawn were not '
+              'lost waiting for it.',
+        );
+      } else if (stalled || failed) {
+        // The engine did not come up — but this is the fix working. The old
+        // build produced this exact outcome with nothing written at all.
+        check(
+          '#331 a spawn that did not complete identifies itself',
+          true,
+          'the engine never became ready, and the trail names the stage it '
+              'died at instead of leaving "no engine, no error". Read the '
+              'matching entry below: STALLED at POSTED means the main thread '
+              'never ran the spawn block; LOADER_READY or later means Flutter '
+              'came up and the engine or its Dart entrypoint did not.',
+        );
+        results.add(
+          'ℹ️ the engine did not come up on this run. That is the reported '
+          'failure — now diagnosable rather than silent. It is also recoverable: '
+          'the next event starts a fresh spawn and delivers what was buffered.',
+        );
+      } else {
+        check(
+          '#331 a spawn always reaches an outcome',
+          false,
+          'REGRESSED — "spawning a FlutterEngine" with no ready, no STALLED '
+              'and no FAILED after it. This is the original #331 signature: an '
+              'engine was asked for and nothing ever said what became of it. '
+              'The 30 s stall timeout should have fired on the next dispatched '
+              'event.',
+        );
+      }
+
+      final headlessTrail = lifecycle
+          .where((e) => e.message.startsWith('headless:'))
+          .toList();
+      if (headlessTrail.isNotEmpty) {
+        results.add(
+          'ℹ️ what a bug report would now carry:\n'
+          '${headlessTrail.take(10).map((e) => '  • ${e.message}').join('\n')}',
+        );
+      }
+
+      final dropped = logs
+          .where((e) => e.message.contains('headless: queue full'))
+          .toList();
+      if (dropped.isNotEmpty) {
+        results.add(
+          'ℹ️ the pending-event queue hit its 200-event cap during this run '
+          '(${dropped.length} drop entries). Oldest-first, so the freshest '
+          'events survived. Before the fix the queue was unbounded and grew by '
+          'one entry per fix for the life of the process.',
+        );
+      }
+
+      final header = allPass
+          ? '✅ SUCCESS: the headless spawn reached a recorded outcome.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Scope: this reads the lifecycle trail the killed-state process wrote, '
+        'which is the only Dart-visible evidence of a native spawn — the '
+        'headless engine has no API surface. It cannot force the intermittency, '
+        'so a green run means "this attempt reached an outcome", not "the '
+        'race is gone". Run it several times.\n\n'
+        'The recovery paths themselves are pinned by JVM tests that drive the '
+        'real HeadlessTaskService — HeadlessEngineSpawnRecoveryTest covers a '
+        'failed spawn keeping its queued events, a stalled spawn being '
+        'abandoned and retried, and the queue cap evicting oldest-first.\n\n'
+        'Press Run once more to re-arm: the verify phase leaves the trail in '
+        'place, so the next tap sees it, clears it and starts over.',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'headless task not invoked task removal swipe recents killed state '
+          'FlutterEngine ensureEngine pendingEvents silent no error headless '
+          'engine spawn stalled 331',
+      title: '#331: headless task silently never invoked after task removal',
+      description:
+          'The headless FlutterEngine intermittently never spawned, with no '
+          'error at any level and events piling up unbounded. Arms a task '
+          'removal, then reads the lifecycle trail to say whether the engine '
+          'came up — or which stage it died at.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/issue_340_card.dart
+++ b/example/lib/issues/issue_340_card.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+
+/// Issue #340 — the same app posted its own sync body on Android and the SDK
+/// default on iOS.
+///
+/// The reported iOS request carried the Rust default shape (`location` +
+/// `params`, one location per request) while Android posted the app's batched
+/// `buildTraceletSyncBody()` envelope against the same server. The original
+/// report also claimed `setRouteContext` was dropped on iOS; that part was a
+/// misread of a stale stored row — route context is applied at record time and
+/// is not retroactive, so rows persisted before the call legitimately lack it —
+/// and it was withdrawn. The wrong *body* was real.
+///
+/// **The cause.** `hasCustomSyncBodyBuilder` only ever reflects the
+/// **foreground** isolate: Dart sets it from `setSyncBodyBuilder`. Both
+/// platforms opened `requestSyncBody` with
+///
+/// ```swift
+/// if !hasCustomSyncBodyBuilder { return traceletNoSyncBodyBuilderSentinel }
+/// ```
+///
+/// and only *below* that consulted the headless builder. So a process whose
+/// Dart never ran the app code that calls `setSyncBodyBuilder` — iOS's
+/// background relaunch, launched by a location event with nobody driving the
+/// UI, which is exactly the `resume=true` session the report came from — read
+/// `false` there and posted the default payload, with
+/// `registerHeadlessSyncBodyBuilder`'s callback sitting registered and usable
+/// the whole time.
+///
+/// This example registers the headless builder in `main()` and the foreground
+/// one in `_initialize()`, behind the Initialize button. A relaunched process
+/// runs the first and not the second, which is why the same build posted two
+/// different bodies.
+///
+/// Android was less exposed but had the same ordering: its engine-less
+/// processes are covered by `HeadlessSyncInterceptor`, installed from a
+/// ContentProvider at process start, which routes straight to the headless
+/// builder. That seam does not exist on iOS, and it does not help an *attached*
+/// engine whose Dart has not registered a foreground builder — the gap fixed
+/// here on both platforms.
+///
+/// **What this card can prove.** `setSyncBodyBuilder(null)` puts the SDK into
+/// the exact state the relaunched process is in: no foreground builder, a
+/// headless builder registered. A sync from there must still send the app's
+/// body. The evidence is the always-on `sync-body:` lifecycle line added in
+/// #341, which names which body each sync posted:
+///
+/// ```text
+/// sync-body: posting the app's custom sync body
+/// sync-body: posting the DEFAULT payload — no custom sync body builder reached native
+/// ```
+///
+/// It is written on *transition*, so the card establishes a known source first
+/// and then asserts that clearing the foreground builder does not flip it to
+/// the default payload.
+///
+/// **What it does not prove.** That a real iOS background relaunch behaves this
+/// way — no foreground card can relaunch itself. It reproduces the *state* that
+/// relaunch produces, which is what the fix turns on. The HTTP POST itself may
+/// well fail (the demo URL points at a test server that is probably not
+/// running); that is irrelevant here, because the body is chosen and reported
+/// before the request goes out.
+class Issue340Card extends StatefulWidget {
+  const Issue340Card({super.key});
+
+  @override
+  State<Issue340Card> createState() => _Issue340CardState();
+}
+
+class _Issue340CardState extends State<Issue340Card> {
+  String _status = 'Idle';
+  bool _running = false;
+
+  void _set(String s) {
+    if (mounted) setState(() => _status = s);
+  }
+
+  /// Mirrors `buildTraceletSyncBody` in `main.dart` — the same envelope the
+  /// app's foreground and headless builders both produce. Kept local rather
+  /// than imported: `main.dart` imports this file's tab, and a card should not
+  /// depend on the app shell to run.
+  Map<String, Object?> _body(List<Map<String, Object?>> locations) =>
+      <String, Object?>{
+        'device': 'tracelet-example',
+        'sentAt': DateTime.now().toUtc().toIso8601String(),
+        'locationCount': locations.length,
+        'locations': locations,
+      };
+
+  static const _defaultPayloadMarker = 'posting the DEFAULT payload';
+  static const _customMarker = "posting the app's custom sync body";
+
+  /// Persists one location and syncs, so a body is actually built.
+  Future<void> _syncOnce() async {
+    await Tracelet.insertLocation(<String, Object?>{
+      'coords': <String, Object?>{'latitude': 10.86077, 'longitude': 76.65026},
+      'timestamp': DateTime.now().toUtc().toIso8601String(),
+    });
+    try {
+      await Tracelet.sync();
+    } catch (_) {
+      // The demo URL points at a local test server that may not be running.
+      // The body is chosen and reported before the POST, which is all this
+      // card reads.
+    }
+    await Future<void>.delayed(const Duration(seconds: 2));
+  }
+
+  Future<List<String>> _syncBodyLines() async {
+    final logs = await Tracelet.getLogs(300);
+    return logs
+        .where((e) => e.level.toUpperCase() == 'LIFECYCLE')
+        .map((e) => e.message)
+        .where((m) => m.startsWith('sync-body:'))
+        .toList();
+  }
+
+  Future<void> _run() async {
+    setState(() => _running = true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    try {
+      if (kIsWeb) {
+        _set(
+          'ℹ️ Not applicable on web — there is no native sync pipeline and no '
+          'headless isolate to fall back to.',
+        );
+        return;
+      }
+
+      await Tracelet.clearLogs();
+
+      // 1. Establish a known source: a foreground builder, registered here so
+      //    the card does not depend on the Initialize button having been
+      //    pressed.
+      await Tracelet.setSyncBodyBuilder(
+        (SyncBodyContext context) async => _body(context.locations),
+      );
+      await _syncOnce();
+
+      final afterForeground = await _syncBodyLines();
+      final sawCustom = afterForeground.any((m) => m.contains(_customMarker));
+      check(
+        'a sync reports which body it posted',
+        afterForeground.isNotEmpty,
+        afterForeground.isNotEmpty
+            ? 'sync-body: "${afterForeground.last}"'
+            : 'no sync-body entry at all. Nothing below is conclusive: either '
+                  'no sync ran (is there an http.url configured, and did the '
+                  'insert land?) or the #341 reporting is not reaching the log '
+                  'store.',
+      );
+      if (!sawCustom && afterForeground.isNotEmpty) {
+        results.add(
+          'ℹ️ the source did not transition to "custom" on this run. The line '
+          'is written only when the source *changes*, so a process that was '
+          'already posting the custom body says nothing here — that is '
+          'expected, not a failure.',
+        );
+      }
+
+      // 2. Reproduce the relaunched-process state: no foreground builder, the
+      //    headless one still registered from main().
+      await Tracelet.setSyncBodyBuilder(null);
+      final before = (await _syncBodyLines()).length;
+      await _syncOnce();
+      final after = await _syncBodyLines();
+      final newLines = after.skip(before).toList();
+
+      final fellBackToDefault = newLines.any(
+        (m) => m.contains(_defaultPayloadMarker),
+      );
+      check(
+        '#340 clearing the foreground builder does not fall back to the '
+        'default payload',
+        !fellBackToDefault,
+        fellBackToDefault
+            ? 'REGRESSED — "${newLines.firstWhere((m) => m.contains(_defaultPayloadMarker))}". '
+                  'A headless builder is registered and reachable; this is the '
+                  'reported bug, and on iOS it is what a background relaunch '
+                  'produced on every sync.'
+            : newLines.isEmpty
+            ? 'the posted body did not change source when the foreground '
+                  'builder went away — the headless builder took over silently, '
+                  'which is the fix working'
+            : 'source after clearing: "${newLines.last}"',
+      );
+
+      // Restore the foreground builder so the rest of the app behaves as the
+      // home page expects.
+      await Tracelet.setSyncBodyBuilder(
+        (SyncBodyContext context) async => _body(context.locations),
+      );
+
+      final header = allPass
+          ? '✅ SUCCESS: a registered headless builder serves the body when the '
+                'foreground one is absent.'
+          : '❌ FAILED — see the failing rows below.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Trail from this run:\n'
+        '${after.isEmpty ? '  (none)' : after.map((m) => '  • $m').join('\n')}\n\n'
+        'Scope: this reproduces the *state* an iOS background relaunch leaves '
+        'the SDK in — headless builder registered, foreground builder never '
+        'registered — and checks the body chosen from there. It cannot force a '
+        'real relaunch. The HTTP POST may fail (the demo URL is a local test '
+        'server); the body is chosen and reported before the request, so that '
+        'does not affect the result.\n\n'
+        'On the withdrawn half of the report: route context was never missing '
+        'on iOS. The 250-location batch is ordered oldest-first and the '
+        'boundary was visible inside it — rows before setRouteContext ran '
+        'lacked extras.route_context, rows after it carried it. Route context '
+        'is applied at record time and is not retroactive.\n\n'
+        'The routing decision itself is pinned by SyncBodyHeadlessFallbackTest '
+        '(Android JVM): a registered headless builder is consulted when the '
+        'foreground one is absent, and with nothing registered anywhere the '
+        '#125 immediate sentinel still comes back so the sync posts the '
+        'default payload instead of aborting.',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'sync body builder custom body default payload headless relaunch '
+          'setSyncBodyBuilder registerHeadlessSyncBodyBuilder route context '
+          'ios android parity 340',
+      title:
+          '#340: iOS posted the default payload while a builder was registered',
+      description:
+          'hasCustomSyncBodyBuilder only reflects the foreground isolate, so a '
+          'relaunched process fell back to the SDK default with a headless '
+          'builder registered. Clears the foreground builder and checks which '
+          'body the next sync posts.',
+      status: _status,
+      running: _running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -61,6 +61,7 @@ import 'package:tracelet_example/issues/issue_320_card.dart';
 import 'package:tracelet_example/issues/issue_321_card.dart';
 import 'package:tracelet_example/issues/issue_324_card.dart';
 import 'package:tracelet_example/issues/issue_326_card.dart';
+import 'package:tracelet_example/issues/issue_331_card.dart';
 import 'package:tracelet_example/issues/issue_332_card.dart';
 import 'package:tracelet_example/issues/issue_333_card.dart';
 import 'package:tracelet_example/issues/issue_334_card.dart';
@@ -1745,6 +1746,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                   const Issue334Card(),
                   const Issue333Card(),
                   const Issue332Card(),
+                  const Issue331Card(),
                   const Issue326Card(),
                   const Issue324Card(),
                   const Issue321Card(),

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -66,6 +66,7 @@ import 'package:tracelet_example/issues/issue_332_card.dart';
 import 'package:tracelet_example/issues/issue_333_card.dart';
 import 'package:tracelet_example/issues/issue_334_card.dart';
 import 'package:tracelet_example/issues/issue_335_card.dart';
+import 'package:tracelet_example/issues/issue_340_card.dart';
 import 'package:tracelet_example/issues/issue_344_card.dart';
 import 'package:tracelet_example/issues/issue_346_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
@@ -1742,6 +1743,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                   // stay wrapped in _searchableCard with explicit keywords.
                   const Issue346Card(),
                   const Issue344Card(),
+                  const Issue340Card(),
                   const Issue335Card(),
                   const Issue334Card(),
                   const Issue333Card(),

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
@@ -346,6 +346,31 @@ class TraceletAndroidPlugin :
             // state — returning the sentinel *immediately, touching nothing* is
             // the #125 guarantee, and routing the log through the SDK broke it.
             // TraceletLog falls back to Log.d until a logger is attached.
+            //
+            // #340: before falling through to the default payload, try the
+            // *headless* builder. This flag only ever reflects the foreground
+            // isolate, so a process whose Dart never ran the app code that calls
+            // setSyncBodyBuilder — a background relaunch, or an app opened but
+            // not yet through its own init — reads false here even when
+            // registerHeadlessSyncBodyBuilder is registered and usable. The
+            // routing below is gated on !isEngineAttached, so it could not
+            // rescue an *attached* engine whose Dart simply had not registered.
+            //
+            // `headlessService` is non-null only on the attached primary
+            // instance, so this cannot fire in the never-attached state the
+            // #125 guarantee is about — `context` itself is unset there.
+            val hs = headlessService
+            if (hs != null && !isMainThread() && hs.isSyncBodyBuilderRegistered()) {
+                TraceletLog.debug(
+                    "requestSyncBody: no foreground builder — routing to the headless builder",
+                )
+                return hs.requestCustomSyncBody(
+                    locations,
+                    DART_CALLBACK_TIMEOUT_MS,
+                    sdk.getTelematicsForCustomBuilder(),
+                )
+            }
+
             TraceletLog.debug(
                 "requestSyncBody: no custom sync body builder registered " +
                     "(setSyncBodyBuilder never reached native) — using the default payload",

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessTaskService.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessTaskService.kt
@@ -9,15 +9,18 @@ import com.ikolvi.tracelet.sdk.ConfigManager
 import com.ikolvi.tracelet.sdk.HeadersRefreshable
 import com.ikolvi.tracelet.sdk.HeadlessDispatcher
 import com.ikolvi.tracelet.sdk.sync.NO_SYNC_BODY_BUILDER_SENTINEL
+import com.ikolvi.tracelet.sdk.util.TraceletLog
+import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
-import io.flutter.embedding.engine.loader.FlutterLoader
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.view.FlutterCallbackInformation
+import android.os.SystemClock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Headless Dart execution service for background events.
@@ -48,10 +51,46 @@ class HeadlessTaskService(
         private const val METHODS_CHANNEL_NAME = "com.tracelet/methods"
 
         // Context flag to protect against FlutterLoader auto-registering plugins.
-        // Used by TraceletAndroidPlugin.onAttachedToEngine to avoid hijacking the primary 
+        // Used by TraceletAndroidPlugin.onAttachedToEngine to avoid hijacking the primary
         // instance singletons (like dartSyncInterceptor) when a headless engine boots (Issue 136).
         @JvmStatic
         var isSpawningHeadlessEngine = false
+
+        /**
+         * How long a spawn may take before it is declared stalled and retried
+         * (#331). Generous: a cold engine on a loaded device legitimately takes
+         * seconds. What it must not do is wait forever in silence.
+         */
+        internal const val ENGINE_SPAWN_TIMEOUT_MS = 30_000L
+
+        /**
+         * Cap on events buffered while the engine comes up (#331). The queue was
+         * unbounded, so a spawn that never completed grew it for as long as
+         * tracking ran — every 2 s on a continuous config.
+         */
+        internal const val MAX_PENDING_EVENTS = 200
+    }
+
+    /**
+     * How far a spawn attempt got. Named in the stall log so a single bug report
+     * identifies which link broke, instead of leaving "no engine, no error"
+     * (#331).
+     */
+    internal enum class SpawnStage {
+        /** No spawn in flight. */
+        IDLE,
+
+        /** Posted to the main thread; the block has not started. */
+        POSTED,
+
+        /** FlutterLoader initialization completed. */
+        LOADER_READY,
+
+        /** The FlutterEngine object exists; Dart has not signalled back. */
+        ENGINE_CREATED,
+
+        /** Dart called `initialized` — events flow. */
+        READY,
     }
 
     enum class CallbackType(val regKey: String, val dispatchKey: String) {
@@ -60,11 +99,31 @@ class HeadlessTaskService(
         SYNC_BODY("headlessSyncBody_registrationId", "headlessSyncBody_dispatchId")
     }
 
+    @Volatile
     private var flutterEngine: FlutterEngine? = null
     private val mainHandler = Handler(Looper.getMainLooper())
     private val isEngineReady = AtomicBoolean(false)
     private val pendingEvents = LinkedBlockingQueue<Map<String, Any?>>()
+    @Volatile
     private var headlessMethodChannel: MethodChannel? = null
+
+    /**
+     * One spawn at a time (#331). Events arrive from several threads at once
+     * (location, heartbeat, sync); without this each one posted its own spawn
+     * and a second FlutterEngine could overwrite [headlessMethodChannel] out
+     * from under the engine that was about to become ready.
+     */
+    private val spawnInFlight = AtomicBoolean(false)
+
+    @Volatile
+    private var spawnStage = SpawnStage.IDLE
+
+    /** [SystemClock.elapsedRealtime] when the in-flight spawn was posted. */
+    @Volatile
+    private var spawnStartedAtMs = 0L
+
+    /** Events discarded because the queue hit [MAX_PENDING_EVENTS]. */
+    private val droppedEvents = AtomicLong(0)
 
     /** Latch signaled when headless Dart callback calls setDynamicHeaders. */
     @Volatile
@@ -114,16 +173,25 @@ class HeadlessTaskService(
             return
         }
 
-        pendingEvents.add(event)
+        enqueue(event)
         ensureEngine()
     }
 
-    /** Destroy the headless FlutterEngine. */
+    /**
+     * Destroy the headless FlutterEngine and discard anything still queued.
+     *
+     * Only for a real teardown. A *failed spawn* must not come through here —
+     * clearing the queue there threw away every event the engine was being
+     * spawned to deliver (#331); [resetSpawn] keeps them for the next attempt.
+     */
     fun destroy() {
-        headlessMethodChannel = null
-        isEngineReady.set(false)
-        flutterEngine?.destroy()
-        flutterEngine = null
+        val abandoned = pendingEvents.size
+        if (abandoned > 0) {
+            TraceletLog.warning(
+                "headless: destroy() discarding $abandoned undelivered event(s)",
+            )
+        }
+        resetSpawn()
         pendingEvents.clear()
     }
 
@@ -167,7 +235,7 @@ class HeadlessTaskService(
         if (isEngineReady.get() && headlessMethodChannel != null) {
             sendEvent(event)
         } else {
-            pendingEvents.add(event)
+            enqueue(event)
             ensureEngine()
         }
 
@@ -237,7 +305,7 @@ class HeadlessTaskService(
         if (isEngineReady.get() && headlessMethodChannel != null) {
             sendEvent(event)
         } else {
-            pendingEvents.add(event)
+            enqueue(event)
             ensureEngine()
         }
 
@@ -263,10 +331,19 @@ class HeadlessTaskService(
     // =========================================================================
 
     private fun ensureEngine() {
+        // A spawn that never finished used to leave the engine non-null (or the
+        // in-flight flag set) forever, and this method's first line then made
+        // every subsequent event a silent no-op. Give up on it and try again
+        // instead (#331).
+        failStalledSpawn()
+
         if (flutterEngine != null) return
 
+        // One spawn at a time — concurrent dispatches must not each post one.
+        if (!spawnInFlight.compareAndSet(false, true)) return
+
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        
+
         // Try main headless callback first, then fallback to headers or sync body
         var registrationCallbackId = prefs.getLong(CallbackType.MAIN.regKey, -1L)
         if (registrationCallbackId == -1L) {
@@ -277,88 +354,215 @@ class HeadlessTaskService(
         }
 
         if (registrationCallbackId == -1L) {
-            TraceletSdk.getInstance(context).logger.warning("No headless callbacks registered")
+            TraceletLog.warning(
+                "headless: no callbacks registered — dropping ${pendingEvents.size} queued event(s)",
+            )
             pendingEvents.clear()
+            spawnInFlight.set(false)
             return
         }
 
+        spawnStage = SpawnStage.POSTED
+        spawnStartedAtMs = SystemClock.elapsedRealtime()
+        // The anchor for every "headless never fired" report: it says a spawn was
+        // asked for. Its absence means routing never reached this service; its
+        // presence without a matching `engine ready` names the stall (#331).
+        TraceletLog.lifecycle(
+            "headless: spawning a FlutterEngine (${pendingEvents.size} event(s) queued)",
+        )
+
         mainHandler.post {
             try {
-                val loader = FlutterLoader()
-                loader.startInitialization(context)
-                loader.ensureInitializationComplete(context, null)
+                // The process-wide loader, not a fresh FlutterLoader(). A new one
+                // re-runs full Flutter initialization — the source of the
+                // "FlutterJNI.loadLibrary called more than once" warning — and
+                // blocks the main thread on its own init future. Once the app has
+                // started Flutter, both calls below return immediately (#331).
+                val loader = FlutterInjector.instance().flutterLoader()
+                if (!loader.initialized()) {
+                    loader.startInitialization(context)
+                    loader.ensureInitializationComplete(context, null)
+                }
+                spawnStage = SpawnStage.LOADER_READY
 
                 isSpawningHeadlessEngine = true
-                try {
-                    flutterEngine = FlutterEngine(context).also { engine ->
-                    headlessMethodChannel = MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL_NAME)
+                val engine = try {
+                    FlutterEngine(context)
+                } finally {
+                    isSpawningHeadlessEngine = false
+                }
 
-                    // Set up method channel to receive "ready" signal from Dart
-                    headlessMethodChannel?.setMethodCallHandler { call, result ->
-                        when (call.method) {
-                            "initialized" -> {
-                                isEngineReady.set(true)
-                                drainPendingEvents()
-                                result.success(true)
-                            }
-                            else -> result.notImplemented()
+                headlessMethodChannel = MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL_NAME)
+
+                // Set up method channel to receive "ready" signal from Dart
+                headlessMethodChannel?.setMethodCallHandler { call, result ->
+                    when (call.method) {
+                        "initialized" -> {
+                            spawnStage = SpawnStage.READY
+                            isEngineReady.set(true)
+                            spawnInFlight.set(false)
+                            TraceletLog.lifecycle(
+                                "headless: engine ready — draining " +
+                                    "${pendingEvents.size} queued event(s)",
+                            )
+                            drainPendingEvents()
+                            result.success(true)
                         }
-                    }
-
-                    // Handle setDynamicHeaders from headless Dart callback.
-                    // When the Dart headless callback calls Tracelet.setDynamicHeaders(),
-                    // it goes through com.tracelet/methods. We handle it here so the
-                    // headless engine can update headers and signal the refresh latch.
-                    val methodsChannel = MethodChannel(engine.dartExecutor.binaryMessenger, METHODS_CHANNEL_NAME)
-                    methodsChannel.setMethodCallHandler { call, result ->
-                        when (call.method) {
-                            "setDynamicHeaders" -> {
-                                @Suppress("UNCHECKED_CAST")
-                                val headers = (call.arguments as? Map<String, Any?>)
-                                    ?.mapValues { it.value?.toString() ?: "" }
-                                    ?: emptyMap()
-                                configManager?.setDynamicHeaders(headers)
-                                headersRefreshLatch?.countDown()
-                                result.success(true)
-                            }
-                            "setSyncBodyResponse" -> {
-                                synchronized(syncBodyLock) {
-                                    syncBodyResponse = call.arguments as? String
-                                }
-                                syncBodyLatch?.countDown()
-                                result.success(true)
-                            }
-                            "requestTermination" -> {
-                                try {
-                                    TraceletSdk.getInstance(context).stop()
-                                    result.success(true)
-                                } catch (e: Exception) {
-                                    result.error("STOP_FAILED", e.message, null)
-                                }
-                            }
-                            else -> result.notImplemented()
-                        }
-                    }
-
-                    // Execute the registration callback in Dart
-                    val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(registrationCallbackId)
-                    if (callbackInfo != null) {
-                        engine.dartExecutor.executeDartCallback(
-                            DartExecutor.DartCallback(context.assets, loader.findAppBundlePath(), callbackInfo)
-                        )
-                    } else {
-                        TraceletSdk.getInstance(context).logger.error("Could not find callback info for ID: $registrationCallbackId")
-                        destroy()
+                        else -> result.notImplemented()
                     }
                 }
-            } finally {
-                isSpawningHeadlessEngine = false
-            }
-        } catch (e: Exception) {
-                TraceletSdk.getInstance(context).logger.error("Failed to create headless FlutterEngine: ${e.message}")
-                destroy()
+
+                // Handle setDynamicHeaders from headless Dart callback.
+                // When the Dart headless callback calls Tracelet.setDynamicHeaders(),
+                // it goes through com.tracelet/methods. We handle it here so the
+                // headless engine can update headers and signal the refresh latch.
+                val methodsChannel = MethodChannel(engine.dartExecutor.binaryMessenger, METHODS_CHANNEL_NAME)
+                methodsChannel.setMethodCallHandler { call, result ->
+                    when (call.method) {
+                        "setDynamicHeaders" -> {
+                            @Suppress("UNCHECKED_CAST")
+                            val headers = (call.arguments as? Map<String, Any?>)
+                                ?.mapValues { it.value?.toString() ?: "" }
+                                ?: emptyMap()
+                            configManager?.setDynamicHeaders(headers)
+                            headersRefreshLatch?.countDown()
+                            result.success(true)
+                        }
+                        "setSyncBodyResponse" -> {
+                            synchronized(syncBodyLock) {
+                                syncBodyResponse = call.arguments as? String
+                            }
+                            syncBodyLatch?.countDown()
+                            result.success(true)
+                        }
+                        "requestTermination" -> {
+                            try {
+                                TraceletSdk.getInstance(context).stop()
+                                result.success(true)
+                            } catch (e: Exception) {
+                                result.error("STOP_FAILED", e.message, null)
+                            }
+                        }
+                        else -> result.notImplemented()
+                    }
+                }
+
+                // Execute the registration callback in Dart
+                val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(registrationCallbackId)
+                if (callbackInfo == null) {
+                    // Nothing can ever consume these events: the callback the
+                    // engine exists to run is gone from the app bundle.
+                    TraceletLog.lifecycle(
+                        "headless: no callback info for ID $registrationCallbackId — " +
+                            "the registered Dart entrypoint is gone from this build",
+                    )
+                    headlessMethodChannel = null
+                    engine.destroy()
+                    destroy()
+                    return@post
+                }
+
+                engine.dartExecutor.executeDartCallback(
+                    DartExecutor.DartCallback(context.assets, loader.findAppBundlePath(), callbackInfo)
+                )
+                // Published only once the engine is fully wired. Assigning it
+                // before this point (as the `.also {}` form did) meant a failure
+                // inside the block still left a non-null engine behind, and
+                // ensureEngine()'s null check then blocked every retry (#331).
+                flutterEngine = engine
+                spawnStage = SpawnStage.ENGINE_CREATED
+            } catch (t: Throwable) {
+                // Throwable, not Exception: a failed native load arrives as
+                // UnsatisfiedLinkError, which escaped this handler unseen and left
+                // the caller with no engine and no error at any level (#331).
+                TraceletLog.lifecycle(
+                    "headless: engine spawn FAILED at stage $spawnStage — ${t.message}",
+                )
+                TraceletLog.error("Failed to create headless FlutterEngine", t)
+                // resetSpawn, not destroy: the queued events are what the engine
+                // was being spawned to deliver. Keep them for the next attempt.
+                resetSpawn()
             }
         }
+    }
+
+    /**
+     * Abandons an in-flight spawn that has outlived [ENGINE_SPAWN_TIMEOUT_MS] so
+     * the next event can start a fresh one (#331).
+     *
+     * The reported failure was permanent: whatever the main thread was doing —
+     * blocked, or never running the posted block at all — no timeout, retry, or
+     * log ever followed, and events accumulated for as long as tracking ran. The
+     * stage recorded here is the diagnostic: it names how far the attempt got.
+     */
+    private fun failStalledSpawn() {
+        if (!spawnInFlight.get() || isEngineReady.get()) return
+        val startedAt = spawnStartedAtMs
+        if (startedAt == 0L) return
+        val elapsed = SystemClock.elapsedRealtime() - startedAt
+        if (elapsed < ENGINE_SPAWN_TIMEOUT_MS) return
+
+        TraceletLog.lifecycle(
+            "headless: engine spawn STALLED at stage $spawnStage after ${elapsed}ms — " +
+                "retrying (${pendingEvents.size} event(s) queued)",
+        )
+        resetSpawn()
+    }
+
+    /**
+     * Returns to a spawnable state, keeping [pendingEvents] intact. Unlike
+     * [destroy] this is recoverable: the next dispatched event starts a new
+     * spawn and drains everything buffered in the meantime.
+     */
+    private fun resetSpawn() {
+        val engine = flutterEngine
+        flutterEngine = null
+        headlessMethodChannel = null
+        isEngineReady.set(false)
+        spawnStage = SpawnStage.IDLE
+        spawnStartedAtMs = 0L
+        spawnInFlight.set(false)
+        // FlutterEngine.destroy() is main-thread-only; failStalledSpawn runs on
+        // whichever thread produced the event.
+        if (engine != null) {
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                engine.destroy()
+            } else {
+                mainHandler.post { engine.destroy() }
+            }
+        }
+    }
+
+    /**
+     * Buffers an event for the engine that is coming up, capped at
+     * [MAX_PENDING_EVENTS].
+     *
+     * The queue was unbounded (#331): a spawn that never completed grew it by one
+     * entry per location fix — every 2 s under the reporter's config — for the
+     * life of the process. Oldest-first eviction keeps the freshest events, and
+     * the drop is reported rather than silent.
+     */
+    private fun enqueue(event: Map<String, Any?>) {
+        var dropped = 0
+        while (pendingEvents.size >= MAX_PENDING_EVENTS) {
+            if (pendingEvents.poll() == null) break
+            dropped++
+        }
+        if (dropped > 0) {
+            val total = droppedEvents.addAndGet(dropped.toLong())
+            if (total == dropped.toLong()) {
+                // Once per queue, on the always-on channel: a report showing this
+                // has a headless engine that never came up.
+                TraceletLog.lifecycle(
+                    "headless: pending-event queue hit its $MAX_PENDING_EVENTS cap — " +
+                        "dropping the oldest events while stage $spawnStage",
+                )
+            }
+            TraceletLog.warning(
+                "headless: queue full — dropped $dropped event(s) (total $total)",
+            )
+        }
+        pendingEvents.add(event)
     }
 
     private fun drainPendingEvents() {

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessTaskService.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessTaskService.kt
@@ -151,6 +151,19 @@ class HeadlessTaskService(
     }
 
     /**
+     * Whether `registerHeadlessSyncBodyBuilder` has persisted a callback pair.
+     *
+     * A SharedPreferences read and nothing else (#340): it is consulted from
+     * `requestSyncBody`'s earliest branch, which must stay cheap and must not
+     * reach into the SDK.
+     */
+    fun isSyncBodyBuilderRegistered(): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getLong(CallbackType.SYNC_BODY.regKey, -1L) != -1L &&
+            prefs.getLong(CallbackType.SYNC_BODY.dispatchKey, -1L) != -1L
+    }
+
+    /**
      * Dispatch a headless event. If no UI engine is available, creates
      * a new FlutterEngine to handle the event.
      *

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/SyncBodyHeadlessFallbackTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/SyncBodyHeadlessFallbackTest.kt
@@ -1,0 +1,159 @@
+package com.ikolvi.tracelet.flutter
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.flutter.service.HeadlessTaskService
+import com.ikolvi.tracelet.sdk.TraceletSdk
+import com.ikolvi.tracelet.sdk.sync.NO_SYNC_BODY_BUILDER_SENTINEL
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.BinaryMessenger
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for #340 — the same app posted its own sync body on Android
+ * and the SDK default on iOS.
+ *
+ * `hasCustomSyncBodyBuilder` only ever reflects the **foreground** isolate. A
+ * process whose Dart never ran the app code that calls `setSyncBodyBuilder` —
+ * a background relaunch, or an app opened but not yet through its own init —
+ * reads `false` there even when `registerHeadlessSyncBodyBuilder` is registered
+ * and perfectly usable. That branch returned the sentinel before the
+ * headless routing further down could be reached, so the device posted the
+ * default payload with a custom builder sitting available in preferences.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SyncBodyHeadlessFallbackTest {
+
+    private lateinit var context: Context
+    private lateinit var mockSdk: TraceletSdk
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        resetPluginStatics()
+        HeadlessTaskService.isSpawningHeadlessEngine = false
+        TraceletAndroidPlugin.hasCustomSyncBodyBuilder = false
+
+        // A mock SDK singleton: attaching as the primary instance otherwise
+        // runs the real initialize(), which needs the native core.
+        mockSdk = mock(TraceletSdk::class.java)
+        `when`(mockSdk.logger).thenReturn(mock(com.ikolvi.tracelet.sdk.util.TraceletLogger::class.java))
+        sdkInstanceField().set(null, mockSdk)
+    }
+
+    @After
+    fun tearDown() {
+        sdkInstanceField().set(null, null)
+        resetPluginStatics()
+        TraceletAndroidPlugin.hasCustomSyncBodyBuilder = false
+    }
+
+    private fun sdkInstanceField() =
+        TraceletSdk::class.java.getDeclaredField("instance").apply { isAccessible = true }
+
+    private fun resetPluginStatics() {
+        TraceletAndroidPlugin::class.java.getDeclaredField("primaryInstance")
+            .apply { isAccessible = true }
+            .set(null, null)
+        val counter = TraceletAndroidPlugin::class.java.getDeclaredField("attachedEngineCount")
+            .apply { isAccessible = true }
+            .get(null) as java.util.concurrent.atomic.AtomicInteger
+        counter.set(0)
+    }
+
+    private fun registerHeadlessSyncBodyBuilder() {
+        context.getSharedPreferences("com.tracelet.headless", Context.MODE_PRIVATE)
+            .edit()
+            .putLong("headlessSyncBody_registrationId", 7L)
+            .putLong("headlessSyncBody_dispatchId", 8L)
+            .apply()
+    }
+
+    private fun attachedPlugin(): TraceletAndroidPlugin {
+        val binding = mock(FlutterPlugin.FlutterPluginBinding::class.java)
+        `when`(binding.applicationContext).thenReturn(context)
+        `when`(binding.binaryMessenger).thenReturn(mock(BinaryMessenger::class.java))
+        return TraceletAndroidPlugin().also { it.onAttachedToEngine(binding) }
+    }
+
+    @Test
+    fun `the headless sync-body registration is readable without touching the SDK`() {
+        val service = HeadlessTaskService(context)
+        assertFalse(
+            service.isSyncBodyBuilderRegistered(),
+            "nothing registered yet",
+        )
+
+        registerHeadlessSyncBodyBuilder()
+        assertTrue(
+            service.isSyncBodyBuilderRegistered(),
+            "both callback ids are persisted, so the builder is reachable",
+        )
+    }
+
+    /**
+     * The #125 guarantee: with nothing registered anywhere, the sentinel comes
+     * back immediately rather than after a channel timeout, so the sync posts
+     * the default payload instead of aborting.
+     */
+    @Test
+    fun `no builder anywhere still returns the sentinel immediately`() {
+        val plugin = attachedPlugin()
+
+        assertEquals(
+            NO_SYNC_BODY_BUILDER_SENTINEL,
+            plugin.requestSyncBody(emptyList()),
+            "no foreground builder and no headless builder — nothing to route to",
+        )
+    }
+
+    /**
+     * #340: a registered headless builder must be consulted before the default
+     * payload is posted. Before the fix this returned the sentinel in
+     * microseconds; now the call reaches the headless service and waits there
+     * for the Dart response, which no engine can deliver in a unit test.
+     */
+    @Test
+    fun `a registered headless builder is consulted when the foreground one is absent`() {
+        registerHeadlessSyncBodyBuilder()
+        val plugin = attachedPlugin()
+
+        val returned = AtomicReference<String?>(null)
+        val done = java.util.concurrent.CountDownLatch(1)
+        // Off the test thread: the headless path blocks on its response latch,
+        // and requestCustomSyncBody refuses to run on the main thread at all.
+        val caller = Thread {
+            try {
+                returned.set(plugin.requestSyncBody(emptyList()))
+            } catch (_: InterruptedException) {
+                // Expected when the test releases it below.
+            } finally {
+                done.countDown()
+            }
+        }
+        caller.isDaemon = true
+        caller.start()
+
+        val finished = done.await(1, TimeUnit.SECONDS)
+        caller.interrupt()
+
+        assertFalse(
+            finished,
+            "requestSyncBody returned ${returned.get()} straight away — it took the " +
+                "default-payload branch instead of the registered headless builder",
+        )
+    }
+}

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessEngineSpawnRecoveryTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/service/HeadlessEngineSpawnRecoveryTest.kt
@@ -1,0 +1,142 @@
+package com.ikolvi.tracelet.flutter.service
+
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+import java.util.concurrent.LinkedBlockingQueue
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for #331 — the headless task was intermittently never
+ * invoked after task removal, and the failure was completely silent: no engine,
+ * no error at any log level, events accumulating in `pendingEvents` forever.
+ *
+ * These drive the real [HeadlessTaskService]. Under Robolectric a FlutterEngine
+ * cannot actually be created, which is what makes the failure handling itself
+ * testable: the spawn attempt fails the way a device's would.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HeadlessEngineSpawnRecoveryTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        HeadlessTaskService.isSpawningHeadlessEngine = false
+        // Callbacks registered, exactly as registerHeadlessTask() leaves them.
+        context.getSharedPreferences("com.tracelet.headless", Context.MODE_PRIVATE)
+            .edit()
+            .putLong("registration_callback_id", 42L)
+            .putLong("dispatch_callback_id", 43L)
+            .apply()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun pendingEvents(service: HeadlessTaskService): LinkedBlockingQueue<Map<String, Any?>> {
+        val f = HeadlessTaskService::class.java.getDeclaredField("pendingEvents")
+        f.isAccessible = true
+        return f.get(service) as LinkedBlockingQueue<Map<String, Any?>>
+    }
+
+    private fun spawnStage(service: HeadlessTaskService): Any {
+        val f = HeadlessTaskService::class.java.getDeclaredField("spawnStage")
+        f.isAccessible = true
+        return f.get(service)
+    }
+
+    /**
+     * A spawn that fails must not take the queued events with it. They are the
+     * reason the engine was being spawned; the next attempt has to deliver them.
+     */
+    @Test
+    fun `a failed spawn keeps its queued events for the next attempt`() {
+        val service = HeadlessTaskService(context)
+        assertTrue(service.isRegistered(), "precondition: headless callbacks registered")
+
+        service.dispatchEvent("location", mapOf("i" to 0))
+        shadowOf(Looper.getMainLooper()).idle() // the spawn attempt runs and fails
+
+        repeat(9) { i -> service.dispatchEvent("location", mapOf("i" to i + 1)) }
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(
+            10,
+            pendingEvents(service).size,
+            "every event must survive a failed spawn — destroy() used to clear them",
+        )
+    }
+
+    /**
+     * The reported failure was permanent. After a spawn that never completes,
+     * the service must give up on it and be spawnable again rather than treating
+     * a half-built engine as proof that one exists.
+     */
+    @Test
+    fun `a stalled spawn is abandoned and retried instead of stranding events`() {
+        val service = HeadlessTaskService(context)
+
+        // Post the spawn but never run it — the failing device log shows no
+        // main-thread work at all after the swipe.
+        service.dispatchEvent("location", mapOf("i" to 0))
+        assertEquals(
+            HeadlessTaskService.SpawnStage.POSTED,
+            spawnStage(service),
+            "the spawn is in flight and knows how far it got",
+        )
+
+        ShadowSystemClock.advanceBy(
+            Duration.ofMillis(HeadlessTaskService.ENGINE_SPAWN_TIMEOUT_MS + 1),
+        )
+
+        // The next event notices the stall, reports it, and starts over.
+        service.dispatchEvent("location", mapOf("i" to 1))
+        assertEquals(
+            HeadlessTaskService.SpawnStage.POSTED,
+            spawnStage(service),
+            "a fresh spawn was started rather than the stalled one being trusted forever",
+        )
+        assertEquals(
+            2,
+            pendingEvents(service).size,
+            "the retry keeps everything buffered so far",
+        )
+    }
+
+    /**
+     * The queue was unbounded: a continuous config appends one entry every 2 s
+     * for as long as the process lives.
+     */
+    @Test
+    fun `the pending queue is capped rather than growing without limit`() {
+        val service = HeadlessTaskService(context)
+
+        repeat(HeadlessTaskService.MAX_PENDING_EVENTS + 50) { i ->
+            service.dispatchEvent("location", mapOf("i" to i))
+        }
+
+        val queue = pendingEvents(service)
+        assertEquals(
+            HeadlessTaskService.MAX_PENDING_EVENTS,
+            queue.size,
+            "the queue must stop at its cap",
+        )
+        @Suppress("UNCHECKED_CAST")
+        val oldest = queue.peek()?.get("event") as? Map<String, Any?>
+        assertEquals(
+            50,
+            oldest?.get("i"),
+            "eviction is oldest-first, so the freshest events are the ones kept",
+        )
+    }
+}

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/HeadlessRunner.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/HeadlessRunner.swift
@@ -33,10 +33,39 @@ final class HeadlessRunner: HeadlessDispatching {
     private static let channelName = "com.tracelet/headless"
     private static let methodsChannelName = "com.tracelet/methods"
 
+    /// How long a spawn may take before it is declared stalled and retried
+    /// (#331). Generous — a cold engine on a loaded device legitimately takes
+    /// seconds. What it must not do is wait forever in silence.
+    private static let engineSpawnTimeout: TimeInterval = 30
+
+    /// Cap on events buffered while the engine comes up (#331). The queue was
+    /// unbounded, so a spawn that never completed grew it for as long as
+    /// tracking ran.
+    private static let maxPendingEvents = 200
+
+    /// How far a spawn attempt got, named in the stall log so one report
+    /// identifies which link broke (#331).
+    private enum SpawnStage: String {
+        case idle = "IDLE"
+        case posted = "POSTED"
+        case engineCreated = "ENGINE_CREATED"
+        case ready = "READY"
+    }
+
+    /// Guards every field below. `dispatchEvent` arrives on whichever thread
+    /// produced the event (location, sync, heartbeat) while `onEngineReady`
+    /// runs on the platform thread; the Swift Array in particular is not
+    /// thread-safe and was being mutated from both (#331).
+    private let stateLock = NSRecursiveLock()
+
     private var engine: FlutterEngine?
     private var channel: FlutterMethodChannel?
     private var isReady = false
     private var pendingEvents: [[String: Any]] = []
+    private var spawnInFlight = false
+    private var spawnStage: SpawnStage = .idle
+    private var spawnStartedAt: TimeInterval = 0
+    private var droppedEvents = 0
 
     /// Background task protecting engine boot + pending event flush.
     private var engineBootTaskId: UIBackgroundTaskIdentifier?
@@ -64,6 +93,17 @@ final class HeadlessRunner: HeadlessDispatching {
         return defaults.integer(forKey: CallbackType.main.regKey) != 0
     }
 
+    /// Whether `registerHeadlessSyncBodyBuilder` has persisted a callback pair.
+    ///
+    /// Read straight from `UserDefaults` and deliberately touching nothing else
+    /// (#340): it is consulted from `requestSyncBody`'s earliest branch, which
+    /// must stay safe before the SDK has finished initializing.
+    func isSyncBodyBuilderRegistered() -> Bool {
+        let defaults = UserDefaults.standard
+        return defaults.integer(forKey: CallbackType.syncBody.regKey) != 0
+            && defaults.integer(forKey: CallbackType.syncBody.dispatchKey) != 0
+    }
+
     func dispatchEvent(_ event: [String: Any]) {
         // Include the dispatch callback ID so the Dart-side dispatcher
         // can look up the user's headless callback.
@@ -72,26 +112,24 @@ final class HeadlessRunner: HeadlessDispatching {
         var enrichedEvent = event
         enrichedEvent["dispatchId"] = dispatchId
 
-        if isReady, let channel = channel {
-            channel.invokeMethod("headlessEvent", arguments: enrichedEvent)
-        } else {
-            pendingEvents.append(enrichedEvent)
-            // Request background time to complete engine boot + event flush.
-            if engineBootTaskId == nil {
-                engineBootTaskId = BackgroundTaskHelper.shared.begin("headlessEngineBoot")
-            }
-            startEngineIfNeeded()
-        }
+        dispatchOrQueue(enrichedEvent, taskName: "headlessEngineBoot")
     }
 
+    /// Tears the engine down and discards anything still queued.
+    ///
+    /// Only for a real teardown. A *failed spawn* must not come through here —
+    /// clearing the queue there threw away the events the engine was being
+    /// spawned to deliver (#331); ``resetSpawn`` keeps them for the next
+    /// attempt.
     func destroy() {
-        engine?.destroyContext()
-        engine = nil
-        channel = nil
-        isReady = false
+        stateLock.lock()
+        let abandoned = pendingEvents.count
         pendingEvents.removeAll()
-        BackgroundTaskHelper.shared.end(engineBootTaskId)
-        engineBootTaskId = nil
+        stateLock.unlock()
+        if abandoned > 0 {
+            TraceletLog.warning("headless: destroy() discarding \(abandoned) undelivered event(s)")
+        }
+        resetSpawn()
     }
 
     /// Request a headers refresh from the headless Dart callback.
@@ -121,15 +159,7 @@ final class HeadlessRunner: HeadlessDispatching {
             "dispatchId": dispatchId,
         ]
 
-        if isReady, let channel = channel {
-            channel.invokeMethod("headlessEvent", arguments: event)
-        } else {
-            pendingEvents.append(event)
-            if engineBootTaskId == nil {
-                engineBootTaskId = BackgroundTaskHelper.shared.begin("headlessHeadersRefresh")
-            }
-            startEngineIfNeeded()
-        }
+        dispatchOrQueue(event, taskName: "headlessHeadersRefresh")
 
         let result = semaphore.wait(timeout: .now() + timeout)
         headersRefreshSemaphore = nil
@@ -186,15 +216,7 @@ final class HeadlessRunner: HeadlessDispatching {
             "dispatchId": dispatchId,
         ]
 
-        if isReady, let channel = channel {
-            channel.invokeMethod("headlessEvent", arguments: event)
-        } else {
-            pendingEvents.append(event)
-            if engineBootTaskId == nil {
-                engineBootTaskId = BackgroundTaskHelper.shared.begin("headlessSyncBody")
-            }
-            startEngineIfNeeded()
-        }
+        dispatchOrQueue(event, taskName: "headlessSyncBody")
 
         let result = semaphore.wait(timeout: .now() + timeout)
         let response = syncBodyResponse
@@ -210,10 +232,69 @@ final class HeadlessRunner: HeadlessDispatching {
         }
     }
 
+    // MARK: - Queueing
+
+    /// Sends the event if the engine is live, otherwise buffers it and asks for
+    /// an engine — the shared body of the three dispatch entry points.
+    private func dispatchOrQueue(_ event: [String: Any], taskName: String) {
+        stateLock.lock()
+        let liveChannel = isReady ? channel : nil
+        stateLock.unlock()
+
+        if let liveChannel = liveChannel {
+            liveChannel.invokeMethod("headlessEvent", arguments: event)
+            return
+        }
+
+        enqueue(event)
+        stateLock.lock()
+        let needsTask = engineBootTaskId == nil
+        stateLock.unlock()
+        if needsTask {
+            let taskId = BackgroundTaskHelper.shared.begin(taskName)
+            stateLock.lock()
+            engineBootTaskId = taskId
+            stateLock.unlock()
+        }
+        startEngineIfNeeded()
+    }
+
+    /// Buffers an event for the engine that is coming up, capped at
+    /// ``maxPendingEvents`` (#331). The array was unbounded, so a spawn that
+    /// never completed grew it by one entry per fix for the life of the
+    /// process. Oldest-first eviction keeps the freshest events, and the drop
+    /// is reported rather than silent.
+    private func enqueue(_ event: [String: Any]) {
+        stateLock.lock()
+        var dropped = 0
+        while pendingEvents.count >= HeadlessRunner.maxPendingEvents {
+            pendingEvents.removeFirst()
+            dropped += 1
+        }
+        pendingEvents.append(event)
+        droppedEvents += dropped
+        let total = droppedEvents
+        let stage = spawnStage
+        stateLock.unlock()
+
+        guard dropped > 0 else { return }
+        if total == dropped {
+            // Once per queue, on the always-on channel: a report showing this
+            // has a headless engine that never came up.
+            TraceletLog.lifecycle(
+                "headless: pending-event queue hit its \(HeadlessRunner.maxPendingEvents) cap — "
+                    + "dropping the oldest events while stage \(stage.rawValue)")
+        }
+        TraceletLog.warning("headless: queue full — dropped \(dropped) event(s) (total \(total))")
+    }
+
     // MARK: - Engine management
 
     private func startEngineIfNeeded() {
-        guard engine == nil else { return }
+        // A spawn that never finished used to leave `engine` non-null forever,
+        // and this method's guard then made every later event a silent no-op.
+        // Give up on it and try again instead (#331).
+        failStalledSpawn()
 
         let defaults = UserDefaults.standard
         // Try main headless callback first, fall back to headers, then sync body
@@ -224,38 +305,78 @@ final class HeadlessRunner: HeadlessDispatching {
         if registrationId == 0 {
             registrationId = defaults.integer(forKey: CallbackType.syncBody.regKey)
         }
-        
+
+        stateLock.lock()
+        guard engine == nil, !spawnInFlight else {
+            stateLock.unlock()
+            return
+        }
         guard registrationId != 0 else {
-            TraceletSdk.shared.logger.debug("No headless callback registered")
+            let abandoned = pendingEvents.count
+            pendingEvents.removeAll()
+            stateLock.unlock()
+            TraceletLog.warning(
+                "headless: no callbacks registered — dropping \(abandoned) queued event(s)")
             return
         }
+        spawnInFlight = true
+        spawnStage = .posted
+        spawnStartedAt = ProcessInfo.processInfo.systemUptime
+        let queued = pendingEvents.count
+        stateLock.unlock()
 
+        // The anchor for every "headless never fired" report: it says a spawn
+        // was asked for. Its absence means routing never reached this runner;
+        // its presence without a matching `engine ready` names the stall (#331).
+        TraceletLog.lifecycle("headless: spawning a FlutterEngine (\(queued) event(s) queued)")
+
+        // FlutterEngine must be created and run on the main thread. This used
+        // to run on whichever thread produced the event — a location callback
+        // queue, or the sync thread blocked on a semaphore (#331).
+        if Thread.isMainThread {
+            spawnEngine(registrationId: registrationId)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.spawnEngine(registrationId: registrationId)
+            }
+        }
+    }
+
+    private func spawnEngine(registrationId: Int) {
         guard let callback = FlutterCallbackCache.lookupCallbackInformation(Int64(registrationId)) else {
-            TraceletSdk.shared.logger.debug("Failed to find callback for registration ID: \(registrationId)")
+            // Nothing can ever consume these events: the callback the engine
+            // exists to run is gone from the app bundle.
+            TraceletLog.lifecycle(
+                "headless: no callback info for ID \(registrationId) — "
+                    + "the registered Dart entrypoint is gone from this build")
+            destroy()
             return
         }
 
-        engine = FlutterEngine(name: "com.tracelet.headless", project: nil, allowHeadlessExecution: true)
-        guard let engine = engine else { return }
-
-        let success = engine.run(
+        let newEngine = FlutterEngine(
+            name: "com.tracelet.headless", project: nil, allowHeadlessExecution: true)
+        let success = newEngine.run(
             withEntrypoint: callback.callbackName,
             libraryURI: callback.callbackLibraryPath
         )
 
         guard success else {
-            TraceletSdk.shared.logger.debug("Failed to start headless engine")
-            self.engine = nil
+            TraceletLog.lifecycle(
+                "headless: engine spawn FAILED at stage \(currentStage()) — "
+                    + "FlutterEngine.run returned false for \(callback.callbackName ?? "?")")
+            // resetSpawn, not destroy: the queued events are what the engine
+            // was being spawned to deliver. Keep them for the next attempt.
+            resetSpawn()
             return
         }
 
         // Set up method channel for bidirectional communication
-        channel = FlutterMethodChannel(
+        let newChannel = FlutterMethodChannel(
             name: HeadlessRunner.channelName,
-            binaryMessenger: engine.binaryMessenger
+            binaryMessenger: newEngine.binaryMessenger
         )
 
-        channel?.setMethodCallHandler { [weak self] call, result in
+        newChannel.setMethodCallHandler { [weak self] call, result in
             if call.method == "initialized" {
                 self?.onEngineReady()
                 result(nil)
@@ -270,7 +391,7 @@ final class HeadlessRunner: HeadlessDispatching {
         // headless engine can update headers and signal the refresh semaphore.
         let methodsChannel = FlutterMethodChannel(
             name: HeadlessRunner.methodsChannelName,
-            binaryMessenger: engine.binaryMessenger
+            binaryMessenger: newEngine.binaryMessenger
         )
         methodsChannel.setMethodCallHandler { [weak self] call, result in
             if call.method == "setDynamicHeaders" {
@@ -287,18 +408,96 @@ final class HeadlessRunner: HeadlessDispatching {
                 result(FlutterMethodNotImplemented)
             }
         }
+
+        // Published only once the engine is fully wired, so a failure above
+        // cannot leave a half-built engine behind for the guard in
+        // startEngineIfNeeded() to trust (#331).
+        stateLock.lock()
+        engine = newEngine
+        channel = newChannel
+        spawnStage = .engineCreated
+        stateLock.unlock()
     }
 
     private func onEngineReady() {
+        stateLock.lock()
         isReady = true
-        // Flush pending events
-        for event in pendingEvents {
-            channel?.invokeMethod("headlessEvent", arguments: event)
-        }
+        spawnInFlight = false
+        spawnStage = .ready
+        let events = pendingEvents
         pendingEvents.removeAll()
+        let liveChannel = channel
+        let taskId = engineBootTaskId
+        engineBootTaskId = nil
+        stateLock.unlock()
+
+        TraceletLog.lifecycle("headless: engine ready — draining \(events.count) queued event(s)")
+
+        for event in events {
+            liveChannel?.invokeMethod("headlessEvent", arguments: event)
+        }
 
         // Engine is up and events are dispatched — end the boot task.
-        BackgroundTaskHelper.shared.end(engineBootTaskId)
+        BackgroundTaskHelper.shared.end(taskId)
+    }
+
+    /// Abandons an in-flight spawn that has outlived ``engineSpawnTimeout`` so
+    /// the next event can start a fresh one (#331).
+    ///
+    /// The reported failure was permanent: no timeout, retry, or log ever
+    /// followed a spawn that did not complete, and events accumulated for as
+    /// long as tracking ran. The stage recorded here is the diagnostic — it
+    /// names how far the attempt got.
+    private func failStalledSpawn() {
+        stateLock.lock()
+        guard spawnInFlight, !isReady, spawnStartedAt > 0 else {
+            stateLock.unlock()
+            return
+        }
+        let elapsed = ProcessInfo.processInfo.systemUptime - spawnStartedAt
+        guard elapsed >= HeadlessRunner.engineSpawnTimeout else {
+            stateLock.unlock()
+            return
+        }
+        let stage = spawnStage
+        let queued = pendingEvents.count
+        stateLock.unlock()
+
+        TraceletLog.lifecycle(
+            "headless: engine spawn STALLED at stage \(stage.rawValue) after "
+                + "\(Int(elapsed * 1000))ms — retrying (\(queued) event(s) queued)")
+        resetSpawn()
+    }
+
+    /// Returns to a spawnable state, keeping ``pendingEvents`` intact. Unlike
+    /// ``destroy`` this is recoverable: the next dispatched event starts a new
+    /// spawn and drains everything buffered in the meantime.
+    private func resetSpawn() {
+        stateLock.lock()
+        let oldEngine = engine
+        engine = nil
+        channel = nil
+        isReady = false
+        spawnInFlight = false
+        spawnStage = .idle
+        spawnStartedAt = 0
+        let taskId = engineBootTaskId
         engineBootTaskId = nil
+        stateLock.unlock()
+
+        BackgroundTaskHelper.shared.end(taskId)
+
+        guard let oldEngine = oldEngine else { return }
+        if Thread.isMainThread {
+            oldEngine.destroyContext()
+        } else {
+            DispatchQueue.main.async { oldEngine.destroyContext() }
+        }
+    }
+
+    private func currentStage() -> String {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return spawnStage.rawValue
     }
 }

--- a/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
+++ b/packages/tracelet_ios/ios/tracelet_ios/Sources/tracelet_ios/TraceletIosPlugin.swift
@@ -239,12 +239,44 @@ public class TraceletIosPlugin: NSObject, FlutterPlugin, DartSyncInterceptor {
             // guarantee, and routing the log through the SDK would put a crash in
             // its way. TraceletLog falls back to NSLog until a logger is attached.
             // The Android counterpart broke its own regression test this way.
+            //
+            // #340: before falling through to the default payload, try the
+            // *headless* builder. This flag only ever reflects the foreground
+            // isolate, and a process relaunched in the background — iOS's
+            // `resume=true` session, launched by a location event with nobody
+            // driving the UI — never runs the app code that calls
+            // `setSyncBodyBuilder`, so it is false there even when the app
+            // registered `registerHeadlessSyncBodyBuilder` at startup. This
+            // branch then returned before the `primaryInstance == nil` routing
+            // below could be reached, and the device posted the SDK default
+            // while the same app on Android posted its own body. Android's
+            // engine-less process is covered by HeadlessSyncInterceptor,
+            // installed from a ContentProvider at process start; iOS has no
+            // equivalent seam, so the fallback belongs here.
+            //
+            // Guarded so the #125 promise survives: a UserDefaults read only,
+            // skipped entirely on the main thread because
+            // requestCustomSyncBody answers nil there (it would deadlock), and
+            // nil means "abort the sync" — a worse outcome than the default
+            // payload this branch exists to permit.
+            if let runner = headlessRunner, !Thread.isMainThread,
+                runner.isSyncBodyBuilderRegistered()
+            {
+                TraceletLog.debug(
+                    "requestSyncBody: no foreground builder — routing to the headless builder")
+                return runner.requestCustomSyncBody(
+                    locations,
+                    timeout: TraceletIosPlugin.dartCallbackTimeout,
+                    telematics: TraceletSdk.shared.getTelematicsForCustomBuilder(),
+                )
+            }
+
             TraceletLog.debug(
                 "requestSyncBody: no custom sync body builder registered "
                     + "(setSyncBodyBuilder never reached native) — using the default payload")
             return traceletNoSyncBodyBuilderSentinel
         }
-        
+
         if TraceletIosPlugin.primaryInstance == nil {
             // Background/killed: no foreground engine. Route to the headless
             // runner, which returns the sentinel when no headless sync-body


### PR DESCRIPTION
Two issues that share a layer: the headless engine that background work runs in, on both platforms.

---

# #331 — the headless task was silently never invoked after task removal

Roughly half the attempts, while native tracking kept producing fixes every 2–4 s. **No error was logged at any level.**

Between `dispatchEvent()` and `FlutterEngine(context)` there was exactly one log line, `No headless callbacks registered`, and the report confirmed it was absent. That left "no engine, no error" as the whole of the evidence, and four defects able to produce it.

### What was wrong (Android)

- **A half-built engine blocked every retry, forever.** `ensureEngine()` opened with `if (flutterEngine != null) return`. An engine created but never signalled `initialized` by its Dart side made every later event a silent no-op — no timeout, no retry, no log. The `.also {}` form made this reachable from the failure path too: it assigned `flutterEngine` even when the block had already called `destroy()`.
- **The spawn blocked the main thread.** It ran a **fresh** `FlutterLoader()` and waited in `ensureInitializationComplete()`, which blocks on that loader's own init future. A fresh loader re-runs full Flutter initialization — the source of the `FlutterJNI.loadLibrary called more than once` warning visible in the reporter's *working* run. It now uses `FlutterInjector.instance().flutterLoader()`, already initialized in a process that has run the app, so both calls return immediately.
- **`catch (e: Exception)` missed `Error`.** An `UnsatisfiedLinkError` from a native load escaped the handler unseen.
- **The queue was unbounded, then discarded.** `pendingEvents` grew by one entry per fix for the life of the process, and a failed spawn called `destroy()`, which cleared it.

### iOS has it too

`HeadlessRunner.startEngineIfNeeded()` has the same `guard engine == nil` that makes a never-ready engine permanent, the same unbounded `pendingEvents`, the same `destroy()`-on-failure that discards them, and its failure paths log at `debug` — dropped in exactly the release builds these reports come from. Two hazards Android did not have:

- it created and ran the `FlutterEngine` on **whichever thread produced the event** — a location callback queue, or the sync thread blocked on a semaphore — where UIKit requires the main thread;
- it mutated `pendingEvents` / `engine` / `isReady` from that thread while `onEngineReady` mutated them from the platform thread, with no lock. A Swift `Array` is not thread-safe.

Both are fixed here.

### What changed

A stalled spawn is abandoned after 30 s and retried; a failed one keeps what it buffered for the next attempt; the queue caps at 200 with oldest-first eviction, reported when it evicts. The engine is published only once fully wired. Concurrent dispatches post one spawn, not several. iOS spawns on the main thread behind an `NSRecursiveLock`.

Diagnostics go on the **lifecycle channel**, which is never level-gated, a handful of rows per session, naming the stage reached:

```text
headless: spawning a FlutterEngine (3 event(s) queued)
headless: engine ready — draining 3 queued event(s)
headless: engine spawn STALLED at stage POSTED after 30001ms — retrying
headless: engine spawn FAILED at stage LOADER_READY — <cause>
```

`STALLED at POSTED` means the main thread never ran the spawn block; `LOADER_READY` or later means Flutter came up and the engine or its Dart entrypoint did not.

**Not claimed:** the intermittency itself is not pinned. The blocking main-thread initialization is the best-supported hypothesis for why it was a coin flip on the reporter's multi-engine app, and it is removed here — but the next occurrence is what will settle it, and it will now arrive with the stage attached.

---

# #340 — iOS posted the default payload while a builder was registered

`hasCustomSyncBodyBuilder` only ever reflects the **foreground** isolate. Both platforms opened `requestSyncBody` with

```swift
if !hasCustomSyncBodyBuilder { return traceletNoSyncBodyBuilderSentinel }
```

and only *below* that consulted the headless builder. A process whose Dart never ran the app code that calls `setSyncBodyBuilder` read `false` there and posted the SDK default — with `registerHeadlessSyncBodyBuilder`'s callback registered and usable the whole time.

That is iOS's background relaunch: launched by a location event with nobody driving the UI, the `resume=true` session the report came from. The example registers the headless builder in `main()` and the foreground one behind the Initialize button — which is precisely why the same build posted its batched envelope on Android and the Rust default on iOS against the same server.

Android was less exposed but had the same ordering: its engine-less processes are covered by `HeadlessSyncInterceptor` (installed from a ContentProvider at process start), which routes straight to the headless builder. iOS has no equivalent seam — and that seam does not help an *attached* engine whose Dart has not registered a foreground builder either. Both platforms now try the headless builder from that branch.

**The #125 promise survives.** The check is a UserDefaults/SharedPreferences read and nothing else, gated on a runner/service that exists only once the plugin has attached, and skipped on the main thread where `requestCustomSyncBody` answers nil — nil means *abort the sync*, a worse outcome than the default payload this branch exists to permit. With nothing registered anywhere, the immediate sentinel still comes back.

**The route-context half is not addressed, because it was not a defect.** The 250-location batch is ordered oldest-first and the boundary was visible inside it: rows recorded before `setRouteContext` ran lacked `extras.route_context`, rows after it carried it. Route context is applied at record time and is not retroactive. That finding is withdrawn.

---

## Verification

**`HeadlessEngineSpawnRecoveryTest`** drives the real `HeadlessTaskService` under Robolectric, where a FlutterEngine genuinely cannot be created — which is what makes the failure handling testable. A failed spawn keeps its queued events; a stalled spawn is abandoned and retried; the queue caps and evicts oldest-first. All three fail on `main`.

**`SyncBodyHeadlessFallbackTest`** covers the #340 routing: a registered headless builder is consulted when the foreground one is absent (verified failing on `main`), and with nothing registered anywhere the immediate sentinel still comes back.

252 Android unit tests pass; the iOS example builds for device; `melos format` and `melos analyze` clean. iOS `HeadlessRunner` has no unit-test target in this repo, so it is covered by the build and by review — worth knowing when reading the Swift half.

**Issue cards.** `issue_331_card.dart` runs in two phases, because no foreground card can swipe itself out of recents: it arms the task removal, then on reopen reads the lifecycle trail and classifies it — engine up, engine failed *and said so*, or the #331 signature (a spawn with no outcome) back. `issue_340_card.dart` uses `setSyncBodyBuilder(null)` to reproduce the exact state a relaunched process is in, then asserts the next sync does not report the default payload. Both say what they cannot prove rather than inferring a pass.

Fixes #331
Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
