### PR TITLE
fix(example): make Execute All actually run every card, and keep results across scrolling

### DIFF
--- a/example/lib/issues/archived_issues_tab.dart
+++ b/example/lib/issues/archived_issues_tab.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:crypto/crypto.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+import 'package:tracelet_example/issues/issue_sweep.dart';
 
 @pragma('vm:entry-point')
 void headlessSyncBodyBuilder136(HeadlessEvent event) {
@@ -26,6 +29,11 @@ class ArchivedIssuesTab extends StatefulWidget {
 class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
   final ScrollController _scrollController = ScrollController();
   final TextEditingController _searchController = TextEditingController();
+  static const _scope = 'archived';
+  late final IssueSweep _sweep = IssueSweep(
+    scrollController: _scrollController,
+    scope: _scope,
+  );
   String _searchQuery = '';
 
   bool _isTracking = false;
@@ -88,10 +96,18 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
         _searchQuery = _searchController.text;
       });
     });
+    _sweep.addListener(_onSweepChanged);
+  }
+
+  void _onSweepChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
   void dispose() {
+    _sweep
+      ..removeListener(_onSweepChanged)
+      ..dispose();
     _scrollController.dispose();
     _searchController.dispose();
     _issue140Timer?.cancel();
@@ -108,18 +124,6 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
       setState(() {
         _statuses[issue] = status;
       });
-    }
-  }
-
-  void _scrollTo(int issue) {
-    final key = _keys[issue];
-    if (key != null && key.currentContext != null) {
-      Scrollable.ensureVisible(
-        key.currentContext!,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-        alignment: 0.1,
-      );
     }
   }
 
@@ -810,50 +814,28 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
     }
   }
 
+  /// Runs every card on the tab (#372).
+  ///
+  /// This used to be a hand-maintained `if` ladder over [_allIssues] that
+  /// scrolled with [Scrollable.ensureVisible] on off-screen cards — which does
+  /// nothing, because a lazy list has not built them — and awaited each test
+  /// with no timeout, so one card that never returned hung the whole run with no
+  /// way to stop it. [IssueSweep] walks the list instead, running whatever has
+  /// mounted, bounding each card and staying cancellable.
   Future<void> _executeAll() async {
-    for (final issue in _allIssues) {
-      // Issues 134, 136 & 140 are manual, long-running background/motion repros —
-      // not part of the automated sweep.
-      if (issue == 134 || issue == 136 || issue == 140) continue;
-      _scrollTo(issue);
-      if (issue == 115) {
-        await _startIssue115Tracking();
-        await Future.delayed(const Duration(seconds: 3));
-        await _stopTracking();
-      } else if (issue == 117) {
-        await _testIssue117();
-        await Future.delayed(const Duration(seconds: 2));
-      } else if (issue == 118) {
-        await _runIssue118All();
-      } else if (issue == 119) {
-        await _testIssue119();
-      } else if (issue == 120) {
-        await _testIssue120();
-      } else if (issue == 124) {
-        await _testIssue124HeaderCrash();
-      } else if (issue == 125) {
-        await _testIssue125();
-      } else if (issue == 126) {
-        await _testIssue126();
-      } else if (issue == 137) {
-        await _testIssue137();
-      } else if (issue == 138) {
-        await _testIssue138();
-      } else if (issue == 139) {
-        await _testIssue139();
-      } else if (issue == 147) {
-        await _testIssue147();
-      } else if (issue == 149) {
-        await _testIssue149();
-      } else if (issue == 154) {
-        await _testIssue154();
-      } else if (issue == 159) {
-        await _testIssue159();
-      } else if (issue == 175) {
-        await _testIssue175();
-      }
-      await Future.delayed(const Duration(seconds: 2));
-    }
+    // Sweeping means "run everything", so a filter left in the search box would
+    // silently make it a lie.
+    _searchController.clear();
+    await _sweep.start();
+  }
+
+  /// Issue #115 in one call, for the sweep: its card drives tracking with
+  /// separate Start and Stop buttons, so the sweep needs the pair plus the
+  /// window in between that the old ladder hard-coded.
+  Future<void> _sweepIssue115() async {
+    await _startIssue115Tracking();
+    await Future<void>.delayed(const Duration(seconds: 3));
+    await _stopTracking();
   }
 
   // ==== ISSUE 137: deltaCoordinatePrecision default ====
@@ -1526,6 +1508,7 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
     required String title,
     required String description,
     required List<Widget> actions,
+    IssueRunner? sweepAction,
   }) {
     if (_searchQuery.isNotEmpty) {
       final query = _searchQuery.toLowerCase();
@@ -1551,41 +1534,63 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
     if (isFailure) statusColor = Colors.red.shade700;
     if (isRunning) statusColor = Colors.blue.shade700;
 
-    return Card(
-      key: _keys[issueNumber],
-      margin: const EdgeInsets.only(bottom: 16),
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Issue #$issueNumber: $title',
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 8),
-            Text(description),
-            const SizedBox(height: 16),
-            Wrap(spacing: 8, runSpacing: 8, children: actions),
-            const SizedBox(height: 16),
-            Container(
-              padding: const EdgeInsets.all(12),
-              width: double.infinity,
-              decoration: BoxDecoration(
-                color: statusColor.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: statusColor.withValues(alpha: 0.3)),
-              ),
-              child: Text(
-                'Status: $status',
-                style: TextStyle(
-                  color: statusColor,
+    // Enlists the card in Execute All for as long as it is mounted, the same
+    // deal the card widgets get from IssueCardRun. A null [sweepAction] keeps a
+    // card manual — a start/stop toggle, or a repro that needs the app killed.
+    return IssueRunnerScope(
+      id: 'issue-$issueNumber',
+      run: sweepAction,
+      child: Card(
+        key: _keys[issueNumber],
+        margin: const EdgeInsets.only(bottom: 16),
+        elevation: 2,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Issue #$issueNumber: $title',
+                style: const TextStyle(
+                  fontSize: 18,
                   fontWeight: FontWeight.bold,
                 ),
               ),
-            ),
-          ],
+              const SizedBox(height: 8),
+              Text(description),
+              const SizedBox(height: 16),
+              Wrap(spacing: 8, runSpacing: 8, children: actions),
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(12),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: statusColor.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: statusColor.withValues(alpha: 0.3)),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: SelectableText(
+                        'Status: $status',
+                        style: TextStyle(
+                          color: statusColor,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    IssueCopyButton(
+                      text: status,
+                      label: 'Issue #$issueNumber',
+                      color: statusColor,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1619,9 +1624,9 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
                 ),
                 const SizedBox(width: 12),
                 FilledButton.icon(
-                  onPressed: _executeAll,
-                  icon: const Icon(Icons.play_arrow),
-                  label: const Text('Execute All'),
+                  onPressed: _sweep.active ? _sweep.cancel : _executeAll,
+                  icon: Icon(_sweep.active ? Icons.stop : Icons.play_arrow),
+                  label: Text(_sweep.active ? 'Stop' : 'Execute All'),
                   style: FilledButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 20,
@@ -1635,440 +1640,455 @@ class _ArchivedIssuesTabState extends State<ArchivedIssuesTab> {
               ],
             ),
           ),
+          IssueSweepBanner(sweep: _sweep),
           Expanded(
-            child: ListView(
-              controller: _scrollController,
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              children: [
-                _buildIssueCard(
-                  issueNumber: 115,
-                  title: 'Battery Drain Test',
-                  description:
-                      'Tests iOS SDK with pausesLocationUpdatesAutomatically = false.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _isTracking ? null : _startIssue115Tracking,
-                      icon: const Icon(Icons.battery_alert),
-                      label: const Text('Start Tracking'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: _isTracking ? _stopTracking : null,
-                      icon: const Icon(Icons.stop),
-                      label: const Text('Stop Tracking'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 117,
-                  title: 'Custom Sync Body Bypass',
-                  description:
-                      'Tests that TraceletSync intercepts the batch correctly and uses the custom body builder instead of the default structure.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue117,
-                      icon: const Icon(Icons.cloud_sync),
-                      label: const Text('Test Custom Sync Body'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 118,
-                  title: 'SSL Pinning Fingerprints',
-                  description:
-                      'Verifies that sync correctly validates against SHA-256 certificate fingerprints and blocks invalid connections natively.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue118Valid,
-                      icon: const Icon(Icons.lock_open),
-                      label: const Text('Test Valid Fingerprint'),
-                    ),
-                    FilledButton.icon(
-                      onPressed: _testIssue118Invalid,
-                      icon: const Icon(Icons.lock),
-                      style: FilledButton.styleFrom(
-                        backgroundColor: Colors.red,
+            child: IssueCardScope(
+              name: _scope,
+              child: ListView(
+                controller: _scrollController,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                children: [
+                  _buildIssueCard(
+                    issueNumber: 115,
+                    sweepAction: _sweepIssue115,
+                    title: 'Battery Drain Test',
+                    description:
+                        'Tests iOS SDK with pausesLocationUpdatesAutomatically = false.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _isTracking ? null : _startIssue115Tracking,
+                        icon: const Icon(Icons.battery_alert),
+                        label: const Text('Start Tracking'),
                       ),
-                      label: const Text('Test Invalid Fingerprint'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 120,
-                  title: 'Rust Core Parity',
-                  description:
-                      'Verifies that UniFFI Rust classes have all properties required by the Dart Config models to prevent silent dropping during serialization.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue120,
-                      icon: const Icon(Icons.sync_problem),
-                      label: const Text('Test Config Parity'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 119,
-                  title: 'Database Timestamp Optimization',
-                  description:
-                      'Verifies that timestamp_ms filters properly constrain results for O(log N) DB query performance.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue119,
-                      icon: const Icon(Icons.timer),
-                      label: const Text('Test Timestamp Filter'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 124,
-                  title: 'Header Parsing & Fallback',
-                  description:
-                      'Reproduces the Header Parse Crash and Headless Timeout bugs.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue124HeaderCrash,
-                      icon: const Icon(Icons.http),
-                      label: const Text('Reproduce Header Crash'),
-                    ),
-                    FilledButton.icon(
-                      onPressed: _testIssue124Timeout,
-                      icon: const Icon(Icons.timer_off),
-                      label: const Text('Reproduce Timeout Bug'),
-                      style: FilledButton.styleFrom(
-                        backgroundColor: Colors.red,
+                      OutlinedButton.icon(
+                        onPressed: _isTracking ? _stopTracking : null,
+                        icon: const Icon(Icons.stop),
+                        label: const Text('Stop Tracking'),
                       ),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 125,
-                  title: 'Timeout Payload Abort',
-                  description:
-                      'Verifies that if the custom sync body builder times out, the native SDK aborts the sync and does NOT post an error payload to the backend.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue125,
-                      icon: const Icon(Icons.timer_off),
-                      label: const Text('Test Timeout Abort'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 134,
-                  title: 'Background Auto-Sync Stalls',
-                  description:
-                      'Reproduces the reporter setup: continuous GPS tracking + '
-                      'autoSync to the scanned backend with a custom sync-body '
-                      'builder. Start, then background the app (do NOT kill it) '
-                      'and move — watch the test server to see if on-the-fly '
-                      'sync keeps firing or stalls ("synced 0 locations").',
-                  actions: [
-                    Row(
-                      children: [
-                        FilledButton.icon(
-                          onPressed: _isIssue134Tracking
-                              ? null
-                              : _startIssue134Repro,
-                          icon: const Icon(Icons.directions_car),
-                          label: const Text('Start Repro'),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 117,
+                    sweepAction: _testIssue117,
+                    title: 'Custom Sync Body Bypass',
+                    description:
+                        'Tests that TraceletSync intercepts the batch correctly and uses the custom body builder instead of the default structure.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue117,
+                        icon: const Icon(Icons.cloud_sync),
+                        label: const Text('Test Custom Sync Body'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 118,
+                    sweepAction: _runIssue118All,
+                    title: 'SSL Pinning Fingerprints',
+                    description:
+                        'Verifies that sync correctly validates against SHA-256 certificate fingerprints and blocks invalid connections natively.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue118Valid,
+                        icon: const Icon(Icons.lock_open),
+                        label: const Text('Test Valid Fingerprint'),
+                      ),
+                      FilledButton.icon(
+                        onPressed: _testIssue118Invalid,
+                        icon: const Icon(Icons.lock),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: Colors.red,
                         ),
-                        const SizedBox(width: 8),
-                        OutlinedButton(
-                          onPressed: _verifyIssue134,
-                          child: const Text('Verify Auto'),
+                        label: const Text('Test Invalid Fingerprint'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 120,
+                    sweepAction: _testIssue120,
+                    title: 'Rust Core Parity',
+                    description:
+                        'Verifies that UniFFI Rust classes have all properties required by the Dart Config models to prevent silent dropping during serialization.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue120,
+                        icon: const Icon(Icons.sync_problem),
+                        label: const Text('Test Config Parity'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 119,
+                    sweepAction: _testIssue119,
+                    title: 'Database Timestamp Optimization',
+                    description:
+                        'Verifies that timestamp_ms filters properly constrain results for O(log N) DB query performance.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue119,
+                        icon: const Icon(Icons.timer),
+                        label: const Text('Test Timestamp Filter'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 124,
+                    sweepAction: _testIssue124HeaderCrash,
+                    title: 'Header Parsing & Fallback',
+                    description:
+                        'Reproduces the Header Parse Crash and Headless Timeout bugs.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue124HeaderCrash,
+                        icon: const Icon(Icons.http),
+                        label: const Text('Reproduce Header Crash'),
+                      ),
+                      FilledButton.icon(
+                        onPressed: _testIssue124Timeout,
+                        icon: const Icon(Icons.timer_off),
+                        label: const Text('Reproduce Timeout Bug'),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: Colors.red,
                         ),
-                      ],
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: _isIssue134Tracking
-                          ? _stopIssue134Repro
-                          : null,
-                      icon: const Icon(Icons.stop),
-                      label: const Text('Stop'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 136,
-                  title: 'Background Sync Body Interceptor',
-                  description:
-                      'Verifies that when the app UI is killed, background syncs still correctly call the headless sync body builder instead of falling back to the default payload. Click test, then kill the app from recents.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue136,
-                      icon: const Icon(Icons.sync_problem),
-                      label: const Text('Test Headless Sync'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 126,
-                  title: 'Sync Payload Schema Alignment',
-                  description:
-                      'Verifies DB-sourced locations passed to setSyncBodyBuilder '
-                      'use the same nested schema as live onLocation events '
-                      '(nested coords/activity/battery) and preserve route_context.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue126,
-                      icon: const Icon(Icons.schema),
-                      label: const Text('Test Schema Alignment'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 137,
-                  title: 'deltaCoordinatePrecision Default',
-                  description:
-                      'Verifies the delta-compression precision default matches the '
-                      'Dart layer (5). A native fallback of 6 produced a finer grid '
-                      'and larger payloads when the value was not set.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue137,
-                      icon: const Icon(Icons.compress),
-                      label: const Text('Verify Default (5)'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 138,
-                  title: 'locationsOrderDirection Honored on Sync',
-                  description:
-                      'Configures descending sync order, records 3 points and syncs. '
-                      'Verify your backend receives the batch in descending order '
-                      '(the sync path previously always uploaded ascending).',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue138,
-                      icon: const Icon(Icons.sort),
-                      label: const Text('Sync Descending'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 139,
-                  title: 'Unbounded getLocations() (no 1000 cap)',
-                  description:
-                      'Inserts 1100 rows and reads them back with getLocations(). '
-                      'Previously an unspecified limit silently capped reads at 1000, '
-                      'truncating full-history reads and getCarbonReport().',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue139,
-                      icon: const Icon(Icons.all_inbox),
-                      label: const Text('Read 1100 Rows'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 140,
-                  title: 'Motion Resumes During Stop-Timeout',
-                  description:
-                      'Starts smart-motion tracking with a short stop-timeout. '
-                      'Walk for a few seconds, stay still until the countdown starts, '
-                      'then move again BEFORE it elapses — tracking should stay in the '
-                      'moving state (iOS keeps the accelerometer active during the '
-                      'countdown; see issue for the Android behavior).',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _isIssue140Tracking ? null : _startIssue140,
-                      icon: const Icon(Icons.directions_walk),
-                      label: const Text('Start'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: _isIssue140Tracking ? _stopIssue140 : null,
-                      icon: const Icon(Icons.stop),
-                      label: const Text('Stop'),
-                    ),
-                    if (_isIssue140Tracking)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8, left: 8),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '⏱️ Stopwatch: $_issue140ElapsedSeconds s (Test your stop-timeout!)',
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 16,
-                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 6,
-                              ),
-                              decoration: BoxDecoration(
-                                color: _issue140IsMoving
-                                    ? Colors.green.shade100
-                                    : Colors.red.shade100,
-                                borderRadius: BorderRadius.circular(8),
-                                border: Border.all(
-                                  color: _issue140IsMoving
-                                      ? Colors.green
-                                      : Colors.red,
-                                ),
-                              ),
-                              child: Text(
-                                'Current State: ${_issue140IsMoving ? 'Moving 🏃' : 'Stationary 🛑'}',
-                                style: TextStyle(
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 125,
+                    sweepAction: _testIssue125,
+                    title: 'Timeout Payload Abort',
+                    description:
+                        'Verifies that if the custom sync body builder times out, the native SDK aborts the sync and does NOT post an error payload to the backend.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue125,
+                        icon: const Icon(Icons.timer_off),
+                        label: const Text('Test Timeout Abort'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 134,
+                    title: 'Background Auto-Sync Stalls',
+                    description:
+                        'Reproduces the reporter setup: continuous GPS tracking + '
+                        'autoSync to the scanned backend with a custom sync-body '
+                        'builder. Start, then background the app (do NOT kill it) '
+                        'and move — watch the test server to see if on-the-fly '
+                        'sync keeps firing or stalls ("synced 0 locations").',
+                    actions: [
+                      Row(
+                        children: [
+                          FilledButton.icon(
+                            onPressed: _isIssue134Tracking
+                                ? null
+                                : _startIssue134Repro,
+                            icon: const Icon(Icons.directions_car),
+                            label: const Text('Start Repro'),
+                          ),
+                          const SizedBox(width: 8),
+                          OutlinedButton(
+                            onPressed: _verifyIssue134,
+                            child: const Text('Verify Auto'),
+                          ),
+                        ],
+                      ),
+                      OutlinedButton.icon(
+                        onPressed: _isIssue134Tracking
+                            ? _stopIssue134Repro
+                            : null,
+                        icon: const Icon(Icons.stop),
+                        label: const Text('Stop'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 136,
+                    title: 'Background Sync Body Interceptor',
+                    description:
+                        'Verifies that when the app UI is killed, background syncs still correctly call the headless sync body builder instead of falling back to the default payload. Click test, then kill the app from recents.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue136,
+                        icon: const Icon(Icons.sync_problem),
+                        label: const Text('Test Headless Sync'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 126,
+                    sweepAction: _testIssue126,
+                    title: 'Sync Payload Schema Alignment',
+                    description:
+                        'Verifies DB-sourced locations passed to setSyncBodyBuilder '
+                        'use the same nested schema as live onLocation events '
+                        '(nested coords/activity/battery) and preserve route_context.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue126,
+                        icon: const Icon(Icons.schema),
+                        label: const Text('Test Schema Alignment'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 137,
+                    sweepAction: _testIssue137,
+                    title: 'deltaCoordinatePrecision Default',
+                    description:
+                        'Verifies the delta-compression precision default matches the '
+                        'Dart layer (5). A native fallback of 6 produced a finer grid '
+                        'and larger payloads when the value was not set.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue137,
+                        icon: const Icon(Icons.compress),
+                        label: const Text('Verify Default (5)'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 138,
+                    sweepAction: _testIssue138,
+                    title: 'locationsOrderDirection Honored on Sync',
+                    description:
+                        'Configures descending sync order, records 3 points and syncs. '
+                        'Verify your backend receives the batch in descending order '
+                        '(the sync path previously always uploaded ascending).',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue138,
+                        icon: const Icon(Icons.sort),
+                        label: const Text('Sync Descending'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 139,
+                    sweepAction: _testIssue139,
+                    title: 'Unbounded getLocations() (no 1000 cap)',
+                    description:
+                        'Inserts 1100 rows and reads them back with getLocations(). '
+                        'Previously an unspecified limit silently capped reads at 1000, '
+                        'truncating full-history reads and getCarbonReport().',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue139,
+                        icon: const Icon(Icons.all_inbox),
+                        label: const Text('Read 1100 Rows'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 140,
+                    title: 'Motion Resumes During Stop-Timeout',
+                    description:
+                        'Starts smart-motion tracking with a short stop-timeout. '
+                        'Walk for a few seconds, stay still until the countdown starts, '
+                        'then move again BEFORE it elapses — tracking should stay in the '
+                        'moving state (iOS keeps the accelerometer active during the '
+                        'countdown; see issue for the Android behavior).',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _isIssue140Tracking ? null : _startIssue140,
+                        icon: const Icon(Icons.directions_walk),
+                        label: const Text('Start'),
+                      ),
+                      OutlinedButton.icon(
+                        onPressed: _isIssue140Tracking ? _stopIssue140 : null,
+                        icon: const Icon(Icons.stop),
+                        label: const Text('Stop'),
+                      ),
+                      if (_isIssue140Tracking)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8, left: 8),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '⏱️ Stopwatch: $_issue140ElapsedSeconds s (Test your stop-timeout!)',
+                                style: const TextStyle(
                                   fontWeight: FontWeight.bold,
-                                  color: _issue140IsMoving
-                                      ? Colors.green.shade900
-                                      : Colors.red.shade900,
+                                  fontSize: 16,
                                 ),
                               ),
-                            ),
-                          ],
+                              const SizedBox(height: 8),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 6,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: _issue140IsMoving
+                                      ? Colors.green.shade100
+                                      : Colors.red.shade100,
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color: _issue140IsMoving
+                                        ? Colors.green
+                                        : Colors.red,
+                                  ),
+                                ),
+                                child: Text(
+                                  'Current State: ${_issue140IsMoving ? 'Moving 🏃' : 'Stationary 🛑'}',
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    color: _issue140IsMoving
+                                        ? Colors.green.shade900
+                                        : Colors.red.shade900,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 141,
+                    title: 'encryptDatabase: true breaks events',
+                    description:
+                        'When encryptDatabase is set to true without an explicit key, '
+                        'the internal DB correctly falls back to unencrypted storage, '
+                        'but the Dart event bridge breaks silently due to Native config bypass. '
+                        'This test ensures we receive location events successfully.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _isIssue141Tracking ? null : _startIssue141,
+                        icon: const Icon(Icons.security),
+                        label: const Text('Start (Encrypted)'),
                       ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 141,
-                  title: 'encryptDatabase: true breaks events',
-                  description:
-                      'When encryptDatabase is set to true without an explicit key, '
-                      'the internal DB correctly falls back to unencrypted storage, '
-                      'but the Dart event bridge breaks silently due to Native config bypass. '
-                      'This test ensures we receive location events successfully.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _isIssue141Tracking ? null : _startIssue141,
-                      icon: const Icon(Icons.security),
-                      label: const Text('Start (Encrypted)'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: _isIssue141Tracking ? _stopIssue141 : null,
-                      icon: const Icon(Icons.stop),
-                      label: const Text('Stop'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 148,
-                  title: 'Kalman Filter silently disabled (key mismatch)',
-                  description:
-                      'Dart writes "useKalmanFilter" but native ConfigManager read '
-                      '"enableKalmanFilter", so the Extended Kalman Filter never '
-                      'initialized. Configures useKalmanFilter:true to confirm it is '
-                      'now wired (observe smoother tracks / native logs while moving).',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue148,
-                      icon: const Icon(Icons.timeline),
-                      label: const Text('Configure & Verify'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 150,
-                  title: 'AuditConfig sha384/sha512 fatal RangeError',
-                  description:
-                      'ready() with HashAlgorithm.sha512 crashed with a fatal '
-                      'RangeError (Pigeon enum mismatch). This test confirms ready() '
-                      'no longer crashes (falls back to sha256). Deterministic.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue150,
-                      icon: const Icon(Icons.lock_outline),
-                      label: const Text('Run Test'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 152,
-                  title: 'getCount ignores query filters',
-                  description:
-                      'getCount(SQLQuery) ignored time bounds and returned the '
-                      'whole-DB total. Inserts 2 points (2h ago + now) and asserts a '
-                      'last-hour query counts 1. Deterministic.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue152,
-                      icon: const Icon(Icons.numbers),
-                      label: const Text('Run Test'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 155,
-                  title: 'Activity permanently "unknown"',
-                  description:
-                      'Detected activity was never propagated to the LocationEngine, '
-                      'so every record had "activity":"unknown". Start tracking and '
-                      'move around — the live activity (in Status) should classify '
-                      '(walking / still / in_vehicle). Needs ACTIVITY_RECOGNITION '
-                      'permission + real motion.',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _isIssue155Tracking ? null : _startIssue155,
-                      icon: const Icon(Icons.directions_walk),
-                      label: const Text('Start'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: _isIssue155Tracking ? _stopIssue155 : null,
-                      icon: const Icon(Icons.stop),
-                      label: const Text('Stop'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 157,
-                  title: 'LocationEngine not rebuilt on ready()',
-                  description:
-                      'ready() with distanceFilter:0 kept the stale default processor, '
-                      'filtering closely-spaced fixes. Start tracking and move slightly '
-                      '— fixes should flow with no distance filtering (live counter in '
-                      'Status).',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _isIssue157Tracking ? null : _startIssue157,
-                      icon: const Icon(Icons.filter_alt_off),
-                      label: const Text('Start (df:0)'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: _isIssue157Tracking ? _stopIssue157 : null,
-                      icon: const Icon(Icons.stop),
-                      label: const Text('Stop'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 151,
-                  title: 'is_moving missing from sync payload',
-                  description:
-                      'The native SyncLocationRecord omitted the motion state, so '
-                      'the HTTP payload never carried "is_moving". This test syncs a '
-                      'record (is_moving:true) to a loopback server and asserts the '
-                      'payload contains it. Deterministic. (Same test as #156.)',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue151156,
-                      icon: const Icon(Icons.directions_run),
-                      label: const Text('Run Test'),
-                    ),
-                  ],
-                ),
-                _buildIssueCard(
-                  issueNumber: 156,
-                  title: 'event key missing from sync payload',
-                  description:
-                      'The native SyncLocationRecord omitted the trigger event, so '
-                      'the HTTP payload never carried "event" (location / motionchange '
-                      '/ heartbeat / geofence). This test syncs a record '
-                      '(event:"motionchange") and asserts the payload contains it. '
-                      'Deterministic. (Same test as #151.)',
-                  actions: [
-                    FilledButton.icon(
-                      onPressed: _testIssue151156,
-                      icon: const Icon(Icons.bolt),
-                      label: const Text('Run Test'),
-                    ),
-                  ],
-                ),
-              ],
+                      OutlinedButton.icon(
+                        onPressed: _isIssue141Tracking ? _stopIssue141 : null,
+                        icon: const Icon(Icons.stop),
+                        label: const Text('Stop'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 148,
+                    title: 'Kalman Filter silently disabled (key mismatch)',
+                    description:
+                        'Dart writes "useKalmanFilter" but native ConfigManager read '
+                        '"enableKalmanFilter", so the Extended Kalman Filter never '
+                        'initialized. Configures useKalmanFilter:true to confirm it is '
+                        'now wired (observe smoother tracks / native logs while moving).',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue148,
+                        icon: const Icon(Icons.timeline),
+                        label: const Text('Configure & Verify'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 150,
+                    title: 'AuditConfig sha384/sha512 fatal RangeError',
+                    description:
+                        'ready() with HashAlgorithm.sha512 crashed with a fatal '
+                        'RangeError (Pigeon enum mismatch). This test confirms ready() '
+                        'no longer crashes (falls back to sha256). Deterministic.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue150,
+                        icon: const Icon(Icons.lock_outline),
+                        label: const Text('Run Test'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 152,
+                    title: 'getCount ignores query filters',
+                    description:
+                        'getCount(SQLQuery) ignored time bounds and returned the '
+                        'whole-DB total. Inserts 2 points (2h ago + now) and asserts a '
+                        'last-hour query counts 1. Deterministic.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue152,
+                        icon: const Icon(Icons.numbers),
+                        label: const Text('Run Test'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 155,
+                    title: 'Activity permanently "unknown"',
+                    description:
+                        'Detected activity was never propagated to the LocationEngine, '
+                        'so every record had "activity":"unknown". Start tracking and '
+                        'move around — the live activity (in Status) should classify '
+                        '(walking / still / in_vehicle). Needs ACTIVITY_RECOGNITION '
+                        'permission + real motion.',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _isIssue155Tracking ? null : _startIssue155,
+                        icon: const Icon(Icons.directions_walk),
+                        label: const Text('Start'),
+                      ),
+                      OutlinedButton.icon(
+                        onPressed: _isIssue155Tracking ? _stopIssue155 : null,
+                        icon: const Icon(Icons.stop),
+                        label: const Text('Stop'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 157,
+                    title: 'LocationEngine not rebuilt on ready()',
+                    description:
+                        'ready() with distanceFilter:0 kept the stale default processor, '
+                        'filtering closely-spaced fixes. Start tracking and move slightly '
+                        '— fixes should flow with no distance filtering (live counter in '
+                        'Status).',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _isIssue157Tracking ? null : _startIssue157,
+                        icon: const Icon(Icons.filter_alt_off),
+                        label: const Text('Start (df:0)'),
+                      ),
+                      OutlinedButton.icon(
+                        onPressed: _isIssue157Tracking ? _stopIssue157 : null,
+                        icon: const Icon(Icons.stop),
+                        label: const Text('Stop'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 151,
+                    title: 'is_moving missing from sync payload',
+                    description:
+                        'The native SyncLocationRecord omitted the motion state, so '
+                        'the HTTP payload never carried "is_moving". This test syncs a '
+                        'record (is_moving:true) to a loopback server and asserts the '
+                        'payload contains it. Deterministic. (Same test as #156.)',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue151156,
+                        icon: const Icon(Icons.directions_run),
+                        label: const Text('Run Test'),
+                      ),
+                    ],
+                  ),
+                  _buildIssueCard(
+                    issueNumber: 156,
+                    title: 'event key missing from sync payload',
+                    description:
+                        'The native SyncLocationRecord omitted the trigger event, so '
+                        'the HTTP payload never carried "event" (location / motionchange '
+                        '/ heartbeat / geofence). This test syncs a record '
+                        '(event:"motionchange") and asserts the payload contains it. '
+                        'Deterministic. (Same test as #151.)',
+                    actions: [
+                      FilledButton.icon(
+                        onPressed: _testIssue151156,
+                        icon: const Icon(Icons.bolt),
+                        label: const Text('Run Test'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ],

--- a/example/lib/issues/battery_budget_remote_config_card.dart
+++ b/example/lib/issues/battery_budget_remote_config_card.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Remote Config → Dart `activeConfig` sync.
 ///
@@ -37,7 +39,8 @@ class BatteryBudgetRemoteConfigCard extends StatefulWidget {
 }
 
 class _BatteryBudgetRemoteConfigCardState
-    extends State<BatteryBudgetRemoteConfigCard> {
+    extends State<BatteryBudgetRemoteConfigCard>
+    with IssueCardRun<BatteryBudgetRemoteConfigCard> {
   /// Gist returning `{"geo":{"batteryBudgetPerHour":1.0}}`.
   static const _remoteUrl =
       'https://gist.githubusercontent.com/MuellerMoritz/'
@@ -46,13 +49,13 @@ class _BatteryBudgetRemoteConfigCardState
   /// The value the gist should apply.
   static const double _expectedBudget = 1;
 
-  String _status = 'Idle';
   bool _busy = false;
   StreamSubscription<Config>? _remoteSub;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   @override
   void dispose() {
@@ -178,22 +181,7 @@ class _BatteryBudgetRemoteConfigCardState
               'showing the local value). Requires network.',
             ),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             FilledButton.icon(
               onPressed: _busy ? null : _run,

--- a/example/lib/issues/issue_185_card.dart
+++ b/example/lib/issues/issue_185_card.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 class Issue185Card extends StatefulWidget {
   const Issue185Card({super.key});
@@ -9,9 +11,9 @@ class Issue185Card extends StatefulWidget {
   State<Issue185Card> createState() => _Issue185CardState();
 }
 
-class _Issue185CardState extends State<Issue185Card> {
+class _Issue185CardState extends State<Issue185Card>
+    with IssueCardRun<Issue185Card> {
   bool _isTracking = false;
-  String _status = 'Idle';
   StreamSubscription? _sub;
 
   final TextEditingController _latController = TextEditingController(
@@ -33,13 +35,11 @@ class _Issue185CardState extends State<Issue185Card> {
     super.dispose();
   }
 
-  void _setStatus(String text) {
-    if (mounted) {
-      setState(() {
-        _status = text;
-      });
-    }
-  }
+  void _setStatus(String text) => setStatus(text);
+
+  // Start/stop tracking by hand: a sweep would leave the SDK tracking.
+  @override
+  IssueRunner? get cardRunner => null;
 
   Future<void> _start() async {
     _setStatus('Requesting permissions...');
@@ -124,22 +124,7 @@ class _Issue185CardState extends State<Issue185Card> {
               ],
             ),
             const SizedBox(height: 8),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             Row(
               children: [

--- a/example/lib/issues/issue_198_card.dart
+++ b/example/lib/issues/issue_198_card.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 class Issue198Card extends StatefulWidget {
   const Issue198Card({super.key});
@@ -9,9 +11,9 @@ class Issue198Card extends StatefulWidget {
   State<Issue198Card> createState() => _Issue198CardState();
 }
 
-class _Issue198CardState extends State<Issue198Card> {
+class _Issue198CardState extends State<Issue198Card>
+    with IssueCardRun<Issue198Card> {
   bool _isTracking = false;
-  String _status = 'Idle';
   StreamSubscription? _sub;
 
   @override
@@ -20,13 +22,11 @@ class _Issue198CardState extends State<Issue198Card> {
     super.dispose();
   }
 
-  void _setStatus(String text) {
-    if (mounted) {
-      setState(() {
-        _status = text;
-      });
-    }
-  }
+  void _setStatus(String text) => setStatus(text);
+
+  // Start/stop tracking by hand: a sweep would leave the SDK tracking.
+  @override
+  IssueRunner? get cardRunner => null;
 
   Future<void> _start() async {
     _setStatus('Requesting permissions...');
@@ -101,22 +101,7 @@ class _Issue198CardState extends State<Issue198Card> {
               ],
             ),
             const SizedBox(height: 8),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             ElevatedButton.icon(
               onPressed: _isTracking ? _stop : _start,

--- a/example/lib/issues/issue_201_card.dart
+++ b/example/lib/issues/issue_201_card.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #201 — Local extras passed to `getCurrentPosition(extras: ...)` must
 /// survive into the location payload alongside the globally-configured
@@ -17,16 +19,15 @@ class Issue201Card extends StatefulWidget {
   State<Issue201Card> createState() => _Issue201CardState();
 }
 
-class _Issue201CardState extends State<Issue201Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue201CardState extends State<Issue201Card>
+    with IssueCardRun<Issue201Card> {
+  void _setStatus(String text) => setStatus(text);
 
-  void _setStatus(String text) {
-    if (mounted) setState(() => _status = text);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _setStatus('Requesting permissions...');
       final auth = await Tracelet.requestLocationAuthorization();
@@ -78,7 +79,7 @@ class _Issue201CardState extends State<Issue201Card> {
     } catch (e) {
       _setStatus('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -102,25 +103,10 @@ class _Issue201CardState extends State<Issue201Card> {
               'with global HttpConfig.extras instead of being dropped.',
             ),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             FilledButton.icon(
-              onPressed: _running ? null : _test,
+              onPressed: running ? null : _test,
               icon: const Icon(Icons.play_arrow),
               label: const Text('Run Test'),
             ),

--- a/example/lib/issues/issue_204_card.dart
+++ b/example/lib/issues/issue_204_card.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #204 — `requestSyncBody` (the custom sync-body builder) must be invoked
 /// exactly ONCE per batch. The bug caused two sync providers to fire
@@ -16,20 +18,18 @@ class Issue204Card extends StatefulWidget {
   State<Issue204Card> createState() => _Issue204CardState();
 }
 
-class _Issue204CardState extends State<Issue204Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue204CardState extends State<Issue204Card>
+    with IssueCardRun<Issue204Card> {
   int _invocations = 0;
 
-  void _setStatus(String text) {
-    if (mounted) setState(() => _status = text);
-  }
+  void _setStatus(String text) => setStatus(text);
+
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() {
-      _running = true;
-      _invocations = 0;
-    });
+    setRunning(running: true);
+    setState(() => _invocations = 0);
     try {
       // Count every requestSyncBody invocation for ONE batch.
       await Tracelet.setSyncBodyBuilder((ctx) async {
@@ -94,7 +94,7 @@ class _Issue204CardState extends State<Issue204Card> {
     } catch (e) {
       _setStatus('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -118,25 +118,16 @@ class _Issue204CardState extends State<Issue204Card> {
               'one batch. Expected exactly 1 (duplicate providers would fire 2).',
             ),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                '$_status\n\nrequestSyncBody invocations: $_invocations',
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
+            IssueStatusBox(
+              // The count is repeated live while the test runs; the final
+              // message names it too, which is the copy that survives a scroll.
+              status: running
+                  ? '$status\n\nrequestSyncBody invocations: $_invocations'
+                  : status,
             ),
             const SizedBox(height: 16),
             FilledButton.icon(
-              onPressed: _running ? null : _test,
+              onPressed: running ? null : _test,
               icon: const Icon(Icons.play_arrow),
               label: const Text('Run Test'),
             ),

--- a/example/lib/issues/issue_210_card.dart
+++ b/example/lib/issues/issue_210_card.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #210 — In geofence mode the iOS blue "location in use" status-bar
 /// indicator was ALWAYS visible (foreground and background), even with
@@ -30,17 +32,18 @@ class Issue210Card extends StatefulWidget {
   State<Issue210Card> createState() => _Issue210CardState();
 }
 
-class _Issue210CardState extends State<Issue210Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue210CardState extends State<Issue210Card>
+    with IssueCardRun<Issue210Card> {
   bool _tracking = false;
   bool _highAccuracy = false;
   final List<String> _log = [];
   StreamSubscription<GeofenceEvent>? _geofenceSub;
 
-  void _setStatus(String text) {
-    if (mounted) setState(() => _status = text);
-  }
+  void _setStatus(String text) => setStatus(text);
+
+  // Start/stop tracking by hand: a sweep would leave the SDK tracking.
+  @override
+  IssueRunner? get cardRunner => null;
 
   void _appendLog(String line) {
     final stamp = TimeOfDay.now().format(context);
@@ -53,10 +56,8 @@ class _Issue210CardState extends State<Issue210Card> {
   }
 
   Future<void> _start() async {
-    setState(() {
-      _running = true;
-      _log.clear();
-    });
+    setRunning(running: true);
+    setState(_log.clear);
     try {
       _setStatus('Requesting permissions...');
       final auth = await Tracelet.requestLocationAuthorization();
@@ -143,12 +144,12 @@ class _Issue210CardState extends State<Issue210Card> {
     } catch (e) {
       _setStatus('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
   Future<void> _stop() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       await _geofenceSub?.cancel();
       _geofenceSub = null;
@@ -159,12 +160,8 @@ class _Issue210CardState extends State<Issue210Card> {
     } catch (e) {
       _setStatus('❌ Error stopping: $e');
     } finally {
-      if (mounted) {
-        setState(() {
-          _running = false;
-          _tracking = false;
-        });
-      }
+      setRunning(running: false);
+      if (mounted) setState(() => _tracking = false);
     }
   }
 
@@ -197,22 +194,7 @@ class _Issue210CardState extends State<Issue210Card> {
               'stream into the log.',
             ),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 4),
             SwitchListTile(
               contentPadding: EdgeInsets.zero,
@@ -224,7 +206,7 @@ class _Issue210CardState extends State<Issue210Card> {
                     : 'OFF: 100m region monitoring — no iOS indicator.',
               ),
               value: _highAccuracy,
-              onChanged: (_running || _tracking)
+              onChanged: (running || _tracking)
                   ? null
                   : (v) => setState(() => _highAccuracy = v),
             ),
@@ -233,7 +215,7 @@ class _Issue210CardState extends State<Issue210Card> {
               children: [
                 Expanded(
                   child: FilledButton.icon(
-                    onPressed: (_running || _tracking) ? null : _start,
+                    onPressed: (running || _tracking) ? null : _start,
                     icon: const Icon(Icons.play_arrow),
                     label: const Text('Start geofencing'),
                   ),
@@ -241,7 +223,7 @@ class _Issue210CardState extends State<Issue210Card> {
                 const SizedBox(width: 8),
                 Expanded(
                   child: OutlinedButton.icon(
-                    onPressed: (_running || !_tracking) ? null : _stop,
+                    onPressed: (running || !_tracking) ? null : _stop,
                     icon: const Icon(Icons.stop),
                     label: const Text('Stop'),
                   ),
@@ -263,7 +245,7 @@ class _Issue210CardState extends State<Issue210Card> {
                 ),
                 constraints: const BoxConstraints(maxHeight: 180),
                 child: SingleChildScrollView(
-                  child: Text(
+                  child: SelectableText(
                     _log.join('\n'),
                     style: const TextStyle(
                       fontFamily: 'monospace',

--- a/example/lib/issues/issue_212_card.dart
+++ b/example/lib/issues/issue_212_card.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #212 — the reverse-geocoded `address` is saved to SQLite but was dropped
 /// from the **default** (non-custom-builder) sync payload because the Rust
@@ -19,16 +20,15 @@ class Issue212Card extends StatefulWidget {
   State<Issue212Card> createState() => _Issue212CardState();
 }
 
-class _Issue212CardState extends State<Issue212Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue212CardState extends State<Issue212Card>
+    with IssueCardRun<Issue212Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     HttpServer? server;
     try {
       server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -89,7 +89,7 @@ class _Issue212CardState extends State<Issue212Card> {
       _set('❌ FAILED: $e');
     } finally {
       await server?.close(force: true);
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -101,8 +101,8 @@ class _Issue212CardState extends State<Issue212Card> {
           'Inserts a location with an address, runs a DEFAULT sync (no custom '
           'builder) to a loopback server, and asserts the payload contains the '
           'address as a nested object.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_213_card.dart
+++ b/example/lib/issues/issue_213_card.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #213 — a debounced auto-sync that was already waiting out its
 /// `autoSyncDelay` kept firing up to ~10s after `Tracelet.stop()`, because the
@@ -19,16 +20,15 @@ class Issue213Card extends StatefulWidget {
   State<Issue213Card> createState() => _Issue213CardState();
 }
 
-class _Issue213CardState extends State<Issue213Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue213CardState extends State<Issue213Card>
+    with IssueCardRun<Issue213Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     HttpServer? server;
     try {
       server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -88,7 +88,7 @@ class _Issue213CardState extends State<Issue213Card> {
       _set('❌ FAILED: $e');
     } finally {
       await server?.close(force: true);
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -100,8 +100,8 @@ class _Issue213CardState extends State<Issue213Card> {
           'Queues a debounced auto-sync, calls stop() before the delay elapses, '
           'then waits past the delay and asserts the loopback server received '
           'NO request. Takes ~7s.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_214_card.dart
+++ b/example/lib/issues/issue_214_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #214 (part 2) — telematics/crash events were omitted from the custom
 /// sync body builder; the builder only received `location_events`, never the
@@ -18,16 +19,15 @@ class Issue214Card extends StatefulWidget {
   State<Issue214Card> createState() => _Issue214CardState();
 }
 
-class _Issue214CardState extends State<Issue214Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue214CardState extends State<Issue214Card>
+    with IssueCardRun<Issue214Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     HttpServer? server;
     try {
       server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -96,7 +96,7 @@ class _Issue214CardState extends State<Issue214Card> {
       _set('❌ FAILED: $e');
     } finally {
       await server?.close(force: true);
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -108,8 +108,8 @@ class _Issue214CardState extends State<Issue214Card> {
           'Enables syncTelematics, simulates a telematics event, and asserts the '
           'custom body builder receives it via context.telematics (was bypassed). '
           'Set syncTelematics:false to confirm nothing is passed.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_230_card.dart
+++ b/example/lib/issues/issue_230_card.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #230 — runtime config changes (setConfig) did not propagate to the
 /// active native tracking/sensor loops. Only a few location keys triggered a
@@ -22,16 +23,15 @@ class Issue230Card extends StatefulWidget {
   State<Issue230Card> createState() => _Issue230CardState();
 }
 
-class _Issue230CardState extends State<Issue230Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue230CardState extends State<Issue230Card>
+    with IssueCardRun<Issue230Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _set('Requesting permissions...');
       final auth = await Tracelet.requestLocationAuthorization();
@@ -100,7 +100,7 @@ class _Issue230CardState extends State<Issue230Card> {
       try {
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -113,8 +113,8 @@ class _Issue230CardState extends State<Issue230Card> {
           'SPEED mode via setConfig, then asserts the native log shows a '
           'stop→start restart of the pipeline (previously the motion sensors '
           'kept running on stale parameters until the app was force-killed).',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_231_card.dart
+++ b/example/lib/issues/issue_231_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #231 — geofence transition events were emitted with hardcoded zero
 /// coordinate metrics (accuracy/speed/heading/altitude) and no `battery` key,
@@ -18,19 +19,19 @@ class Issue231Card extends StatefulWidget {
   State<Issue231Card> createState() => _Issue231CardState();
 }
 
-class _Issue231CardState extends State<Issue231Card> {
+class _Issue231CardState extends State<Issue231Card>
+    with IssueCardRun<Issue231Card> {
   static const _geofenceId = 'issue-231-here';
 
-  String _status = 'Idle';
-  bool _running = false;
   StreamSubscription<GeofenceEvent>? _sub;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final completer = Completer<String>();
     try {
       _set('Requesting permissions...');
@@ -121,7 +122,7 @@ class _Issue231CardState extends State<Issue231Card> {
         await Tracelet.removeGeofence(_geofenceId);
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -140,8 +141,8 @@ class _Issue231CardState extends State<Issue231Card> {
           'triggers an ENTER, and asserts the event carries a real accuracy and '
           'a valid battery level (previously hardcoded 0.0 / -1.0). Needs a live '
           'GPS fix — run outdoors or with a mock location set.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_237_card.dart
+++ b/example/lib/issues/issue_237_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #237 — periodic mode with `periodicUseForegroundService: true` did not
 /// start a foreground service, so tracking died the moment the app was swiped
@@ -29,13 +30,12 @@ class Issue237Card extends StatefulWidget {
   State<Issue237Card> createState() => _Issue237CardState();
 }
 
-class _Issue237CardState extends State<Issue237Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue237CardState extends State<Issue237Card>
+    with IssueCardRun<Issue237Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
     if (!Platform.isAndroid) {
@@ -43,7 +43,7 @@ class _Issue237CardState extends State<Issue237Card> {
       return;
     }
 
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _set('Requesting permissions...');
       final auth = await Tracelet.requestLocationAuthorization();
@@ -86,7 +86,7 @@ class _Issue237CardState extends State<Issue237Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -99,8 +99,8 @@ class _Issue237CardState extends State<Issue237Card> {
           'interval (the exact reporter setup). The foreground service used to '
           'be stopped-then-restarted, racing itself into oblivion; now it starts '
           'and survives app swipe-away. Android-only. Verify via dumpsys.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_238_card.dart
+++ b/example/lib/issues/issue_238_card.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #238 — `setSyncBodyBuilder` fails with status=0 "Custom body sync failed"
 ///
@@ -18,19 +19,19 @@ class Issue238Card extends StatefulWidget {
   State<Issue238Card> createState() => _Issue238CardState();
 }
 
-class _Issue238CardState extends State<Issue238Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue238CardState extends State<Issue238Card>
+    with IssueCardRun<Issue238Card> {
   HttpServer? _server;
   StreamSubscription? _syncSub;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
     _set('Starting local server...');
 
     try {
@@ -107,7 +108,7 @@ class _Issue238CardState extends State<Issue238Card> {
       _syncSub = null;
       await Tracelet.stop();
       Tracelet.setSyncBodyBuilder(null);
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -127,8 +128,8 @@ class _Issue238CardState extends State<Issue238Card> {
           'sync to a local HttpServer. The server intentionally returns '
           'a 400 Bad Request to simulate rejection. The test asserts that '
           'the SDK correctly reports status=400 instead of masking it as 0.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_243_card.dart
+++ b/example/lib/issues/issue_243_card.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #243 — startPeriodic posts the foreground notification even though
 /// `periodicUseForegroundService: false` and `foregroundService.enabled: false`.
@@ -22,17 +23,16 @@ class Issue243Card extends StatefulWidget {
   State<Issue243Card> createState() => _Issue243CardState();
 }
 
-class _Issue243CardState extends State<Issue243Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue243CardState extends State<Issue243Card>
+    with IssueCardRun<Issue243Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       if (!Platform.isAndroid) {
@@ -89,7 +89,7 @@ class _Issue243CardState extends State<Issue243Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -103,8 +103,8 @@ class _Issue243CardState extends State<Issue243Card> {
           'On aggressive OEMs the old native config layer silently forced '
           'both flags to true, posting the default foreground notification. '
           'Explicit config is now honored (WorkManager strategy, no service).',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_244_card.dart
+++ b/example/lib/issues/issue_244_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// PR #244 — iOS `buildLocationMap` hardcoded `activity.type: "unknown"` /
 /// `confidence: -1` on every persisted/dispatched location, so the fused
@@ -24,17 +25,16 @@ class Issue244Card extends StatefulWidget {
   State<Issue244Card> createState() => _Issue244CardState();
 }
 
-class _Issue244CardState extends State<Issue244Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue244CardState extends State<Issue244Card>
+    with IssueCardRun<Issue244Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     StreamSubscription<ModeChangeEvent>? modeSub;
     StreamSubscription<Location>? locSub;
@@ -104,7 +104,7 @@ class _Issue244CardState extends State<Issue244Card> {
       await modeSub?.cancel();
       await locSub?.cancel();
       await Tracelet.stop();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -118,8 +118,8 @@ class _Issue244CardState extends State<Issue244Card> {
           '(e.g. still, in_vehicle) with a real confidence — on iOS it was '
           'hardcoded unknown/-1, and vehicle/cycling now map to the AR '
           'vocabulary on both platforms. Run on a real device.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_247_card.dart
+++ b/example/lib/issues/issue_247_card.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #247 — startGeofences() posts the foreground notification even though
 /// `GeofenceConfig(geofenceModeHighAccuracy: false)` is set.
@@ -26,17 +27,16 @@ class Issue247Card extends StatefulWidget {
   State<Issue247Card> createState() => _Issue247CardState();
 }
 
-class _Issue247CardState extends State<Issue247Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue247CardState extends State<Issue247Card>
+    with IssueCardRun<Issue247Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       if (!Platform.isAndroid) {
@@ -97,7 +97,7 @@ class _Issue247CardState extends State<Issue247Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -112,8 +112,8 @@ class _Issue247CardState extends State<Issue247Card> {
           'the location engine and the foreground-service notification that '
           'low-accuracy geofences-only mode exists to avoid. Explicit config '
           'is now honored (native GeofencingClient only, no service).',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_248_card.dart
+++ b/example/lib/issues/issue_248_card.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #248 — `insertLocation failed: UNIQUE constraint failed:
 /// location_events.uuid` recurring on a fixed ~2-minute interval while
@@ -30,20 +31,19 @@ class Issue248Card extends StatefulWidget {
   State<Issue248Card> createState() => _Issue248CardState();
 }
 
-class _Issue248CardState extends State<Issue248Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue248CardState extends State<Issue248Card>
+    with IssueCardRun<Issue248Card> {
   static const int _intervalSeconds = 30;
   static const int _waitSeconds = 75; // two ticks + margin
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       if (!Platform.isAndroid) {
@@ -121,7 +121,7 @@ class _Issue248CardState extends State<Issue248Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -138,8 +138,8 @@ class _Issue248CardState extends State<Issue248Card> {
           'second insert failed with "UNIQUE constraint failed: '
           'location_events.uuid" every ~120s (the default interval). Verifies '
           'ticks now persist exactly once, as "periodic" events.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_250_card.dart
+++ b/example/lib/issues/issue_250_card.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart'
     show TlIosActivityType;
 
@@ -29,17 +30,16 @@ class Issue250Card extends StatefulWidget {
   State<Issue250Card> createState() => _Issue250CardState();
 }
 
-class _Issue250CardState extends State<Issue250Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue250CardState extends State<Issue250Card>
+    with IssueCardRun<Issue250Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       // The exact mapping the SDK must produce — by name, never by index.
@@ -103,7 +103,7 @@ class _Issue250CardState extends State<Issue250Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -118,8 +118,8 @@ class _Issue250CardState extends State<Issue250Card> {
           'it also pushes activityType=automotiveNavigation through ready() so '
           'you can confirm CLLocationManager.activityType now honors the '
           'configured value instead of always falling back to otherNavigation.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_251_card.dart
+++ b/example/lib/issues/issue_251_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #251 — `destroyLocation(uuid)` could not delete persisted locations
 /// because the native SDK parsed the public UUID as a numeric database id.
@@ -22,17 +23,16 @@ class Issue251Card extends StatefulWidget {
   State<Issue251Card> createState() => _Issue251CardState();
 }
 
-class _Issue251CardState extends State<Issue251Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue251CardState extends State<Issue251Card>
+    with IssueCardRun<Issue251Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       _set('Inserting a location to obtain a real UUID...');
@@ -82,7 +82,7 @@ class _Issue251CardState extends State<Issue251Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -95,8 +95,8 @@ class _Issue251CardState extends State<Issue251Card> {
           '(not a bare number), then deletes it via destroyLocation(uuid) and '
           'verifies it is gone. Both Android and iOS used to parse the UUID as '
           'a numeric database id and return false without deleting anything.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_252_card.dart
+++ b/example/lib/issues/issue_252_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #252 — the iOS heartbeat writer persisted the same GPS fix twice, so
 /// `getLocations()` returned byte-identical duplicate location rows (roughly
@@ -27,17 +28,16 @@ class Issue252Card extends StatefulWidget {
   State<Issue252Card> createState() => _Issue252CardState();
 }
 
-class _Issue252CardState extends State<Issue252Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue252CardState extends State<Issue252Card>
+    with IssueCardRun<Issue252Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       _set('Clearing the store...');
@@ -91,7 +91,7 @@ class _Issue252CardState extends State<Issue252Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -105,8 +105,8 @@ class _Issue252CardState extends State<Issue252Card> {
           'a single row is stored. On iOS the heartbeat used to bypass the '
           'location-only dedup guard and persist a byte-identical duplicate, so '
           'getLocations() returned roughly half a moving trip twice.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_253_card.dart
+++ b/example/lib/issues/issue_253_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #253 — a failed foreground promotion still marked the Android service
 /// as a running foreground service.
@@ -39,19 +40,18 @@ class Issue253Card extends StatefulWidget {
   State<Issue253Card> createState() => _Issue253CardState();
 }
 
-class _Issue253CardState extends State<Issue253Card> {
+class _Issue253CardState extends State<Issue253Card>
+    with IssueCardRun<Issue253Card> {
   static const _debug = MethodChannel('com.tracelet/debug');
 
-  String _status = 'Idle';
-  bool _running = false;
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       _set('Inspecting the native foreground-promotion guard...');
@@ -99,7 +99,7 @@ class _Issue253CardState extends State<Issue253Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -114,8 +114,8 @@ class _Issue253CardState extends State<Issue253Card> {
           'now returns its success and callers gate the flag on it. This test '
           'inspects the shipped native code to confirm the guard is in place '
           '(Android); iOS is structurally unaffected.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_254_card.dart
+++ b/example/lib/issues/issue_254_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #254 — `setConfig()` restart exposed the same foreground-service race
 /// that #237 fixed for `startPeriodic()`.
@@ -36,13 +37,12 @@ class Issue254Card extends StatefulWidget {
   State<Issue254Card> createState() => _Issue254CardState();
 }
 
-class _Issue254CardState extends State<Issue254Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue254CardState extends State<Issue254Card>
+    with IssueCardRun<Issue254Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
     if (!Platform.isAndroid) {
@@ -50,7 +50,7 @@ class _Issue254CardState extends State<Issue254Card> {
       return;
     }
 
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _set('Requesting permissions...');
       final auth = await Tracelet.requestLocationAuthorization();
@@ -113,7 +113,7 @@ class _Issue254CardState extends State<Issue254Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -127,8 +127,8 @@ class _Issue254CardState extends State<Issue254Card> {
           'stop()/start() used to race ACTION_STOP against ACTION_START and '
           'could destroy the just-promoted service; the service is now preserved '
           'across the restart. Android-only. Verify via dumpsys.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_255_card.dart
+++ b/example/lib/issues/issue_255_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #255 — authoritative foreground-service health exposed to Dart.
 ///
@@ -30,16 +31,15 @@ class Issue255Card extends StatefulWidget {
   State<Issue255Card> createState() => _Issue255CardState();
 }
 
-class _Issue255CardState extends State<Issue255Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue255CardState extends State<Issue255Card>
+    with IssueCardRun<Issue255Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -188,7 +188,7 @@ class _Issue255CardState extends State<Issue255Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -207,8 +207,8 @@ class _Issue255CardState extends State<Issue255Card> {
           'whether the service is running and promoted, and when a promotion '
           'was deferred or failed, the exception class and message behind it. '
           'Android-only fields are skipped on other platforms.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_256_card.dart
+++ b/example/lib/issues/issue_256_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #256 — `setConfig()` could restore a TEMPORARY stationary mode as the
 /// main tracking mode.
@@ -36,16 +37,15 @@ class Issue256Card extends StatefulWidget {
   State<Issue256Card> createState() => _Issue256CardState();
 }
 
-class _Issue256CardState extends State<Issue256Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue256CardState extends State<Issue256Card>
+    with IssueCardRun<Issue256Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _set('Requesting permissions...');
       final auth = await Tracelet.requestLocationAuthorization();
@@ -152,7 +152,7 @@ class _Issue256CardState extends State<Issue256Card> {
       try {
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -167,8 +167,8 @@ class _Issue256CardState extends State<Issue256Card> {
           'restart-sensitive setConfig(). Asserts the restart went through the '
           'continuous motion-aware start() path and did NOT rebuild a standalone '
           'geofence/periodic mode (which would strand tracking).',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_257_card.dart
+++ b/example/lib/issues/issue_257_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #257 — expose a public API to refresh the active foreground-service
 /// notification (and its iOS Live Activity analogue).
@@ -39,13 +40,12 @@ class Issue257Card extends StatefulWidget {
   State<Issue257Card> createState() => _Issue257CardState();
 }
 
-class _Issue257CardState extends State<Issue257Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue257CardState extends State<Issue257Card>
+    with IssueCardRun<Issue257Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   /// Keeps tracking alive for [seconds] while updating the status once per
   /// second via [message] (given the remaining seconds), so the live
@@ -63,7 +63,7 @@ class _Issue257CardState extends State<Issue257Card> {
   }
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid && !Platform.isIOS) {
         _set(
@@ -215,7 +215,7 @@ class _Issue257CardState extends State<Issue257Card> {
       try {
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -231,8 +231,8 @@ class _Issue257CardState extends State<Issue257Card> {
           'to refresh the live indicator without restarting tracking. Asserts '
           'the call completes and tracking stays enabled. Watch the '
           'notification shade (Android) or Dynamic Island / Lock Screen (iOS).',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_261_card.dart
+++ b/example/lib/issues/issue_261_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #261 — `IosConfig.useSignificantChangesOnly` must not open a
 /// `CLBackgroundActivitySession`.
@@ -36,16 +37,15 @@ class Issue261Card extends StatefulWidget {
   State<Issue261Card> createState() => _Issue261CardState();
 }
 
-class _Issue261CardState extends State<Issue261Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue261CardState extends State<Issue261Card>
+    with IssueCardRun<Issue261Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isIOS) {
         _set(
@@ -148,7 +148,7 @@ class _Issue261CardState extends State<Issue261Card> {
       try {
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -169,8 +169,8 @@ class _Issue261CardState extends State<Issue261Card> {
           'CLBackgroundActivitySession (which would keep the persistent iOS '
           'location indicator on and defeat significant-change monitoring). '
           'iOS 17+ only; background the app to confirm no ongoing location pill.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_262_card.dart
+++ b/example/lib/issues/issue_262_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #262 — `ready()` must not surface remote-config event registration
 /// failure as an UNCAUGHT async error.
@@ -38,16 +39,15 @@ class Issue262Card extends StatefulWidget {
   State<Issue262Card> createState() => _Issue262CardState();
 }
 
-class _Issue262CardState extends State<Issue262Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue262CardState extends State<Issue262Card>
+    with IssueCardRun<Issue262Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _set(
         'Calling Tracelet.ready() inside a runZonedGuarded error zone and '
@@ -127,7 +127,7 @@ class _Issue262CardState extends State<Issue262Card> {
       try {
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -146,8 +146,8 @@ class _Issue262CardState extends State<Issue262Card> {
           'handler while the remote-config event channel registers. Pre-fix, a '
           'fire-and-forget requestStateFlush() failure landed in the zone and '
           'took down a ride-start sequence. Runs on Android and iOS.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_263_card.dart
+++ b/example/lib/issues/issue_263_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #263 — `IncompatibleClassChangeError` when Play Services Location
 /// resolved below 21.2.0.
@@ -36,16 +37,15 @@ class Issue263Card extends StatefulWidget {
   State<Issue263Card> createState() => _Issue263CardState();
 }
 
-class _Issue263CardState extends State<Issue263Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue263CardState extends State<Issue263Card>
+    with IssueCardRun<Issue263Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -162,7 +162,7 @@ class _Issue263CardState extends State<Issue263Card> {
         '${results.join('\n')}',
       );
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -182,8 +182,8 @@ class _Issue263CardState extends State<Issue263Card> {
           'ActivityRecognitionClient are concrete classes rather than the '
           'interfaces Tracelet compiles against. Exercises both client paths; '
           'a timeout indoors is tolerated, a linkage error is not.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_264_card.dart
+++ b/example/lib/issues/issue_264_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #264 — Android `startOnBoot` geofence restart crashes with an
 /// uninitialized `geofenceManager`.
@@ -52,18 +53,18 @@ class Issue264Card extends StatefulWidget {
   State<Issue264Card> createState() => _Issue264CardState();
 }
 
-class _Issue264CardState extends State<Issue264Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue264CardState extends State<Issue264Card>
+    with IssueCardRun<Issue264Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  // Two-phase: arm, reboot the device, then check. Not sweepable.
+  @override
+  IssueRunner? get cardRunner => null;
 
   /// Persist the exact state described in #264 so a reboot exercises the native
   /// `startBootTracking()` → `geofenceManager` path.
   Future<void> _arm() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid) {
         _set(
@@ -141,7 +142,7 @@ class _Issue264CardState extends State<Issue264Card> {
     } catch (e) {
       _set('❌ FAILED to arm the repro: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -150,7 +151,7 @@ class _Issue264CardState extends State<Issue264Card> {
   /// the process survived boot the SDK marks `didDeviceReboot` and keeps the
   /// geofence mode enabled.
   Future<void> _checkPostReboot() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid) {
         _set('ℹ️ #264 is Android-only.');
@@ -172,7 +173,7 @@ class _Issue264CardState extends State<Issue264Card> {
     } catch (e) {
       _set('❌ FAILED to read state: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -217,34 +218,19 @@ class _Issue264CardState extends State<Issue264Card> {
             const SizedBox(height: 8),
             const Text(_description),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             Wrap(
               spacing: 8,
               runSpacing: 8,
               children: [
                 FilledButton.icon(
-                  onPressed: _running ? null : _arm,
+                  onPressed: running ? null : _arm,
                   icon: const Icon(Icons.play_arrow),
                   label: const Text('Arm reboot repro'),
                 ),
                 OutlinedButton.icon(
-                  onPressed: _running ? null : _checkPostReboot,
+                  onPressed: running ? null : _checkPostReboot,
                   icon: const Icon(Icons.restart_alt),
                   label: const Text('Check post-reboot state'),
                 ),

--- a/example/lib/issues/issue_265_card.dart
+++ b/example/lib/issues/issue_265_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #265 — Android `addGeofence()` returns `false` after a *successful*
 /// persistence.
@@ -54,16 +55,15 @@ class Issue265Card extends StatefulWidget {
   State<Issue265Card> createState() => _Issue265CardState();
 }
 
-class _Issue265CardState extends State<Issue265Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue265CardState extends State<Issue265Card>
+    with IssueCardRun<Issue265Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid) {
         _set(
@@ -143,7 +143,7 @@ class _Issue265CardState extends State<Issue265Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -164,8 +164,8 @@ class _Issue265CardState extends State<Issue265Card> {
           '(the async Play Services callback has not flipped success yet) while '
           'getGeofences() shows the geofence. Android-only; run right after a '
           'fresh launch for the most reliable repro.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_267_card.dart
+++ b/example/lib/issues/issue_267_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #267 — expose [Tracelet.requestTermination] on the headless
 /// `com.tracelet/methods` MethodChannel so a killed-app background isolate can
@@ -48,16 +49,15 @@ class Issue267Card extends StatefulWidget {
   State<Issue267Card> createState() => _Issue267CardState();
 }
 
-class _Issue267CardState extends State<Issue267Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue267CardState extends State<Issue267Card>
+    with IssueCardRun<Issue267Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid) {
         _set(
@@ -129,7 +129,7 @@ class _Issue267CardState extends State<Issue267Card> {
       try {
         await Tracelet.stop();
       } catch (_) {}
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -154,8 +154,8 @@ class _Issue267CardState extends State<Issue267Card> {
           'headless engine). Trigger it from a real FCM background handler '
           'while the app is killed to see the GPS service stop. Android-only.',
       runLabel: 'Arm headless repro',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/issue_268_card.dart
+++ b/example/lib/issues/issue_268_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #268 — Geofence ENTER/EXIT flapping for a stationary device inside
 /// the radius (high-accuracy mode).
@@ -31,16 +32,15 @@ class Issue268Card extends StatefulWidget {
   State<Issue268Card> createState() => _Issue268CardState();
 }
 
-class _Issue268CardState extends State<Issue268Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue268CardState extends State<Issue268Card>
+    with IssueCardRun<Issue268Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       const centerLat = 37.4219983;
       const centerLng = -122.084;
@@ -109,7 +109,7 @@ class _Issue268CardState extends State<Issue268Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -129,8 +129,8 @@ class _Issue268CardState extends State<Issue268Card> {
           'ENTER/EXIT) so you can confirm #268 exists; on the fixed build it '
           'reports exactly one ENTER and no EXIT. Runs in-process; no '
           'permissions or device movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_270_card.dart
+++ b/example/lib/issues/issue_270_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// PR #270 — Android boot/broadcast init race: geofence transitions and
 /// confirmed crash/fall deliveries can be silently dropped right after a cold
@@ -55,15 +56,16 @@ class Issue270Card extends StatefulWidget {
   State<Issue270Card> createState() => _Issue270CardState();
 }
 
-class _Issue270CardState extends State<Issue270Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue270CardState extends State<Issue270Card>
+    with IssueCardRun<Issue270Card> {
   StreamSubscription<GeofenceEvent>? _geofenceSub;
   int _liveTransitions = 0;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  // Two-phase: arm, reboot the device, then check. Not sweepable.
+  @override
+  IssueRunner? get cardRunner => null;
 
   @override
   void dispose() {
@@ -75,7 +77,7 @@ class _Issue270CardState extends State<Issue270Card> {
   /// `GeofenceBroadcastReceiver.onReceive` → `awaitInit()` → `geofenceManager`
   /// path.
   Future<void> _arm() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid) {
         _set(
@@ -155,7 +157,7 @@ class _Issue270CardState extends State<Issue270Card> {
     } catch (e) {
       _set('❌ FAILED to arm the repro: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -164,7 +166,7 @@ class _Issue270CardState extends State<Issue270Card> {
   /// the receiver waited for init (fixed); zero (with a confirmed crossing)
   /// points at the dropped-transition regression.
   Future<void> _checkTransitions() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       if (!Platform.isAndroid) {
         _set('ℹ️ PR #270 is Android-only.');
@@ -198,7 +200,7 @@ class _Issue270CardState extends State<Issue270Card> {
     } catch (e) {
       _set('❌ FAILED to read state: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -244,34 +246,19 @@ class _Issue270CardState extends State<Issue270Card> {
             const SizedBox(height: 8),
             const Text(_description),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             Wrap(
               spacing: 8,
               runSpacing: 8,
               children: [
                 FilledButton.icon(
-                  onPressed: _running ? null : _arm,
+                  onPressed: running ? null : _arm,
                   icon: const Icon(Icons.play_arrow),
                   label: const Text('Arm reboot repro'),
                 ),
                 OutlinedButton.icon(
-                  onPressed: _running ? null : _checkTransitions,
+                  onPressed: running ? null : _checkTransitions,
                   icon: const Icon(Icons.sensors),
                   label: const Text('Check delivered transitions'),
                 ),

--- a/example/lib/issues/issue_274_card.dart
+++ b/example/lib/issues/issue_274_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #274 — GPS drift fires a false EXIT on small-radius geofences
 /// (high-accuracy mode).
@@ -38,16 +39,15 @@ class Issue274Card extends StatefulWidget {
   State<Issue274Card> createState() => _Issue274CardState();
 }
 
-class _Issue274CardState extends State<Issue274Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue274CardState extends State<Issue274Card>
+    with IssueCardRun<Issue274Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       const centerLat = 37.4219983;
       const centerLng = -122.084;
@@ -134,7 +134,7 @@ class _Issue274CardState extends State<Issue274Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -154,8 +154,8 @@ class _Issue274CardState extends State<Issue274Card> {
           'confirm #274 exists; on the fixed build the accuracy-aware exit '
           'holds through the drift and EXITs only on the real departure. Runs '
           'in-process; no permissions or device movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_276_card.dart
+++ b/example/lib/issues/issue_276_card.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #276 — tunable accuracy-aware geofence EXIT (`geofenceExitAccuracyMax`).
 ///
@@ -37,13 +38,12 @@ class Issue276Card extends StatefulWidget {
   State<Issue276Card> createState() => _Issue276CardState();
 }
 
-class _Issue276CardState extends State<Issue276Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue276CardState extends State<Issue276Card>
+    with IssueCardRun<Issue276Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   /// Mirrors the native `GeofenceManager.effectiveExitAccuracy` clamp so the
   /// in-process demo matches on-device behavior:
@@ -99,7 +99,7 @@ class _Issue276CardState extends State<Issue276Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       const modes = <int>[-1, 0, 20];
       final log = StringBuffer();
@@ -154,7 +154,7 @@ class _Issue276CardState extends State<Issue276Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -174,8 +174,8 @@ class _Issue276CardState extends State<Issue276Card> {
           'drift spike while still detecting a real departure, and that '
           'disabling gating (0) reproduces the eager pre-#274 exit. Runs '
           'in-process; no permissions or movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_280_card.dart
+++ b/example/lib/issues/issue_280_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #280 — `locationSource` / `reducedAccuracy` dropped from persisted &
 /// synced locations.
@@ -26,16 +27,15 @@ class Issue280Card extends StatefulWidget {
   State<Issue280Card> createState() => _Issue280CardState();
 }
 
-class _Issue280CardState extends State<Issue280Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue280CardState extends State<Issue280Card>
+    with IssueCardRun<Issue280Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       _set('Testing #280 (persist locationSource / reducedAccuracy)...');
       await Tracelet.ready(const Config());
@@ -86,7 +86,7 @@ class _Issue280CardState extends State<Issue280Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -103,8 +103,8 @@ class _Issue280CardState extends State<Issue280Card> {
           'tags survived. Before the fix the persist path never serialized them '
           'into route_context, so DB-sourced reads and the sync payload always '
           'reported "unknown" / false. Requires a running device (on-device E2E).',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_282_card.dart
+++ b/example/lib/issues/issue_282_card.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #282 — iOS periodic fixes now use the shared best-of-N sampling window.
 ///
@@ -26,26 +27,25 @@ class Issue282Card extends StatefulWidget {
   State<Issue282Card> createState() => _Issue282CardState();
 }
 
-class _Issue282CardState extends State<Issue282Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue282CardState extends State<Issue282Card>
+    with IssueCardRun<Issue282Card> {
   bool _tracking = false;
   int _fixCount = 0;
   StreamSubscription<Location>? _sub;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  // Start/stop tracking by hand: a sweep would leave the SDK tracking.
+  @override
+  IssueRunner? get cardRunner => null;
 
   Future<void> _start() async {
     if (!Platform.isIOS) {
       _set('ℹ️ iOS-only repro (#282 changes the iOS periodic fix path).');
       return;
     }
-    setState(() {
-      _running = true;
-      _fixCount = 0;
-    });
+    setRunning(running: true);
+    setState(() => _fixCount = 0);
     try {
       await Tracelet.requestLocationAuthorization();
       await Tracelet.ready(
@@ -88,7 +88,7 @@ class _Issue282CardState extends State<Issue282Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -122,8 +122,8 @@ class _Issue282CardState extends State<Issue282Card> {
           'accuracy / locationSource. On iOS, periodic fixes now route through '
           'the shared best-of-N window instead of a single requestLocation() '
           'one-shot, so they should be GPS-quality. Manual on-device iOS repro.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       runLabel: _tracking ? 'Stop' : 'Start tracking',
       onRun: _tracking ? _stop : _start,
     );

--- a/example/lib/issues/issue_286_card.dart
+++ b/example/lib/issues/issue_286_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Entrypoint for the secondary engines the iOS probe spawns (see
 /// `AppDelegate.probeIssue286`). A FlutterEngine must be **running** before
@@ -66,19 +67,18 @@ class Issue286Card extends StatefulWidget {
   State<Issue286Card> createState() => _Issue286CardState();
 }
 
-class _Issue286CardState extends State<Issue286Card> {
+class _Issue286CardState extends State<Issue286Card>
+    with IssueCardRun<Issue286Card> {
   static const _debug = MethodChannel('com.tracelet/debug');
 
-  String _status = 'Idle';
-  bool _running = false;
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
     try {
       _set('Attaching 2 secondary FlutterEngines, then releasing them...');
       final res = await _debug.invokeMapMethod<String, dynamic>(
@@ -232,7 +232,7 @@ class _Issue286CardState extends State<Issue286Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -255,8 +255,8 @@ class _Issue286CardState extends State<Issue286Card> {
           'VERIFIES: it attaches and releases 2 secondary engines, then reports '
           'how many distinct sinks were created, how many survive, and how many '
           'are registered on the LocationEngine. Debug build; no fix applied.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       runLabel: 'Verify',
       onRun: _test,
     );

--- a/example/lib/issues/issue_288_card.dart
+++ b/example/lib/issues/issue_288_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tracelet/tracelet.dart' as tl;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #288 — the pace never leaves MOVING in smart motion mode.
 ///
@@ -42,19 +43,18 @@ class Issue288Card extends StatefulWidget {
   State<Issue288Card> createState() => _Issue288CardState();
 }
 
-class _Issue288CardState extends State<Issue288Card> {
+class _Issue288CardState extends State<Issue288Card>
+    with IssueCardRun<Issue288Card> {
   static const _debug = MethodChannel('com.tracelet/debug');
-
-  String _status = 'Idle';
-  bool _running = false;
 
   StreamSubscription<tl.SpeedMotionEvent>? _speedSub;
   StreamSubscription<tl.Location>? _paceSub;
   Timer? _ticker;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _test;
 
   @override
   void dispose() {
@@ -65,8 +65,8 @@ class _Issue288CardState extends State<Issue288Card> {
   }
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     final timeline = <String>[];
     var slowingToMovingFlips = 0;
@@ -238,7 +238,7 @@ class _Issue288CardState extends State<Issue288Card> {
       await _paceSub?.cancel();
       _speedSub = null;
       _paceSub = null;
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -354,8 +354,8 @@ class _Issue288CardState extends State<Issue288Card> {
           'SDK is actually using, so an unset one must show its platform '
           'default. Start tracking first, put the phone on a desk, and do not '
           'touch it while it runs.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       runLabel: 'Verify',
       onRun: _test,
     );

--- a/example/lib/issues/issue_292_card.dart
+++ b/example/lib/issues/issue_292_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #292 — Geofence high-accuracy mode re-emits ENTER on every
 /// resume/boot for a stationary device inside the fence.
@@ -34,16 +35,15 @@ class Issue292Card extends StatefulWidget {
   State<Issue292Card> createState() => _Issue292CardState();
 }
 
-class _Issue292CardState extends State<Issue292Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue292CardState extends State<Issue292Card>
+    with IssueCardRun<Issue292Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       const centerLat = 10.787929;
       const centerLng = 76.684183;
@@ -144,7 +144,7 @@ class _Issue292CardState extends State<Issue292Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -165,8 +165,8 @@ class _Issue292CardState extends State<Issue292Card> {
           'false punch-in); applying the shipped persisted known-inside dedup '
           'collapses it to exactly one ENTER and zero EXIT. Runs in-process; no '
           'permissions or device movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_294_card.dart
+++ b/example/lib/issues/issue_294_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #294 — a single over-confident GPS fix causes false EXIT/ENTER
 /// flapping for a stationary device (high-accuracy geofence mode).
@@ -25,13 +26,12 @@ class Issue294Card extends StatefulWidget {
   State<Issue294Card> createState() => _Issue294CardState();
 }
 
-class _Issue294CardState extends State<Issue294Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue294CardState extends State<Issue294Card>
+    with IssueCardRun<Issue294Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   static const _lat = 10.787929;
   static const _lng = 76.684183;
@@ -86,7 +86,7 @@ class _Issue294CardState extends State<Issue294Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       final results = <String>[];
       var allPass = true;
@@ -181,7 +181,7 @@ class _Issue294CardState extends State<Issue294Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -201,8 +201,8 @@ class _Issue294CardState extends State<Issue294Card> {
           'sustained departure still fires exactly one EXIT (delayed one fix). '
           'Confirms a normal exit is never missed. Runs in-process; no '
           'permissions or device movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_297_card.dart
+++ b/example/lib/issues/issue_297_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #297 — high-accuracy geofence ENTER/EXIT intermittently not firing
 /// (location starvation on stable providers).
@@ -32,13 +33,12 @@ class Issue297Card extends StatefulWidget {
   State<Issue297Card> createState() => _Issue297CardState();
 }
 
-class _Issue297CardState extends State<Issue297Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue297CardState extends State<Issue297Card>
+    with IssueCardRun<Issue297Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   static const _lat = 10.787929;
   static const _lng = 76.684183;
@@ -103,7 +103,7 @@ class _Issue297CardState extends State<Issue297Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       final results = <String>[];
       var allPass = true;
@@ -175,7 +175,7 @@ class _Issue297CardState extends State<Issue297Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -195,8 +195,8 @@ class _Issue297CardState extends State<Issue297Card> {
           'raw-stream path fires exactly one EXIT — and the persisted fix count '
           'is identical, so location volume is unchanged. Runs in-process; no '
           'permissions or device movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_299_card.dart
+++ b/example/lib/issues/issue_299_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #299 — distance over-reported on foot: the odometer ignored Kalman
 /// smoothing, and the transport classifier never tuned the filters.
@@ -36,13 +37,12 @@ class Issue299Card extends StatefulWidget {
   State<Issue299Card> createState() => _Issue299CardState();
 }
 
-class _Issue299CardState extends State<Issue299Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue299CardState extends State<Issue299Card>
+    with IssueCardRun<Issue299Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   static const _lat = 10.787929;
   static const _lng = 76.684183;
@@ -168,7 +168,7 @@ class _Issue299CardState extends State<Issue299Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     try {
       final results = <String>[];
       var allPass = true;
@@ -275,7 +275,7 @@ class _Issue299CardState extends State<Issue299Card> {
     } catch (e) {
       _set('❌ FAILED: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -295,8 +295,8 @@ class _Issue299CardState extends State<Issue299Card> {
           'smoothing ran after the odometer), and smoothing-first plus the '
           'walking auto-tune row landing within 10% of truth. Runs in-process; '
           'no permissions or device movement required.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_301_card.dart
+++ b/example/lib/issues/issue_301_card.dart
@@ -5,6 +5,7 @@ import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart'
     show TlLocationTuning, TlModeChangeEvent;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #301 — auto-tune follow-ups to #299.
 ///
@@ -31,10 +32,8 @@ class Issue301Card extends StatefulWidget {
   State<Issue301Card> createState() => _Issue301CardState();
 }
 
-class _Issue301CardState extends State<Issue301Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue301CardState extends State<Issue301Card>
+    with IssueCardRun<Issue301Card> {
   StreamSubscription<ModeChangeEvent>? _sub;
 
   /// How long to watch the live classifier before giving up on a commit. The
@@ -76,9 +75,10 @@ class _Issue301CardState extends State<Issue301Card> {
     ),
   };
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   @override
   void dispose() {
@@ -87,7 +87,7 @@ class _Issue301CardState extends State<Issue301Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -240,7 +240,7 @@ class _Issue301CardState extends State<Issue301Card> {
       _sub = null;
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -260,8 +260,8 @@ class _Issue301CardState extends State<Issue301Card> {
           'auto-tuning off restores your configured values instead of leaving '
           'the last mode in force. The contract checks run in-process; the live '
           'section watches the real classifier for 25s, so walk around.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_303_card.dart
+++ b/example/lib/issues/issue_303_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #303 — location-filter config never reached the Rust processor.
 ///
@@ -35,16 +36,15 @@ class Issue303Card extends StatefulWidget {
   State<Issue303Card> createState() => _Issue303CardState();
 }
 
-class _Issue303CardState extends State<Issue303Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue303CardState extends State<Issue303Card>
+    with IssueCardRun<Issue303Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -216,7 +216,7 @@ class _Issue303CardState extends State<Issue303Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -236,8 +236,8 @@ class _Issue303CardState extends State<Issue303Card> {
           'ignored until the next cold start — and that disabling auto-tuning '
           'restores the values you most recently set, not the ones captured '
           'when the processor was first built.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_304_card.dart
+++ b/example/lib/issues/issue_304_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #304 — config keys accepted but never applied.
 ///
@@ -43,16 +44,15 @@ class Issue304Card extends StatefulWidget {
   State<Issue304Card> createState() => _Issue304CardState();
 }
 
-class _Issue304CardState extends State<Issue304Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue304CardState extends State<Issue304Card>
+    with IssueCardRun<Issue304Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -144,7 +144,7 @@ class _Issue304CardState extends State<Issue304Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -163,8 +163,8 @@ class _Issue304CardState extends State<Issue304Card> {
           'never implemented at all — now deprecated with a reason instead of '
           'silently doing nothing. Found by sweeping all 156 Android / 149 iOS '
           'config getters against their real consumers.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_305_card.dart
+++ b/example/lib/issues/issue_305_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #305 — the cross-platform geofence high-accuracy flag was dropped on
 /// two of the four config transports.
@@ -33,16 +34,15 @@ class Issue305Card extends StatefulWidget {
   State<Issue305Card> createState() => _Issue305CardState();
 }
 
-class _Issue305CardState extends State<Issue305Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue305CardState extends State<Issue305Card>
+    with IssueCardRun<Issue305Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -128,7 +128,7 @@ class _Issue305CardState extends State<Issue305Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -149,8 +149,8 @@ class _Issue305CardState extends State<Issue305Card> {
           'were silently dropped on the method-channel transport, including '
           'the #276 geofenceExitAccuracyMax tunable — and that the deprecated '
           'Android-only flag still works for existing apps.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_306_card.dart
+++ b/example/lib/issues/issue_306_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:tracelet_platform_interface/tracelet_platform_interface.dart'
     show GeofenceEvaluator;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #306 — the pure-Dart `GeofenceEvaluator` ignored
 /// `geofenceExitAccuracyMax`, diverging from the native #276 gate.
@@ -31,10 +32,8 @@ class Issue306Card extends StatefulWidget {
   State<Issue306Card> createState() => _Issue306CardState();
 }
 
-class _Issue306CardState extends State<Issue306Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue306CardState extends State<Issue306Card>
+    with IssueCardRun<Issue306Card> {
   /// A 100 m fence. All fixes below are placed due north of its centre.
   static const _lat = 37.4219983;
   static const _lng = -122.084;
@@ -53,9 +52,10 @@ class _Issue306CardState extends State<Issue306Card> {
     'lng': _lng,
   };
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   /// Drives an evaluator from inside the fence out to [outsideMetres] with the
   /// given [accuracy] and [exitAccuracyMax], and reports whether EXIT fired.
@@ -92,7 +92,7 @@ class _Issue306CardState extends State<Issue306Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -186,7 +186,7 @@ class _Issue306CardState extends State<Issue306Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -205,8 +205,8 @@ class _Issue306CardState extends State<Issue306Card> {
           'bounds the worst-case EXIT delay without ever loosening gating for '
           'a fix that is already tighter than the cap. Runs in-process; no '
           'movement or permissions needed.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_309_card.dart
+++ b/example/lib/issues/issue_309_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issues #309–#314 — crash-ML and telematics wiring fixes.
 ///
@@ -42,10 +43,8 @@ class Issue309Card extends StatefulWidget {
   State<Issue309Card> createState() => _Issue309CardState();
 }
 
-class _Issue309CardState extends State<Issue309Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue309CardState extends State<Issue309Card>
+    with IssueCardRun<Issue309Card> {
   static const _debug = MethodChannel('com.tracelet/debug');
 
   /// Deterministic key shared with the #183 crash-model integration tests.
@@ -71,12 +70,13 @@ class _Issue309CardState extends State<Issue309Card> {
       '2O+cbPWmELO9rmIO90MI8zEKM3CaHhezSAcJb6XkoqviSp1RQ75r2qbqDIXoPuAe/w2U'
       'wVgv6sOuYBf2oiR+tPX45AxdGqMH6r1ph0wV89XcBQ==';
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -236,7 +236,7 @@ class _Issue309CardState extends State<Issue309Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -257,8 +257,8 @@ class _Issue309CardState extends State<Issue309Card> {
           'silently disabling crash detection — while a valid model still '
           'loads and scores. Also checks that getTelematicsEvents() returns '
           'the most recent events rather than the oldest unsynced ones.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_316_card.dart
+++ b/example/lib/issues/issue_316_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issues #316 / #317 — background & killed-state tracking restore.
 ///
@@ -47,16 +48,15 @@ class Issue316Card extends StatefulWidget {
   State<Issue316Card> createState() => _Issue316CardState();
 }
 
-class _Issue316CardState extends State<Issue316Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue316CardState extends State<Issue316Card>
+    with IssueCardRun<Issue316Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -167,7 +167,7 @@ class _Issue316CardState extends State<Issue316Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -187,8 +187,8 @@ class _Issue316CardState extends State<Issue316Card> {
           'violating, silently converting geofence-only apps to continuous '
           'tracking. Also documents how to confirm the Android boot-retry fix by '
           'hand.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_318_card.dart
+++ b/example/lib/issues/issue_318_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #318 — killed-state failures left no usable evidence in the logs
 /// table (Android + iOS).
@@ -49,16 +50,15 @@ class Issue318Card extends StatefulWidget {
   State<Issue318Card> createState() => _Issue318CardState();
 }
 
-class _Issue318CardState extends State<Issue318Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue318CardState extends State<Issue318Card>
+    with IssueCardRun<Issue318Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -222,7 +222,7 @@ class _Issue318CardState extends State<Issue318Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -241,8 +241,8 @@ class _Issue318CardState extends State<Issue318Card> {
           'table even though logLevel defaults to off — so an intermittent '
           'background failure can be diagnosed from the run that actually '
           'failed, instead of asking the user to reproduce it with logging on.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_320_card.dart
+++ b/example/lib/issues/issue_320_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #320 — a partial `setConfig()` overwrote the persisted
 /// foreground-service configuration with defaults.
@@ -43,16 +44,15 @@ class Issue320Card extends StatefulWidget {
   State<Issue320Card> createState() => _Issue320CardState();
 }
 
-class _Issue320CardState extends State<Issue320Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue320CardState extends State<Issue320Card>
+    with IssueCardRun<Issue320Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -262,7 +262,7 @@ class _Issue320CardState extends State<Issue320Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -280,8 +280,8 @@ class _Issue320CardState extends State<Issue320Card> {
           'showNotificationOnPauseOnly, title, text and channel — instead of '
           'overwriting them with defaults, while a field that is supplied still '
           'takes effect.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_321_card.dart
+++ b/example/lib/issues/issue_321_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #321 — a partial `setConfig()` reset *every* section, not just the
 /// foreground service.
@@ -43,16 +44,15 @@ class Issue321Card extends StatefulWidget {
   State<Issue321Card> createState() => _Issue321CardState();
 }
 
-class _Issue321CardState extends State<Issue321Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue321CardState extends State<Issue321Card>
+    with IssueCardRun<Issue321Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -269,7 +269,7 @@ class _Issue321CardState extends State<Issue321Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -288,8 +288,8 @@ class _Issue321CardState extends State<Issue321Card> {
           'http, iOS keep-alive flags and the Android foreground service — '
           'while a field that is supplied still takes effect, and ready() '
           'still sends a complete baseline.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_324_card.dart
+++ b/example/lib/issues/issue_324_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #324 — the always-on lifecycle channel never recorded a tracking
 /// session's own start or stop, so a foreground run left evidence only on the
@@ -41,13 +42,12 @@ class Issue324Card extends StatefulWidget {
   State<Issue324Card> createState() => _Issue324CardState();
 }
 
-class _Issue324CardState extends State<Issue324Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue324CardState extends State<Issue324Card>
+    with IssueCardRun<Issue324Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   /// Clears the log, runs one `start()`/`stop()` cycle, and returns the
   /// `LIFECYCLE` messages it produced.
@@ -69,7 +69,7 @@ class _Issue324CardState extends State<Issue324Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -265,7 +265,7 @@ class _Issue324CardState extends State<Issue324Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -283,8 +283,8 @@ class _Issue324CardState extends State<Issue324Card> {
           'logged at info only, so the trail could not say that tracking was '
           'stopped — and the only entries a foreground run produced were '
           'one-shots that fire once per process launch.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_326_card.dart
+++ b/example/lib/issues/issue_326_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #326 — `Config.toMap()` emitted sixteen empty sections for a config
 /// that set nothing, because every per-section guard was dead code.
@@ -41,16 +42,15 @@ class Issue326Card extends StatefulWidget {
   State<Issue326Card> createState() => _Issue326CardState();
 }
 
-class _Issue326CardState extends State<Issue326Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue326CardState extends State<Issue326Card>
+    with IssueCardRun<Issue326Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -224,7 +224,7 @@ class _Issue326CardState extends State<Issue326Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -241,8 +241,8 @@ class _Issue326CardState extends State<Issue326Card> {
           'not just an unset nested sub-map — while a supplied field still '
           'appears, ready() still sends a complete baseline, and a sparse '
           'payload round-trips without inflating unset fields into defaults.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_331_card.dart
+++ b/example/lib/issues/issue_331_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #331 — after task removal the headless Dart task was intermittently
 /// never invoked, and the failure was completely silent.
@@ -77,13 +78,12 @@ class Issue331Card extends StatefulWidget {
   State<Issue331Card> createState() => _Issue331CardState();
 }
 
-class _Issue331CardState extends State<Issue331Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue331CardState extends State<Issue331Card>
+    with IssueCardRun<Issue331Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   static const _spawning = 'headless: spawning a FlutterEngine';
   static const _ready = 'headless: engine ready';
@@ -92,7 +92,7 @@ class _Issue331CardState extends State<Issue331Card> {
   static const _bootTracking = 'boot-tracking: bootstrapping';
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -267,7 +267,7 @@ class _Issue331CardState extends State<Issue331Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -284,8 +284,8 @@ class _Issue331CardState extends State<Issue331Card> {
           'error at any level and events piling up unbounded. Arms a task '
           'removal, then reads the lifecycle trail to say whether the engine '
           'came up — or which stage it died at.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_332_card.dart
+++ b/example/lib/issues/issue_332_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #332 — a location the Rust processor rejected reported
 /// `effectiveSpeed: 0.0`, so the GPS-speed motion machine was told the device
@@ -40,22 +41,21 @@ class Issue332Card extends StatefulWidget {
   State<Issue332Card> createState() => _Issue332CardState();
 }
 
-class _Issue332CardState extends State<Issue332Card> {
+class _Issue332CardState extends State<Issue332Card>
+    with IssueCardRun<Issue332Card> {
   static const _observeWindow = Duration(seconds: 45);
 
   /// The SDK default for `speedMovingThreshold` (m/s). Fixes at or above this
   /// are what the machine must treat as motion.
   static const _movingThreshold = 1.5;
 
-  String _status = 'Idle';
-  bool _running = false;
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -196,7 +196,7 @@ class _Issue332CardState extends State<Issue332Card> {
     } finally {
       await locSub?.cancel();
       await smSub?.cancel();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -213,8 +213,8 @@ class _Issue332CardState extends State<Issue332Card> {
           'fails if the machine declares a stop while the device is above the '
           'moving threshold. Run it while travelling — a stationary run is '
           'reported as inconclusive rather than green.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_333_card.dart
+++ b/example/lib/issues/issue_333_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #333 — `SmartMotionCoordinator` read the raw platform speed to decide
 /// whether to overrule a *moving* accelerometer, and an unavailable reading
@@ -43,18 +44,17 @@ class Issue333Card extends StatefulWidget {
   State<Issue333Card> createState() => _Issue333CardState();
 }
 
-class _Issue333CardState extends State<Issue333Card> {
+class _Issue333CardState extends State<Issue333Card>
+    with IssueCardRun<Issue333Card> {
   static const _observeWindow = Duration(seconds: 20);
 
-  String _status = 'Idle';
-  bool _running = false;
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -154,7 +154,7 @@ class _Issue333CardState extends State<Issue333Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -174,8 +174,8 @@ class _Issue333CardState extends State<Issue333Card> {
           'speed reading, and a log line calling 40 km/h "walking". Which '
           'branch actually runs depends on the device, so that is reported as '
           'context.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_334_card.dart
+++ b/example/lib/issues/issue_334_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #334 — the GPS-speed motion machine and the coordinator's mode
 /// switches were `debug`-only, so a bug report gathered at the shipped log
@@ -44,16 +45,15 @@ class Issue334Card extends StatefulWidget {
   State<Issue334Card> createState() => _Issue334CardState();
 }
 
-class _Issue334CardState extends State<Issue334Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue334CardState extends State<Issue334Card>
+    with IssueCardRun<Issue334Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -198,7 +198,7 @@ class _Issue334CardState extends State<Issue334Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -215,8 +215,8 @@ class _Issue334CardState extends State<Issue334Card> {
           'speed machine still records its transitions — with the deciding '
           'speed and readable state names — on the always-on lifecycle channel '
           'that Doctor reads.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_335_card.dart
+++ b/example/lib/issues/issue_335_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #335 — iOS emitted the `speedmotion` event twice for most transitions.
 ///
@@ -46,16 +47,15 @@ class Issue335Card extends StatefulWidget {
   State<Issue335Card> createState() => _Issue335CardState();
 }
 
-class _Issue335CardState extends State<Issue335Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue335CardState extends State<Issue335Card>
+    with IssueCardRun<Issue335Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -231,7 +231,7 @@ class _Issue335CardState extends State<Issue335Card> {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
       await sub?.cancel();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -246,8 +246,8 @@ class _Issue335CardState extends State<Issue335Card> {
           'Forces stop/resume transitions with changePace() and asserts each '
           'produces exactly one speedmotion event. iOS used to emit most '
           'transitions twice because both the handler and its caller emitted.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_340_card.dart
+++ b/example/lib/issues/issue_340_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #340 — the same app posted its own sync body on Android and the SDK
 /// default on iOS.
@@ -81,13 +82,12 @@ class Issue340Card extends StatefulWidget {
   State<Issue340Card> createState() => _Issue340CardState();
 }
 
-class _Issue340CardState extends State<Issue340Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue340CardState extends State<Issue340Card>
+    with IssueCardRun<Issue340Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   /// Mirrors `buildTraceletSyncBody` in `main.dart` — the same envelope the
   /// app's foreground and headless builders both produce. Kept local rather
@@ -131,7 +131,7 @@ class _Issue340CardState extends State<Issue340Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -255,7 +255,7 @@ class _Issue340CardState extends State<Issue340Card> {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
       await httpSub?.cancel();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -273,8 +273,8 @@ class _Issue340CardState extends State<Issue340Card> {
           'relaunched process fell back to the SDK default with a headless '
           'builder registered. Clears the foreground builder and checks which '
           'body the next sync posts.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_344_card.dart
+++ b/example/lib/issues/issue_344_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #344 — in SMART motion mode, a `start()` whose committed pace was
 /// stationary left the coordinator permanently deaf to motion.
@@ -81,16 +82,15 @@ class Issue344Card extends StatefulWidget {
   State<Issue344Card> createState() => _Issue344CardState();
 }
 
-class _Issue344CardState extends State<Issue344Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue344CardState extends State<Issue344Card>
+    with IssueCardRun<Issue344Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -249,7 +249,7 @@ class _Issue344CardState extends State<Issue344Card> {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
       await sub?.cancel();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -266,8 +266,8 @@ class _Issue344CardState extends State<Issue344Card> {
           'process, and checks that motion still wakes it. syncCurrentMode() '
           'used to write CONTINUOUS into the coordinator while both its inputs '
           'said stationary, and every wake-up after that returned none.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_346_card.dart
+++ b/example/lib/issues/issue_346_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #346 — transport-mode auto-tuning overwrote an explicit
 /// `distanceFilter: 0`, so a parked device recorded nothing and never synced.
@@ -62,16 +63,15 @@ class Issue346Card extends StatefulWidget {
   State<Issue346Card> createState() => _Issue346CardState();
 }
 
-class _Issue346CardState extends State<Issue346Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue346CardState extends State<Issue346Card>
+    with IssueCardRun<Issue346Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -222,7 +222,7 @@ class _Issue346CardState extends State<Issue346Card> {
     } finally {
       await modeSub?.cancel();
       await locSub?.cancel();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -238,8 +238,8 @@ class _Issue346CardState extends State<Issue346Card> {
           'A committed "still" mode swapped in a 25 m distance filter over a '
           'configured 0, so a parked device filtered out every fix and had '
           'nothing to sync. Checks the gate in force and that fixes still land.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_352_card.dart
+++ b/example/lib/issues/issue_352_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #352 — geofence ENTER/EXIT stop firing because proximity
 /// registration rode the persistence-filtered location stream.
@@ -35,18 +36,17 @@ class Issue352Card extends StatefulWidget {
   State<Issue352Card> createState() => _Issue352CardState();
 }
 
-class _Issue352CardState extends State<Issue352Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue352CardState extends State<Issue352Card>
+    with IssueCardRun<Issue352Card> {
   static const _fenceId = 'issue-352-fence';
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -172,7 +172,7 @@ class _Issue352CardState extends State<Issue352Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -192,8 +192,8 @@ class _Issue352CardState extends State<Issue352Card> {
           'maxImpliedSpeed=3m/s froze Play Services registration and '
           'ENTER/EXIT stopped firing for good. Checks that the filter is '
           'clamped and the fence survives it anyway.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_353_card.dart
+++ b/example/lib/issues/issue_353_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #353 — Android: geofences added alongside continuous tracking (not
 /// `startGeofences()`) were unregistered on task removal and never restored,
@@ -40,18 +41,17 @@ class Issue353Card extends StatefulWidget {
   State<Issue353Card> createState() => _Issue353CardState();
 }
 
-class _Issue353CardState extends State<Issue353Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue353CardState extends State<Issue353Card>
+    with IssueCardRun<Issue353Card> {
   static const _fenceId = 'issue-353-office';
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -134,7 +134,7 @@ class _Issue353CardState extends State<Issue353Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -155,8 +155,8 @@ class _Issue353CardState extends State<Issue353Card> {
           'removal and never restore them, so ENTER/EXIT silently stopped '
           'firing forever. Also documents the manual repro and the new '
           'always-on lifecycle logging.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_355_card.dart
+++ b/example/lib/issues/issue_355_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/geofence_notifier.dart';
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #355 — a geofence smaller than the OS can resolve must still fire
 /// ENTER/EXIT, including while the app is terminated.
@@ -39,19 +40,18 @@ class Issue355Card extends StatefulWidget {
   State<Issue355Card> createState() => _Issue355CardState();
 }
 
-class _Issue355CardState extends State<Issue355Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue355CardState extends State<Issue355Card>
+    with IssueCardRun<Issue355Card> {
   static const _fenceId = 'issue-355-tiny';
   static const _radiusMeters = 10.0;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -188,7 +188,7 @@ class _Issue355CardState extends State<Issue355Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -208,8 +208,8 @@ class _Issue355CardState extends State<Issue355Card> {
           'radius with a hysteresis band scaled to your measured fix accuracy. '
           'Crossings post a local notification from the headless isolate, '
           'which is the only real-time evidence when the app is dead.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_357_card.dart
+++ b/example/lib/issues/issue_357_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #357 — a geofence added *after* `start()` must still get the fix
 /// cadence it is decided from.
@@ -33,10 +34,8 @@ class Issue357Card extends StatefulWidget {
   State<Issue357Card> createState() => _Issue357CardState();
 }
 
-class _Issue357CardState extends State<Issue357Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue357CardState extends State<Issue357Card>
+    with IssueCardRun<Issue357Card> {
   static const _fenceId = 'issue-357-cadence';
   static const _radiusMeters = 10.0;
 
@@ -65,9 +64,10 @@ class _Issue357CardState extends State<Issue357Card> {
   /// what the location cadence has to be.
   static const _realignMarker = 'realigning the location cadence';
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   /// Highest log id currently stored — the window boundary.
   ///
@@ -92,7 +92,7 @@ class _Issue357CardState extends State<Issue357Card> {
   }
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -232,7 +232,7 @@ class _Issue357CardState extends State<Issue357Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -251,8 +251,8 @@ class _Issue357CardState extends State<Issue357Card> {
           'Previously the SDK settled that question at start() and never '
           'revisited it, so a fence added afterwards was judged from one fix '
           'per distanceFilter metres travelled and EXIT fired late or never.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_361_card.dart
+++ b/example/lib/issues/issue_361_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #361 — `maxDaysToPersist` / `maxRecordsToPersist` accepted but never
 /// enforced.
@@ -40,22 +41,21 @@ class Issue361Card extends StatefulWidget {
   State<Issue361Card> createState() => _Issue361CardState();
 }
 
-class _Issue361CardState extends State<Issue361Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue361CardState extends State<Issue361Card>
+    with IssueCardRun<Issue361Card> {
   /// The record cap under test — the reporter's own value.
   static const _maxRecords = 3;
 
   /// Must match `PRUNE_EVERY_N_INSERTS` in the native SDKs.
   static const _pruneWindow = 100;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -236,7 +236,7 @@ class _Issue361CardState extends State<Issue361Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -255,8 +255,8 @@ class _Issue361CardState extends State<Issue361Card> {
           'Pruning is amortized over 100 inserts, so this measures the queue '
           'returning to the cap and staying bounded by cap + window — not a '
           'per-insert ceiling, which was never the promise.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_364_card.dart
+++ b/example/lib/issues/issue_364_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #364 — a FlutterEngine created by *another plugin* must not be
 /// treated as an event receiver.
@@ -51,7 +52,8 @@ class Issue364Card extends StatefulWidget {
   State<Issue364Card> createState() => _Issue364CardState();
 }
 
-class _Issue364CardState extends State<Issue364Card> {
+class _Issue364CardState extends State<Issue364Card>
+    with IssueCardRun<Issue364Card> {
   static const _debug = MethodChannel('com.tracelet/debug');
 
   /// The always-on line the plugin writes when a secondary engine attaches.
@@ -61,12 +63,10 @@ class _Issue364CardState extends State<Issue364Card> {
   /// it is let into the fan-out.
   static const _joinMarker = 'joining the event fan-out';
 
-  String _status = 'Idle';
-  bool _running = false;
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<int> _latestLogId() async {
     final logs = await Tracelet.getLogs(500);
@@ -82,8 +82,8 @@ class _Issue364CardState extends State<Issue364Card> {
   }
 
   Future<void> _run() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -193,7 +193,7 @@ class _Issue364CardState extends State<Issue364Card> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -205,8 +205,8 @@ class _Issue364CardState extends State<Issue364Card> {
           'Creates a FlutterEngine the way another plugin would and checks it '
           'does not join the event fan-out, so events still reach the headless '
           'task after task removal.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       keywords:
           'foreign engine firebase_messaging headless fan-out secondary '
           'engine task removal eventApi',

--- a/example/lib/issues/issue_366_card.dart
+++ b/example/lib/issues/issue_366_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 import 'package:tracelet_example/issues/test_server_endpoint.dart';
 
 /// Issue #366 — a failed telematics sync deleted the events anyway.
@@ -47,20 +48,19 @@ class Issue366Card extends StatefulWidget {
   State<Issue366Card> createState() => _Issue366CardState();
 }
 
-class _Issue366CardState extends State<Issue366Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue366CardState extends State<Issue366Card>
+    with IssueCardRun<Issue366Card> {
   static final _deadUrl = deadUrl('telematics-sync');
 
   static const _eventCount = 3;
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -259,7 +259,7 @@ class _Issue366CardState extends State<Issue366Card> {
           // Restoring is best-effort: never turn cleanup into the card's result.
         }
       }
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -278,8 +278,8 @@ class _Issue366CardState extends State<Issue366Card> {
           'unpredicated DELETE whenever telematics had been attached, so an '
           'offline device destroyed exactly the data it was meant to be '
           'queueing.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_367_card.dart
+++ b/example/lib/issues/issue_367_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Issue #367 — stored telematics dropped `speed` and `value`.
 ///
@@ -39,16 +40,15 @@ class Issue367Card extends StatefulWidget {
   State<Issue367Card> createState() => _Issue367CardState();
 }
 
-class _Issue367CardState extends State<Issue367Card> {
-  String _status = 'Idle';
-  bool _running = false;
+class _Issue367CardState extends State<Issue367Card>
+    with IssueCardRun<Issue367Card> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
 
@@ -139,7 +139,7 @@ class _Issue367CardState extends State<Issue367Card> {
     } catch (e) {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -158,8 +158,8 @@ class _Issue367CardState extends State<Issue367Card> {
           'dropped at the insert, so stored history and every synced payload '
           'kept only a normalized flag. A simulated event has no measurement, '
           'so the values are zero — this proves the wiring, not the capture.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_368_card.dart
+++ b/example/lib/issues/issue_368_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 import 'package:tracelet_example/issues/test_server_endpoint.dart';
 
 /// Issue #368 — `telematicsUrl` was accepted everywhere and read nowhere.
@@ -55,21 +56,20 @@ class Issue368Card extends StatefulWidget {
   State<Issue368Card> createState() => _Issue368CardState();
 }
 
-class _Issue368CardState extends State<Issue368Card> {
-  String _status = 'Idle';
-  bool _running = false;
-
+class _Issue368CardState extends State<Issue368Card>
+    with IssueCardRun<Issue368Card> {
   /// Two distinct paths on the refused-connection host, so the offline half has
   /// endpoints that fail fast while staying clearly separate from each other.
   static final _locationUrl = deadUrl('locations');
   static final _telematicsUrl = deadUrl('telematics');
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
 
   Future<void> _run() async {
-    setState(() => _running = true);
+    setRunning(running: true);
     final results = <String>[];
     var allPass = true;
     StreamSubscription<HttpEvent>? httpSub;
@@ -205,7 +205,7 @@ class _Issue368CardState extends State<Issue368Card> {
       _set('❌ FAILED: $e\n\n${results.join('\n')}');
     } finally {
       await httpSub?.cancel();
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -224,8 +224,8 @@ class _Issue368CardState extends State<Issue368Card> {
           'field was plumbed all the way to the Rust config struct and then '
           'read by nothing, so a separate telematics endpoint silently '
           'received no traffic at all.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _run,
     );
   }

--- a/example/lib/issues/issue_card_shell.dart
+++ b/example/lib/issues/issue_card_shell.dart
@@ -1,5 +1,94 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:tracelet_example/issues/issue_run_harness.dart';
+
+/// The monospace result box every issue card prints into.
+///
+/// Selectable, and with a one-tap copy of the whole message (#374). Cards are
+/// the only place the SDK's actual answer is shown — several print multi-line
+/// reports with per-assertion detail, exception text and payload keys — and
+/// pasting a red one into an issue is the normal next step, which a plain [Text]
+/// made impossible.
+class IssueStatusBox extends StatelessWidget {
+  const IssueStatusBox({required this.status, this.label, super.key});
+
+  final String status;
+
+  /// Named in the "copied" confirmation, so it is clear which card was copied
+  /// when several are on screen.
+  final String? label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(12, 12, 4, 12),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: SelectableText(
+              status,
+              // Explicit dark text: the box background is always light
+              // (grey.shade100), so without this the status is invisible in
+              // dark mode (default text color becomes light → white-on-white).
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 13,
+                color: Colors.black87,
+              ),
+            ),
+          ),
+          IssueCopyButton(text: status, label: label),
+        ],
+      ),
+    );
+  }
+}
+
+/// Copies a card's result to the clipboard and says so.
+///
+/// Selection alone is awkward on a phone for a report that runs past the fold,
+/// so every status box carries one of these.
+class IssueCopyButton extends StatelessWidget {
+  const IssueCopyButton({
+    required this.text,
+    this.label,
+    this.color = Colors.black54,
+    super.key,
+  });
+
+  final String text;
+
+  /// Named in the confirmation, so it is clear which card was copied when
+  /// several are on screen.
+  final String? label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(Icons.copy, size: 18, color: color),
+      tooltip: 'Copy result',
+      visualDensity: VisualDensity.compact,
+      onPressed: () async {
+        await Clipboard.setData(ClipboardData(text: text));
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            duration: const Duration(seconds: 2),
+            content: Text(label == null ? 'Result copied' : 'Copied: $label'),
+          ),
+        );
+      },
+    );
+  }
+}
 
 /// Propagates the current issue-search query down to every [IssueCardShell] so
 /// each card can filter itself against its own on-screen text (title +
@@ -102,25 +191,7 @@ class IssueCardShell extends StatelessWidget {
             const SizedBox(height: 8),
             Text(description),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                status,
-                // Explicit dark text: the box background is always light
-                // (grey.shade100), so without this the status is invisible in
-                // dark mode (default text color becomes light → white-on-white).
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status, label: title),
             const SizedBox(height: 16),
             FilledButton.icon(
               onPressed: running

--- a/example/lib/issues/issue_card_state.dart
+++ b/example/lib/issues/issue_card_state.dart
@@ -1,0 +1,317 @@
+import 'package:flutter/widgets.dart';
+import 'package:tracelet_example/issues/issue_run_harness.dart';
+
+/// A card's primary action — what its Run button does, and what Execute All
+/// invokes on its behalf.
+typedef IssueRunner = Future<void> Function();
+
+/// What one issue card remembers between builds: the last status it printed and
+/// whether its test is currently in flight (#373).
+///
+/// This is deliberately two fields and a listener list. Nothing here references
+/// a [Widget], [Element] or [RenderObject], so an entry costs a short string
+/// even for a card that has been scrolled past a hundred times.
+class IssueCardEntry extends ChangeNotifier {
+  String _status = 'Idle';
+  bool _running = false;
+
+  /// The last message the card printed. `'Idle'` until it is first run.
+  String get status => _status;
+
+  /// Whether the card's test is running right now — drives the disabled Run
+  /// button, and is set from the test itself rather than from the widget, so it
+  /// clears correctly even if the card was unmounted mid-run.
+  bool get running => _running;
+
+  void _setStatus(String value) {
+    if (_status == value) return;
+    _status = value;
+    notifyListeners();
+  }
+
+  void _setRunning(bool value) {
+    if (_running == value) return;
+    _running = value;
+    notifyListeners();
+  }
+}
+
+class _Registration {
+  const _Registration({
+    required this.owner,
+    required this.run,
+    required this.prepare,
+    required this.scope,
+  });
+
+  /// Which tab's list the card is in. The store is app-wide but a sweep belongs
+  /// to one tab, and `TabBarView` can have both tabs built at once while a swipe
+  /// is in flight — without this, a sweep could reach across and run the other
+  /// tab's cards.
+  final String scope;
+
+  /// Whoever registered this runner — the card's [State], or the
+  /// [IssueRunnerScope] element for tab-built cards. Used so a stale owner
+  /// cannot unregister a runner that has since been replaced.
+  final Object owner;
+  final IssueRunner run;
+
+  /// Whether [prepareIssueRun] should run first, mirroring what the card's own
+  /// Run button does.
+  final bool prepare;
+}
+
+/// Holds every issue card's result outside the widget tree, and tracks which
+/// cards are currently mounted so Execute All can drive them (#372, #373).
+///
+/// **Why a store rather than keep-alive.** The Issues page is one long
+/// `ListView` whose children are unmounted as they leave the viewport, which is
+/// what discards a card's result. The one-line fix is
+/// `AutomaticKeepAliveClientMixin`, and it is the wrong one: it pins each card's
+/// whole element and render subtree for the lifetime of the page and turns the
+/// list into a non-virtualized one, so scrolling to the bottom once leaves ~70
+/// laid-out card subtrees resident — a number that only grows as cards are
+/// added. Keeping the *result* instead costs a map entry and a string per card,
+/// and leaves the widgets free to be recycled exactly as they are today.
+///
+/// The runner registry is scoped to mounted cards on purpose: a runner closes
+/// over a live [State], so holding one for every card ever seen would quietly
+/// reintroduce the retention this store exists to avoid.
+class IssueCardStore {
+  IssueCardStore._();
+
+  static final IssueCardStore instance = IssueCardStore._();
+
+  final Map<String, IssueCardEntry> _entries = <String, IssueCardEntry>{};
+  final Map<String, _Registration> _runners = <String, _Registration>{};
+  final List<String> _mountOrder = <String>[];
+
+  /// The remembered state for [id], created on first use.
+  IssueCardEntry entry(String id) =>
+      _entries.putIfAbsent(id, IssueCardEntry.new);
+
+  void setStatus(String id, String status) => entry(id)._setStatus(status);
+
+  void setRunning(String id, {required bool running}) =>
+      entry(id)._setRunning(running);
+
+  /// Ids of [scope]'s cards that are mounted right now, in the order they
+  /// mounted.
+  ///
+  /// Sweeping the list downward mounts cards top to bottom, so for Execute All
+  /// this reads as list order without the tab having to maintain a second,
+  /// hand-synchronised list of every card on the page.
+  List<String> mountedIds(String scope) => List<String>.unmodifiable(
+    _mountOrder.where((id) => _runners[id]?.scope == scope),
+  );
+
+  void registerRunner({
+    required String id,
+    required Object owner,
+    required IssueRunner run,
+    required String scope,
+    bool prepare = true,
+  }) {
+    if (!_runners.containsKey(id)) _mountOrder.add(id);
+    _runners[id] = _Registration(
+      owner: owner,
+      run: run,
+      prepare: prepare,
+      scope: scope,
+    );
+  }
+
+  /// Drops [id]'s runner, but only if [owner] still owns it. A card that is
+  /// scrolled back into view mounts its new [State] before the old one is
+  /// disposed, and without this check the newcomer's registration would be
+  /// removed by its predecessor's `dispose`.
+  void unregisterRunner({required String id, required Object owner}) {
+    if (_runners[id]?.owner != owner) return;
+    _runners.remove(id);
+    _mountOrder.remove(id);
+  }
+
+  bool isRegistered(String id) => _runners.containsKey(id);
+
+  /// Runs [id] the way its own Run button would, including the shared
+  /// [prepareIssueRun] preamble. Returns normally when [id] has no runner.
+  Future<void> run(String id) async {
+    final registration = _runners[id];
+    if (registration == null) return;
+    if (registration.prepare) {
+      try {
+        await prepareIssueRun();
+      } catch (e) {
+        // Same call as the Run button makes, and the same handling: report the
+        // failure through the card rather than abandoning the run, so it lands
+        // somewhere the user can read it.
+        debugPrint('prepareIssueRun failed for $id: $e');
+      }
+    }
+    await registration.run();
+  }
+}
+
+/// Names the list a card is in, so Execute All on one tab sweeps that tab.
+///
+/// Each issues tab wraps its list in one of these; cards look it up rather than
+/// being told, so a card can be moved between tabs without rewiring.
+class IssueCardScope extends InheritedWidget {
+  const IssueCardScope({required this.name, required super.child, super.key});
+
+  final String name;
+
+  /// The enclosing list's name, or `'default'` for a card used outside a tab.
+  static String of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<IssueCardScope>()?.name ??
+      'default';
+
+  @override
+  bool updateShouldNotify(IssueCardScope oldWidget) => name != oldWidget.name;
+}
+
+/// Card state that lives in [IssueCardStore] instead of in the [State].
+///
+/// A card mixes this in and drops its own `_status`/`_running` fields. Two
+/// things follow. Its result survives being scrolled out of view, because the
+/// result was never in the widget to begin with. And a test that finishes after
+/// its card was unmounted still reports — the old `if (mounted) setState(...)`
+/// guard silently discarded those, which is precisely what a scrolling Execute
+/// All sweep provoked.
+///
+/// Mixing this in also enlists the card in Execute All, which is why
+/// [cardRunner] is required.
+mixin IssueCardRun<T extends StatefulWidget> on State<T> {
+  /// Identity for the card's remembered state. The widget type is unique per
+  /// card and stable across rebuilds, which is all this needs to be.
+  String get cardId => widget.runtimeType.toString();
+
+  /// The card's primary action — normally the same callback it hands to
+  /// `IssueCardShell.onRun`.
+  ///
+  /// Null for a card that has to stay manual: a start/stop toggle, or a
+  /// two-phase repro that needs the device rebooted or the app killed between
+  /// halves. Execute All skips those rather than firing half of them.
+  IssueRunner? get cardRunner;
+
+  /// Whether Execute All should call [prepareIssueRun] before [cardRunner].
+  /// Mirrors `IssueCardShell.prepare`; override alongside it.
+  bool get prepareBeforeRun => true;
+
+  IssueCardEntry get _entry => IssueCardStore.instance.entry(cardId);
+
+  /// The card's last reported message.
+  String get status => _entry.status;
+
+  /// Whether the card's test is in flight.
+  bool get running => _entry.running;
+
+  /// Reports [value] as the card's result. Safe to call after the card has been
+  /// unmounted — the message is kept and shown when the card comes back.
+  void setStatus(String value) =>
+      IssueCardStore.instance.setStatus(cardId, value);
+
+  void setRunning({required bool running}) =>
+      IssueCardStore.instance.setRunning(cardId, running: running);
+
+  @override
+  void initState() {
+    super.initState();
+    _entry.addListener(_onEntryChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Registration waits until here because it needs [IssueCardScope], and an
+    // inherited widget cannot be looked up from `initState`.
+    final runner = cardRunner;
+    if (runner == null) return;
+    IssueCardStore.instance.registerRunner(
+      id: cardId,
+      owner: this,
+      run: runner,
+      scope: IssueCardScope.of(context),
+      prepare: prepareBeforeRun,
+    );
+  }
+
+  @override
+  void dispose() {
+    _entry.removeListener(_onEntryChanged);
+    IssueCardStore.instance.unregisterRunner(id: cardId, owner: this);
+    super.dispose();
+  }
+
+  void _onEntryChanged() {
+    if (mounted) setState(() {});
+  }
+}
+
+/// Enlists a card that the tab builds itself — the older `_buildIssueCard`
+/// entries, whose test lives on the tab's [State] rather than in a card widget
+/// — in Execute All, with the same mounted-only lifetime the mixin gives the
+/// card widgets.
+///
+/// Those cards keep their status on the tab, which outlives scrolling, so this
+/// deals only with the runner. Pass a null [run] for a card that should stay
+/// manual (a start/stop toggle, or a repro that needs the app backgrounded);
+/// unregistered cards are skipped by the sweep.
+class IssueRunnerScope extends StatefulWidget {
+  const IssueRunnerScope({
+    required this.id,
+    required this.run,
+    required this.child,
+    super.key,
+  });
+
+  final String id;
+  final IssueRunner? run;
+  final Widget child;
+
+  @override
+  State<IssueRunnerScope> createState() => _IssueRunnerScopeState();
+}
+
+class _IssueRunnerScopeState extends State<IssueRunnerScope> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _register();
+  }
+
+  @override
+  void didUpdateWidget(IssueRunnerScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // The tab rebuilds these on every setState, handing over a fresh closure
+    // each time; the registry has to point at the current one.
+    if (oldWidget.id != widget.id) {
+      IssueCardStore.instance.unregisterRunner(id: oldWidget.id, owner: this);
+    }
+    _register();
+  }
+
+  void _register() {
+    final run = widget.run;
+    if (run == null) return;
+    IssueCardStore.instance.registerRunner(
+      id: widget.id,
+      owner: this,
+      run: run,
+      scope: IssueCardScope.of(context),
+      // These predate the shared preamble and read config the home page or a
+      // scanned QR left behind, so running them is left exactly as their own
+      // button leaves it.
+      prepare: false,
+    );
+  }
+
+  @override
+  void dispose() {
+    IssueCardStore.instance.unregisterRunner(id: widget.id, owner: this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/example/lib/issues/issue_sweep.dart
+++ b/example/lib/issues/issue_sweep.dart
@@ -1,0 +1,215 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+
+/// Runs every card on an issues tab, top to bottom (#372).
+///
+/// **Why it scrolls.** A card's test lives in that card's [State], and the tab's
+/// `ListView` only builds the cards near the viewport — so from a standing start
+/// the tab cannot reach ~70 of the ~75 tests on the page, because those widgets
+/// do not exist yet. The sweep therefore walks the list: run everything mounted,
+/// scroll a screen, run whatever that mounted, repeat. Cards enlist themselves
+/// through [IssueCardStore] as they mount, so a card added tomorrow is swept
+/// with no list to update here, and the scrolling doubles as the progress
+/// indicator the old version never had.
+///
+/// Results are safe from the scrolling: they live in [IssueCardStore], not in
+/// the cards being scrolled past.
+class IssueSweep extends ChangeNotifier {
+  IssueSweep({
+    required this.scrollController,
+    required this.scope,
+    this.cardTimeout = const Duration(seconds: 60),
+    this.betweenCards = const Duration(milliseconds: 250),
+  });
+
+  final ScrollController scrollController;
+
+  /// Which tab's cards to run — see [IssueCardScope]. Must match the name the
+  /// tab wraps its list in.
+  final String scope;
+
+  /// How long a single card gets before the sweep gives up on it and moves on.
+  ///
+  /// The old sweep awaited each test with no bound, so one card that never
+  /// returned — `getCurrentPosition` waiting on a GPS fix indoors, a sync
+  /// against a server that is not there — hung the whole run with no way out
+  /// short of leaving the page.
+  final Duration cardTimeout;
+
+  /// Breather between cards. These tests reconfigure and restart the SDK; back
+  /// to back with no gap, a card can observe the previous card's teardown.
+  final Duration betweenCards;
+
+  final Set<String> _done = <String>{};
+  bool _active = false;
+  bool _cancelled = false;
+  String? _current;
+  bool _disposed = false;
+
+  /// Whether a sweep is in progress.
+  bool get active => _active;
+
+  /// How many cards this sweep has run so far. The total is not known up front:
+  /// the list is lazy, so the sweep discovers cards as it scrolls to them.
+  int get completed => _done.length;
+
+  /// Id of the card being run, for the progress line.
+  String? get current => _current;
+
+  /// Asks the sweep to stop after the card in flight. That card is not
+  /// interrupted — it is talking to the SDK, and cutting it off mid-run would
+  /// leave the SDK in whatever state it had reached.
+  void cancel() {
+    if (!_active) return;
+    _cancelled = true;
+    _notify();
+  }
+
+  Future<void> start() async {
+    if (_active) return;
+    _active = true;
+    _cancelled = false;
+    _done.clear();
+    _current = null;
+    _notify();
+
+    try {
+      await _scrollToTop();
+      while (!_cancelled) {
+        await _runMountedCards();
+        if (_cancelled) break;
+        if (!await _scrollForward()) {
+          // At the bottom. The last scroll may still have mounted cards that
+          // have not run; one more pass, then there is nothing left to reach.
+          final remaining = IssueCardStore.instance
+              .mountedIds(scope)
+              .where((id) => !_done.contains(id));
+          if (remaining.isEmpty) break;
+        }
+      }
+    } finally {
+      _active = false;
+      _current = null;
+      _notify();
+    }
+  }
+
+  Future<void> _runMountedCards() async {
+    // Snapshot: scrolling during a run mounts and unmounts cards, which mutates
+    // the store's list underneath us.
+    final pending = IssueCardStore.instance
+        .mountedIds(scope)
+        .where((id) => !_done.contains(id))
+        .toList();
+
+    for (final id in pending) {
+      if (_cancelled) return;
+      _done.add(id);
+      _current = id;
+      _notify();
+      await IssueCardStore.instance
+          .run(id)
+          .timeout(
+            cardTimeout,
+            onTimeout: () {
+              // The test is still out there — `timeout` bounds the wait, not the
+              // work — so it may yet overwrite this with its real result. Say so
+              // rather than leaving a card that reads as though it never ran.
+              IssueCardStore.instance.setStatus(
+                id,
+                '⏱ TIMED OUT: still running after '
+                '${cardTimeout.inSeconds}s, so Execute All moved on. Run this '
+                'card on its own to see how it finishes.',
+              );
+              IssueCardStore.instance.setRunning(id, running: false);
+            },
+          );
+      if (_cancelled) return;
+      await Future<void>.delayed(betweenCards);
+    }
+  }
+
+  Future<void> _scrollToTop() async {
+    if (!scrollController.hasClients) return;
+    if (scrollController.position.pixels <= 0) return;
+    await scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+    await _settle();
+  }
+
+  /// Advances roughly a screen. Returns false once the list is at its end.
+  Future<bool> _scrollForward() async {
+    if (!scrollController.hasClients) return false;
+    final position = scrollController.position;
+    if (position.pixels >= position.maxScrollExtent - 1) {
+      await _settle();
+      return false;
+    }
+    final target = math.min(
+      position.pixels + position.viewportDimension * 0.75,
+      position.maxScrollExtent,
+    );
+    await scrollController.animateTo(
+      target,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeInOut,
+    );
+    await _settle();
+    return true;
+  }
+
+  /// Waits for the frame that builds whatever the scroll just revealed, so those
+  /// cards have registered before the next pass looks for them.
+  Future<void> _settle() async {
+    await SchedulerBinding.instance.endOfFrame;
+    await SchedulerBinding.instance.endOfFrame;
+  }
+
+  void _notify() {
+    if (_disposed) return;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _cancelled = true;
+    super.dispose();
+  }
+}
+
+/// The progress strip shown under an issues tab's toolbar while a sweep runs.
+class IssueSweepBanner extends StatelessWidget {
+  const IssueSweepBanner({required this.sweep, super.key});
+
+  final IssueSweep sweep;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!sweep.active) return const SizedBox.shrink();
+    final current = sweep.current;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const LinearProgressIndicator(minHeight: 3),
+          const SizedBox(height: 6),
+          Text(
+            current == null
+                ? 'Execute All: starting…'
+                : 'Execute All: running $current — ${sweep.completed} card(s) '
+                      'done',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/issues/mock_rejection_card.dart
+++ b/example/lib/issues/mock_rejection_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Mock-location rejection on one-shot APIs (found while auditing #243).
 ///
@@ -24,17 +25,16 @@ class MockRejectionCard extends StatefulWidget {
   State<MockRejectionCard> createState() => _MockRejectionCardState();
 }
 
-class _MockRejectionCardState extends State<MockRejectionCard> {
-  String _status = 'Idle';
-  bool _running = false;
+class _MockRejectionCardState extends State<MockRejectionCard>
+    with IssueCardRun<MockRejectionCard> {
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     try {
       if (!Platform.isAndroid) {
@@ -107,7 +107,7 @@ class _MockRejectionCardState extends State<MockRejectionCard> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -121,8 +121,8 @@ class _MockRejectionCardState extends State<MockRejectionCard> {
           'delivered spoofed locations. All delivery paths now enforce the '
           'flag. Run once for a baseline genuine fix, then again with a mock '
           'location app active to see the rejection.',
-      status: _status,
-      running: _running,
+      status: status,
+      running: running,
       onRun: _test,
     );
   }

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -7,6 +7,8 @@ import 'package:flutter/services.dart';
 import 'package:crypto/crypto.dart';
 import 'package:tracelet/tracelet.dart' hide State;
 import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+import 'package:tracelet_example/issues/issue_sweep.dart';
 import 'package:tracelet_example/issues/issue_185_card.dart';
 import 'package:tracelet_example/issues/issue_198_card.dart';
 import 'package:tracelet_example/issues/issue_201_card.dart';
@@ -101,6 +103,11 @@ class RecentIssuesTab extends StatefulWidget {
 class _RecentIssuesTabState extends State<RecentIssuesTab> {
   final ScrollController _scrollController = ScrollController();
   final TextEditingController _searchController = TextEditingController();
+  static const _scope = 'recent';
+  late final IssueSweep _sweep = IssueSweep(
+    scrollController: _scrollController,
+    scope: _scope,
+  );
   String _searchQuery = '';
 
   bool _isTracking = false;
@@ -151,10 +158,18 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
         _searchQuery = _searchController.text;
       });
     });
+    _sweep.addListener(_onSweepChanged);
+  }
+
+  void _onSweepChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
   void dispose() {
+    _sweep
+      ..removeListener(_onSweepChanged)
+      ..dispose();
     _scrollController.dispose();
     _searchController.dispose();
     _issue140Timer?.cancel();
@@ -171,18 +186,6 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
       setState(() {
         _statuses[issue] = status;
       });
-    }
-  }
-
-  void _scrollTo(int issue) {
-    final key = _keys[issue];
-    if (key != null && key.currentContext != null) {
-      Scrollable.ensureVisible(
-        key.currentContext!,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-        alignment: 0.1,
-      );
     }
   }
 
@@ -873,50 +876,19 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
     }
   }
 
+  /// Runs every card on the tab (#372).
+  ///
+  /// This used to be a hand-maintained `if` ladder over [_allIssues], which by
+  /// the time it was noticed reached five of the ~75 cards on the page: the
+  /// list predates the per-card widgets, and a card's test lives in that card's
+  /// own `State` where the tab cannot call it. [IssueSweep] instead walks the
+  /// list and runs whatever has mounted, so every card — including ones added
+  /// after this line was written — is swept with nothing to keep in sync here.
   Future<void> _executeAll() async {
-    for (final issue in _allIssues) {
-      // Issues 134, 136 & 140 are manual, long-running background/motion repros —
-      // not part of the automated sweep.
-      if (issue == 134 || issue == 136 || issue == 140) continue;
-      _scrollTo(issue);
-      if (issue == 115) {
-        await _startIssue115Tracking();
-        await Future.delayed(const Duration(seconds: 3));
-        await _stopTracking();
-      } else if (issue == 117) {
-        await _testIssue117();
-        await Future.delayed(const Duration(seconds: 2));
-      } else if (issue == 118) {
-        await _runIssue118All();
-      } else if (issue == 119) {
-        await _testIssue119();
-      } else if (issue == 120) {
-        await _testIssue120();
-      } else if (issue == 124) {
-        await _testIssue124HeaderCrash();
-      } else if (issue == 125) {
-        await _testIssue125();
-      } else if (issue == 126) {
-        await _testIssue126();
-      } else if (issue == 137) {
-        await _testIssue137();
-      } else if (issue == 138) {
-        await _testIssue138();
-      } else if (issue == 139) {
-        await _testIssue139();
-      } else if (issue == 147) {
-        await _testIssue147();
-      } else if (issue == 149) {
-        await _testIssue149();
-      } else if (issue == 154) {
-        await _testIssue154();
-      } else if (issue == 159) {
-        await _testIssue159();
-      } else if (issue == 175) {
-        await _testIssue175();
-      }
-      await Future.delayed(const Duration(seconds: 2));
-    }
+    // Sweeping means "run everything", so a filter left in the search box would
+    // silently make it a lie.
+    _searchController.clear();
+    await _sweep.start();
   }
 
   // ==== ISSUE 137: deltaCoordinatePrecision default ====
@@ -1589,6 +1561,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
     required String title,
     required String description,
     required List<Widget> actions,
+    IssueRunner? sweepAction,
   }) {
     if (_searchQuery.isNotEmpty) {
       final query = _searchQuery.toLowerCase();
@@ -1601,7 +1574,14 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
       }
     }
 
-    return _buildIssueCardBody(issueNumber, title, description, actions);
+    // Enlists the card in Execute All for as long as it is mounted, the same
+    // deal the card widgets get from IssueCardRun. A null [sweepAction] keeps a
+    // card manual — a start/stop toggle, or a repro that needs the app killed.
+    return IssueRunnerScope(
+      id: 'issue-$issueNumber',
+      run: sweepAction,
+      child: _buildIssueCardBody(issueNumber, title, description, actions),
+    );
   }
 
   /// Wraps a self-contained issue card widget (one that renders its own
@@ -1670,12 +1650,24 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(color: statusColor.withValues(alpha: 0.3)),
               ),
-              child: Text(
-                'Status: $status',
-                style: TextStyle(
-                  color: statusColor,
-                  fontWeight: FontWeight.bold,
-                ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: SelectableText(
+                      'Status: $status',
+                      style: TextStyle(
+                        color: statusColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IssueCopyButton(
+                    text: status,
+                    label: 'Issue #$issueNumber',
+                    color: statusColor,
+                  ),
+                ],
               ),
             ),
           ],
@@ -1721,9 +1713,9 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                 ),
                 const SizedBox(width: 12),
                 FilledButton.icon(
-                  onPressed: _executeAll,
-                  icon: const Icon(Icons.play_arrow),
-                  label: const Text('Execute All'),
+                  onPressed: _sweep.active ? _sweep.cancel : _executeAll,
+                  icon: Icon(_sweep.active ? Icons.stop : Icons.play_arrow),
+                  label: Text(_sweep.active ? 'Stop' : 'Execute All'),
                   style: FilledButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 20,
@@ -1737,232 +1729,242 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
               ],
             ),
           ),
+          IssueSweepBanner(sweep: _sweep),
           Expanded(
-            child: IssueSearchScope(
-              query: _searchQuery.trim().toLowerCase(),
-              child: ListView(
-                controller: _scrollController,
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                children: [
-                  // Latest issues first (newest on top).
-                  //
-                  // Cards built on IssueCardShell filter themselves against their
-                  // own title/description/keywords via IssueSearchScope, so they
-                  // are rendered directly. Cards with a bespoke layout (no shell)
-                  // stay wrapped in _searchableCard with explicit keywords.
-                  const Issue368Card(),
-                  const Issue367Card(),
-                  const Issue366Card(),
-                  const Issue364Card(),
-                  const Issue361Card(),
-                  const Issue357Card(),
-                  const Issue355Card(),
-                  const Issue353Card(),
-                  const Issue352Card(),
-                  const Issue346Card(),
-                  const Issue344Card(),
-                  const Issue340Card(),
-                  const Issue335Card(),
-                  const Issue334Card(),
-                  const Issue333Card(),
-                  const Issue332Card(),
-                  const Issue331Card(),
-                  const Issue326Card(),
-                  const Issue324Card(),
-                  const Issue321Card(),
-                  const Issue320Card(),
-                  const Issue318Card(),
-                  const Issue316Card(),
-                  const Issue309Card(),
-                  const Issue306Card(),
-                  const Issue305Card(),
-                  const Issue304Card(),
-                  const Issue303Card(),
-                  const Issue301Card(),
-                  const Issue299Card(),
-                  const Issue297Card(),
-                  const Issue294Card(),
-                  const Issue292Card(),
-                  const Issue288Card(),
-                  const Issue286Card(),
-                  const Issue282Card(),
-                  const Issue280Card(),
-                  const Issue276Card(),
-                  const Issue274Card(),
-                  const Issue270Card(),
-                  const Issue268Card(),
-                  const Issue267Card(),
-                  const Issue265Card(),
-                  const Issue264Card(),
-                  const Issue263Card(),
-                  const Issue262Card(),
-                  const Issue261Card(),
-                  const Issue257Card(),
-                  const Issue256Card(),
-                  const Issue255Card(),
-                  const Issue254Card(),
-                  const Issue253Card(),
-                  const Issue252Card(),
-                  const Issue251Card(),
-                  const Issue250Card(),
-                  const Issue248Card(),
-                  const Issue247Card(),
-                  const Issue244Card(),
-                  const Issue243Card(),
-                  const Issue238Card(),
-                  const Issue237Card(),
-                  const Issue231Card(),
-                  const Issue230Card(),
-                  const Issue214Card(),
-                  const Issue213Card(),
-                  const Issue212Card(),
-                  _searchableCard(
-                    issueNumber: 210,
-                    keywords:
-                        'ios blue location indicator geofence mode region '
-                        'monitoring background location high accuracy',
-                    child: const Issue210Card(),
-                  ),
-                  _searchableCard(
-                    issueNumber: 204,
-                    keywords:
-                        'duplicate requestsyncbody sync body builder batch',
-                    child: const Issue204Card(),
-                  ),
-                  _searchableCard(
-                    issueNumber: 201,
-                    keywords:
-                        'local extras getcurrentposition merge global httpconfig',
-                    child: const Issue201Card(),
-                  ),
-                  _searchableCard(
-                    issueNumber: 198,
-                    keywords:
-                        'passive profile battery optimization ios background '
-                        'activity session dynamic island status bar pill',
-                    child: const Issue198Card(),
-                  ),
-                  _searchableCard(
-                    issueNumber: 185,
-                    keywords: 'high accuracy geofence transitions reboot dwell',
-                    child: const Issue185Card(),
-                  ),
-                  _buildIssueCard(
-                    issueNumber: 147,
-                    title: 'getState() drops active config',
-                    description:
-                        'The Pigeon TlState FFI struct had no config field, so '
-                        'State.config was permanently null from ready()/getState(). '
-                        'Now backfilled from the active config. Scan a Test Server '
-                        'QR code first.',
-                    actions: [
-                      FilledButton.icon(
-                        onPressed: _testIssue147,
-                        icon: const Icon(Icons.settings_backup_restore),
-                        label: const Text('Run Test'),
-                      ),
-                    ],
-                  ),
-                  _buildIssueCard(
-                    issueNumber: 149,
-                    title: 'Missing syncInterval in HttpConfig',
-                    description:
-                        'HttpConfig.syncInterval (interval-based sync) was missing '
-                        'from the Dart class and Pigeon struct, causing compile '
-                        'failures. Now present, serialized, and round-trips through '
-                        'native. Scan a Test Server QR code first.',
-                    actions: [
-                      FilledButton.icon(
-                        onPressed: _testIssue149,
-                        icon: const Icon(Icons.timelapse),
-                        label: const Text('Run Test'),
-                      ),
-                    ],
-                  ),
-                  _buildIssueCard(
-                    issueNumber: 154,
-                    title: 'Dummy destroySyncedLocations stub',
-                    description:
-                        'destroySyncedLocations() always returned a hardcoded 0. It '
-                        'now reports the real count of locations synced-and-pruned. '
-                        'Syncs 3 records to a loopback server and asserts the count. '
-                        'Deterministic.',
-                    actions: [
-                      FilledButton.icon(
-                        onPressed: _testIssue154,
-                        icon: const Icon(Icons.delete_sweep),
-                        label: const Text('Run Test'),
-                      ),
-                    ],
-                  ),
-                  _buildIssueCard(
-                    issueNumber: 159,
-                    title: 'Offline queue metrics',
-                    description:
-                        'Adds getPendingLocations()/getPendingLocationCount() to '
-                        'expose the offline (pending-sync) queue. Inserts 4 records '
-                        'and asserts both APIs report them. Deterministic.',
-                    actions: [
-                      FilledButton.icon(
-                        onPressed: _testIssue159,
-                        icon: const Icon(Icons.inbox),
-                        label: const Text('Run Test'),
-                      ),
-                    ],
-                  ),
-                  _buildIssueCard(
-                    issueNumber: 162,
-                    title: 'Battery Budget & Wakelock',
-                    description:
-                        'Test dynamic battery budgeting (adjusts distanceFilter, '
-                        'desiredAccuracy, and periodic interval based on target %/hr) '
-                        'and stationary OEM Wakelock release.\n\n'
-                        '$_issue162Details',
-                    actions: [
-                      FilledButton.icon(
-                        onPressed: _toggleIssue162,
-                        icon: Icon(
-                          _isIssue162Tracking ? Icons.stop : Icons.play_arrow,
+            child: IssueCardScope(
+              name: _scope,
+              child: IssueSearchScope(
+                query: _searchQuery.trim().toLowerCase(),
+                child: ListView(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  children: [
+                    // Latest issues first (newest on top).
+                    //
+                    // Cards built on IssueCardShell filter themselves against their
+                    // own title/description/keywords via IssueSearchScope, so they
+                    // are rendered directly. Cards with a bespoke layout (no shell)
+                    // stay wrapped in _searchableCard with explicit keywords.
+                    const Issue368Card(),
+                    const Issue367Card(),
+                    const Issue366Card(),
+                    const Issue364Card(),
+                    const Issue361Card(),
+                    const Issue357Card(),
+                    const Issue355Card(),
+                    const Issue353Card(),
+                    const Issue352Card(),
+                    const Issue346Card(),
+                    const Issue344Card(),
+                    const Issue340Card(),
+                    const Issue335Card(),
+                    const Issue334Card(),
+                    const Issue333Card(),
+                    const Issue332Card(),
+                    const Issue331Card(),
+                    const Issue326Card(),
+                    const Issue324Card(),
+                    const Issue321Card(),
+                    const Issue320Card(),
+                    const Issue318Card(),
+                    const Issue316Card(),
+                    const Issue309Card(),
+                    const Issue306Card(),
+                    const Issue305Card(),
+                    const Issue304Card(),
+                    const Issue303Card(),
+                    const Issue301Card(),
+                    const Issue299Card(),
+                    const Issue297Card(),
+                    const Issue294Card(),
+                    const Issue292Card(),
+                    const Issue288Card(),
+                    const Issue286Card(),
+                    const Issue282Card(),
+                    const Issue280Card(),
+                    const Issue276Card(),
+                    const Issue274Card(),
+                    const Issue270Card(),
+                    const Issue268Card(),
+                    const Issue267Card(),
+                    const Issue265Card(),
+                    const Issue264Card(),
+                    const Issue263Card(),
+                    const Issue262Card(),
+                    const Issue261Card(),
+                    const Issue257Card(),
+                    const Issue256Card(),
+                    const Issue255Card(),
+                    const Issue254Card(),
+                    const Issue253Card(),
+                    const Issue252Card(),
+                    const Issue251Card(),
+                    const Issue250Card(),
+                    const Issue248Card(),
+                    const Issue247Card(),
+                    const Issue244Card(),
+                    const Issue243Card(),
+                    const Issue238Card(),
+                    const Issue237Card(),
+                    const Issue231Card(),
+                    const Issue230Card(),
+                    const Issue214Card(),
+                    const Issue213Card(),
+                    const Issue212Card(),
+                    _searchableCard(
+                      issueNumber: 210,
+                      keywords:
+                          'ios blue location indicator geofence mode region '
+                          'monitoring background location high accuracy',
+                      child: const Issue210Card(),
+                    ),
+                    _searchableCard(
+                      issueNumber: 204,
+                      keywords:
+                          'duplicate requestsyncbody sync body builder batch',
+                      child: const Issue204Card(),
+                    ),
+                    _searchableCard(
+                      issueNumber: 201,
+                      keywords:
+                          'local extras getcurrentposition merge global httpconfig',
+                      child: const Issue201Card(),
+                    ),
+                    _searchableCard(
+                      issueNumber: 198,
+                      keywords:
+                          'passive profile battery optimization ios background '
+                          'activity session dynamic island status bar pill',
+                      child: const Issue198Card(),
+                    ),
+                    _searchableCard(
+                      issueNumber: 185,
+                      keywords:
+                          'high accuracy geofence transitions reboot dwell',
+                      child: const Issue185Card(),
+                    ),
+                    _buildIssueCard(
+                      issueNumber: 147,
+                      sweepAction: _testIssue147,
+                      title: 'getState() drops active config',
+                      description:
+                          'The Pigeon TlState FFI struct had no config field, so '
+                          'State.config was permanently null from ready()/getState(). '
+                          'Now backfilled from the active config. Scan a Test Server '
+                          'QR code first.',
+                      actions: [
+                        FilledButton.icon(
+                          onPressed: _testIssue147,
+                          icon: const Icon(Icons.settings_backup_restore),
+                          label: const Text('Run Test'),
                         ),
-                        label: Text(
-                          _isIssue162Tracking ? 'Stop' : 'Start tracking',
+                      ],
+                    ),
+                    _buildIssueCard(
+                      issueNumber: 149,
+                      sweepAction: _testIssue149,
+                      title: 'Missing syncInterval in HttpConfig',
+                      description:
+                          'HttpConfig.syncInterval (interval-based sync) was missing '
+                          'from the Dart class and Pigeon struct, causing compile '
+                          'failures. Now present, serialized, and round-trips through '
+                          'native. Scan a Test Server QR code first.',
+                      actions: [
+                        FilledButton.icon(
+                          onPressed: _testIssue149,
+                          icon: const Icon(Icons.timelapse),
+                          label: const Text('Run Test'),
                         ),
-                      ),
-                    ],
-                  ),
-                  _buildIssueCard(
-                    issueNumber: 175,
-                    title: 'Battery & Extras DB Persistence',
-                    description:
-                        'Verifies that custom battery levels and globally configured extras '
-                        'are correctly serialized into the SQLite DB (via route_context) '
-                        'and successfully restored on retrieval instead of falling back to default values.',
-                    actions: [
-                      FilledButton.icon(
-                        onPressed: _testIssue175,
-                        icon: const Icon(Icons.play_arrow),
-                        label: const Text('Run Test'),
-                      ),
-                    ],
-                  ),
-                  // Feature demos (not numbered issues) — searchable by keyword
-                  // and kept at the bottom so they never sit above real issues.
-                  _searchableCard(
-                    keywords:
-                        'battery budget remote config batterybudgetperhour '
-                        'runtime setconfig onbudgetadjustment activeconfig sync',
-                    child: const BatteryBudgetRemoteConfigCard(),
-                  ),
-                  _searchableCard(
-                    keywords:
-                        'remote config remoteconfig native background fetch '
-                        'remoteconfigurl https cache setconfig',
-                    child: const RemoteConfigCard(),
-                  ),
-                  // MockRejectionCard uses IssueCardShell, so it self-filters via
-                  // IssueSearchScope (title/description/keywords).
-                  const MockRejectionCard(),
-                ],
+                      ],
+                    ),
+                    _buildIssueCard(
+                      issueNumber: 154,
+                      sweepAction: _testIssue154,
+                      title: 'Dummy destroySyncedLocations stub',
+                      description:
+                          'destroySyncedLocations() always returned a hardcoded 0. It '
+                          'now reports the real count of locations synced-and-pruned. '
+                          'Syncs 3 records to a loopback server and asserts the count. '
+                          'Deterministic.',
+                      actions: [
+                        FilledButton.icon(
+                          onPressed: _testIssue154,
+                          icon: const Icon(Icons.delete_sweep),
+                          label: const Text('Run Test'),
+                        ),
+                      ],
+                    ),
+                    _buildIssueCard(
+                      issueNumber: 159,
+                      sweepAction: _testIssue159,
+                      title: 'Offline queue metrics',
+                      description:
+                          'Adds getPendingLocations()/getPendingLocationCount() to '
+                          'expose the offline (pending-sync) queue. Inserts 4 records '
+                          'and asserts both APIs report them. Deterministic.',
+                      actions: [
+                        FilledButton.icon(
+                          onPressed: _testIssue159,
+                          icon: const Icon(Icons.inbox),
+                          label: const Text('Run Test'),
+                        ),
+                      ],
+                    ),
+                    _buildIssueCard(
+                      issueNumber: 162,
+                      title: 'Battery Budget & Wakelock',
+                      description:
+                          'Test dynamic battery budgeting (adjusts distanceFilter, '
+                          'desiredAccuracy, and periodic interval based on target %/hr) '
+                          'and stationary OEM Wakelock release.\n\n'
+                          '$_issue162Details',
+                      actions: [
+                        FilledButton.icon(
+                          onPressed: _toggleIssue162,
+                          icon: Icon(
+                            _isIssue162Tracking ? Icons.stop : Icons.play_arrow,
+                          ),
+                          label: Text(
+                            _isIssue162Tracking ? 'Stop' : 'Start tracking',
+                          ),
+                        ),
+                      ],
+                    ),
+                    _buildIssueCard(
+                      issueNumber: 175,
+                      sweepAction: _testIssue175,
+                      title: 'Battery & Extras DB Persistence',
+                      description:
+                          'Verifies that custom battery levels and globally configured extras '
+                          'are correctly serialized into the SQLite DB (via route_context) '
+                          'and successfully restored on retrieval instead of falling back to default values.',
+                      actions: [
+                        FilledButton.icon(
+                          onPressed: _testIssue175,
+                          icon: const Icon(Icons.play_arrow),
+                          label: const Text('Run Test'),
+                        ),
+                      ],
+                    ),
+                    // Feature demos (not numbered issues) — searchable by keyword
+                    // and kept at the bottom so they never sit above real issues.
+                    _searchableCard(
+                      keywords:
+                          'battery budget remote config batterybudgetperhour '
+                          'runtime setconfig onbudgetadjustment activeconfig sync',
+                      child: const BatteryBudgetRemoteConfigCard(),
+                    ),
+                    _searchableCard(
+                      keywords:
+                          'remote config remoteconfig native background fetch '
+                          'remoteconfigurl https cache setconfig',
+                      child: const RemoteConfigCard(),
+                    ),
+                    // MockRejectionCard uses IssueCardShell, so it self-filters via
+                    // IssueSearchScope (title/description/keywords).
+                    const MockRejectionCard(),
+                  ],
+                ),
               ),
             ),
           ),

--- a/example/lib/issues/remote_config_card.dart
+++ b/example/lib/issues/remote_config_card.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
 
 /// Remote Config — verifies the native background fetch of `remoteConfigUrl`.
 ///
@@ -35,7 +37,8 @@ class RemoteConfigCard extends StatefulWidget {
   State<RemoteConfigCard> createState() => _RemoteConfigCardState();
 }
 
-class _RemoteConfigCardState extends State<RemoteConfigCard> {
+class _RemoteConfigCardState extends State<RemoteConfigCard>
+    with IssueCardRun<RemoteConfigCard> {
   /// A public, config-shaped JSON fixture served over HTTPS (a GitHub gist,
   /// mirroring `example/assets/remote_config_sample.json`). Editable below.
   static const String _defaultUrl =
@@ -46,12 +49,10 @@ class _RemoteConfigCardState extends State<RemoteConfigCard> {
     text: _defaultUrl,
   );
 
-  String _status = 'Idle';
-  bool _running = false;
+  void _set(String s) => setStatus(s);
 
-  void _set(String s) {
-    if (mounted) setState(() => _status = s);
-  }
+  @override
+  IssueRunner? get cardRunner => _test;
 
   @override
   void dispose() {
@@ -82,8 +83,8 @@ class _RemoteConfigCardState extends State<RemoteConfigCard> {
   }
 
   Future<void> _test() async {
-    if (_running) return;
-    setState(() => _running = true);
+    if (running) return;
+    setRunning(running: true);
 
     final url = _urlController.text.trim();
     try {
@@ -141,7 +142,7 @@ class _RemoteConfigCardState extends State<RemoteConfigCard> {
     } catch (e) {
       _set('❌ ERROR: $e');
     } finally {
-      if (mounted) setState(() => _running = false);
+      setRunning(running: false);
     }
   }
 
@@ -180,25 +181,10 @@ class _RemoteConfigCardState extends State<RemoteConfigCard> {
               minLines: 1,
             ),
             const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Text(
-                _status,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
-              ),
-            ),
+            IssueStatusBox(status: status),
             const SizedBox(height: 16),
             FilledButton.icon(
-              onPressed: _running ? null : _test,
+              onPressed: running ? null : _test,
               icon: const Icon(Icons.cloud_download),
               label: const Text('Fetch & Apply'),
             ),

--- a/example/test/issue_card_state_test.dart
+++ b/example/test/issue_card_state_test.dart
@@ -1,0 +1,291 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+import 'package:tracelet_example/issues/issue_sweep.dart';
+
+/// A stand-in for a real issue card: same shape (store-backed status, a runner
+/// that reports into it), none of the SDK.
+class _FakeCard extends StatefulWidget {
+  const _FakeCard({required this.id, this.body, this.height = 400});
+
+  final String id;
+  final Future<void> Function(void Function(String) report)? body;
+  final double height;
+
+  @override
+  State<_FakeCard> createState() => _FakeCardState();
+}
+
+class _FakeCardState extends State<_FakeCard> with IssueCardRun<_FakeCard> {
+  @override
+  String get cardId => widget.id;
+
+  @override
+  bool get prepareBeforeRun => false;
+
+  @override
+  IssueRunner? get cardRunner => widget.body == null ? null : _run;
+
+  Future<void> _run() async {
+    setRunning(running: true);
+    try {
+      await widget.body!(setStatus);
+    } finally {
+      setRunning(running: false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      SizedBox(height: widget.height, child: Text('${widget.id}: $status'));
+}
+
+Widget _host({
+  required List<Widget> cards,
+  required ScrollController controller,
+  String scope = 'test',
+  double viewport = 600,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        height: viewport,
+        child: IssueCardScope(
+          name: scope,
+          child: ListView(controller: controller, children: cards),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a result survives the card being scrolled out of view', (
+    tester,
+  ) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      _host(
+        controller: controller,
+        cards: [
+          _FakeCard(
+            id: 'card-a',
+            body: (report) async => report('✅ SUCCESS: proved it'),
+          ),
+          const _FakeCard(id: 'card-b', height: 2000),
+        ],
+      ),
+    );
+
+    await IssueCardStore.instance.run('card-a');
+    await tester.pump();
+    expect(find.text('card-a: ✅ SUCCESS: proved it'), findsOneWidget);
+
+    // Far enough that the ListView unmounts card-a entirely.
+    controller.jumpTo(1800);
+    await tester.pump();
+    expect(find.textContaining('card-a'), findsNothing);
+
+    controller.jumpTo(0);
+    await tester.pump();
+    expect(find.text('card-a: ✅ SUCCESS: proved it'), findsOneWidget);
+  });
+
+  testWidgets('a result reported after the card is unmounted is not lost', (
+    tester,
+  ) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    final finish = Completer<void>();
+
+    await tester.pumpWidget(
+      _host(
+        controller: controller,
+        cards: [
+          _FakeCard(
+            id: 'slow-card',
+            body: (report) async {
+              report('Running…');
+              await finish.future;
+              report('✅ SUCCESS: finished off-screen');
+            },
+          ),
+          const _FakeCard(id: 'filler', height: 2000),
+        ],
+      ),
+    );
+
+    final run = IssueCardStore.instance.run('slow-card');
+    await tester.pump();
+
+    controller.jumpTo(1800);
+    await tester.pump();
+    expect(find.textContaining('slow-card'), findsNothing);
+
+    finish.complete();
+    await run;
+
+    controller.jumpTo(0);
+    await tester.pump();
+    expect(
+      find.text('slow-card: ✅ SUCCESS: finished off-screen'),
+      findsOneWidget,
+    );
+    expect(IssueCardStore.instance.entry('slow-card').running, isFalse);
+  });
+
+  testWidgets('the sweep reaches cards that start off-screen', (tester) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    final ran = <String>[];
+
+    await tester.pumpWidget(
+      _host(
+        controller: controller,
+        cards: [
+          for (var i = 0; i < 8; i++)
+            _FakeCard(
+              id: 'sweep-$i',
+              body: (report) async {
+                ran.add('sweep-$i');
+                report('done');
+              },
+            ),
+        ],
+      ),
+    );
+
+    // Only the first screenful is built to begin with — which is exactly why
+    // the old ladder could not reach the rest.
+    expect(IssueCardStore.instance.mountedIds('test').length, lessThan(8));
+
+    final sweep = IssueSweep(
+      scrollController: controller,
+      scope: 'test',
+      betweenCards: Duration.zero,
+    );
+    addTearDown(sweep.dispose);
+
+    final done = sweep.start();
+    await tester.pumpAndSettle();
+    await done;
+
+    expect(ran, [for (var i = 0; i < 8; i++) 'sweep-$i']);
+    expect(sweep.completed, 8);
+    expect(sweep.active, isFalse);
+  });
+
+  testWidgets('a card that never returns does not stall the sweep', (
+    tester,
+  ) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    final hang = Completer<void>();
+    addTearDown(() {
+      if (!hang.isCompleted) hang.complete();
+    });
+    final ran = <String>[];
+
+    await tester.pumpWidget(
+      _host(
+        controller: controller,
+        cards: [
+          _FakeCard(
+            id: 'hangs',
+            body: (report) async {
+              ran.add('hangs');
+              await hang.future;
+            },
+          ),
+          _FakeCard(
+            id: 'after',
+            body: (report) async {
+              ran.add('after');
+              report('done');
+            },
+          ),
+        ],
+      ),
+    );
+
+    final sweep = IssueSweep(
+      scrollController: controller,
+      scope: 'test',
+      cardTimeout: const Duration(milliseconds: 50),
+      betweenCards: Duration.zero,
+    );
+    addTearDown(sweep.dispose);
+
+    final done = sweep.start();
+    await tester.pumpAndSettle();
+    await done;
+
+    expect(ran, ['hangs', 'after']);
+    expect(
+      IssueCardStore.instance.entry('hangs').status,
+      contains('TIMED OUT'),
+    );
+    expect(IssueCardStore.instance.entry('hangs').running, isFalse);
+  });
+
+  testWidgets("a sweep only runs its own tab's cards", (tester) async {
+    final mine = ScrollController();
+    final theirs = ScrollController();
+    addTearDown(mine.dispose);
+    addTearDown(theirs.dispose);
+    final ran = <String>[];
+
+    Widget card(String id) => _FakeCard(
+      id: id,
+      height: 80,
+      body: (report) async {
+        ran.add(id);
+        report('done');
+      },
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              SizedBox(
+                height: 200,
+                child: IssueCardScope(
+                  name: 'mine',
+                  child: ListView(controller: mine, children: [card('mine-1')]),
+                ),
+              ),
+              SizedBox(
+                height: 200,
+                child: IssueCardScope(
+                  name: 'theirs',
+                  child: ListView(
+                    controller: theirs,
+                    children: [card('theirs-1')],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final sweep = IssueSweep(
+      scrollController: mine,
+      scope: 'mine',
+      betweenCards: Duration.zero,
+    );
+    addTearDown(sweep.dispose);
+
+    final done = sweep.start();
+    await tester.pumpAndSettle();
+    await done;
+
+    expect(ran, ['mine-1']);
+  });
+}

--- a/example/test/issues_page_test.dart
+++ b/example/test/issues_page_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+import 'package:tracelet_example/issues_page.dart';
+
+void main() {
+  testWidgets('the issues page builds and enlists its cards in Execute All', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: IssuesPage()));
+    await tester.pump();
+
+    expect(find.text('Execute All'), findsOneWidget);
+
+    // The cards visible on the Recent tab have registered themselves, so
+    // Execute All has something to run before it has scrolled anywhere. The old
+    // sweep could reach five hard-coded ids and nothing else.
+    expect(IssueCardStore.instance.mountedIds('recent'), isNotEmpty);
+  });
+}


### PR DESCRIPTION
Three defects on the example app's Issues page, all downstream of the same drift: the page started as a handful of cards the tab owned and drew itself, and grew into ~75 self-contained card widgets, while the machinery around them stayed as it was.

## Execute All ran five cards, showed nothing, and could hang — #372

`_executeAll()` was an `if` ladder over a ten-element list of issue numbers. That list predates the per-card widgets, and every card from `Issue212Card` up keeps its test inside its own `State`, where the tab has no way to call it — so the sweep reached five of ~75 cards. Of the ten ids it walked, five had no branch at all and contributed only the trailing two-second delay.

It also looked frozen, for two compounding reasons. Each step began with `Scrollable.ensureVisible` on `key.currentContext`, which is null for a card a lazy list has not built — so the list never moved, and the statuses being written landed on cards below the fold. And the button had no running state, so tapping it changed nothing on screen.

Finally, every step was awaited with no timeout. `_testIssue175` calls `getCurrentPosition`, which indoors can wait on a GPS fix for minutes or never; `_testIssue154` awaits a sync. Either one stalled the sweep with no cancel short of leaving the page, and a second tap started a second concurrent sweep.

`IssueSweep` replaces the ladder with something that walks the page: run every card currently mounted, scroll a screen, run whatever that mounted, repeat until the end. Cards enlist themselves through the store as they mount, so there is no list here to keep in sync and a card added next month is swept automatically. Each card is bounded (60s, then the sweep moves on and says so on the card), the button turns into **Stop**, and a progress strip names the card in flight — the scrolling itself doubles as the feedback the old version never gave.

Cards that must stay manual declare `cardRunner => null` and are skipped: start/stop tracking toggles, and the two-phase repros (#264, #270) that need the device rebooted between halves. Firing half of those is worse than not firing them.

## A card's result vanished when it scrolled out of view — #373

Status lived in each card's `State`; `ListView` disposes children that leave the viewport, and the result went with them. Scrolling back built a fresh `State` reading `Idle`.

**On the memory question:** the one-line fix is `AutomaticKeepAliveClientMixin`, and it is the wrong trade here. It pins every card's element and render subtree for the life of the page and defeats the list's virtualization — scroll to the bottom once and ~70 laid-out card subtrees are resident, a number that only grows as cards are added. What actually needs to survive is a string and a bool per card. Those now live in `IssueCardStore`, keyed by card, and the widgets stay as disposable as they are today.

The same change fixes a quieter loss: `if (mounted) setState(...)` silently discarded any result that arrived after its card was unmounted. That is exactly what a scrolling sweep does to the cards it passes, so the two bugs had to be fixed together.

Runner registration is deliberately scoped to *mounted* cards — a runner closes over a live `State`, so keeping one per card ever seen would quietly reintroduce the retention the store exists to avoid. Registrations are also namespaced per tab, so Execute All on Recent cannot reach across and fire Archived's cards while `TabBarView` has both built mid-swipe.

## Results could not be selected or copied — #374

Every status box was a plain `Text`. They are the only view of what the SDK actually returned, several print multi-line reports, and pasting a red one into an issue is the normal next step. They are now `SelectableText` with a one-tap copy — in the shell, in both tabs' own cards, in the nine bespoke-layout cards, and in #210's geofence log.

## Shape of the diff

74 card files change mechanically and identically: drop `_status`/`_running`, mix in `IssueCardRun`, declare `cardRunner`. No test logic was touched.

## Verification

`melos format` and `melos analyze` are clean. New tests in `example/test/` cover the claims rather than the plumbing:

- a result survives its card being scrolled out of view and back;
- a result reported *after* the card is unmounted is kept, and the running flag clears;
- the sweep reaches cards that start off-screen, in list order (the test asserts up front that fewer than all of them are mounted — the exact condition the old ladder could not handle);
- a card that never returns does not stall the sweep, and is marked as timed out;
- a sweep runs only its own tab's cards.

Plus a smoke test that the real page builds and that its cards have enlisted.

## Not done here

A few bespoke cards keep secondary live counters in local state (#210's log, #282's fix count) that still reset on scroll. Those are progress indicators watched during a manual run, not results — the result line itself is preserved. #204's invocation counter was the one case where a stale counter could contradict the remembered status, so it now shows only while the test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
