### PR TITLE
fix(android): route events to the headless task when the fan-out is empty (#371)

### DIFF
--- a/example/android/app/src/main/kotlin/com/ikolvi/tracelet/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/ikolvi/tracelet/example/MainActivity.kt
@@ -444,6 +444,14 @@ class MainActivity : FlutterActivity() {
                     // The restore is in a finally — leaving the app's own
                     // dispatcher out would break event delivery for the rest of
                     // the session, which is the very bug being tested.
+                    //
+                    // Delivery is observed by wrapping the fan-out's own
+                    // headless fallback for the duration of the send, not by
+                    // grepping the log. Both log lines this used to look for are
+                    // once-per-process — the "#371" line is written on the
+                    // transition into headless routing, and "headless: spawning"
+                    // only when there is no engine yet — so a second run of this
+                    // card routed correctly and reported a false failure.
                     try {
                         val dispatchers = fanOutDispatchers()
                             ?: throw IllegalStateException(
@@ -453,12 +461,27 @@ class MainActivity : FlutterActivity() {
                             .getInstance(applicationContext)
                         val sender = sdk.getEventSender()
                         val removed = ArrayList<Any?>(dispatchers)
+                        val routed = ArrayList<String>()
+                        val fallbackField = fanOutFallbackField(sender)
+                        val original = fallbackField?.get(sender)
                         try {
+                            if (original != null) {
+                                @Suppress("UNCHECKED_CAST")
+                                val delegate =
+                                    original as (String, Map<String, Any?>) -> Unit
+                                val recorder: (String, Map<String, Any?>) -> Unit =
+                                    { name, data ->
+                                        routed.add(name)
+                                        delegate(name, data)
+                                    }
+                                fallbackField.set(sender, recorder)
+                            }
                             dispatchers.clear()
                             sender.sendLocation(issue371ProbeLocation())
                         } finally {
                             @Suppress("UNCHECKED_CAST")
                             (dispatchers as MutableList<Any?>).addAll(removed)
+                            if (original != null) fallbackField?.set(sender, original)
                         }
                         result.success(
                             mapOf(
@@ -470,6 +493,8 @@ class MainActivity : FlutterActivity() {
                                 "restoredCount" to fanOutSize(),
                                 "fanOutFallbackWired" to fanOutFallbackWired(),
                                 "headlessTaskRegistered" to headlessTaskRegistered(),
+                                "routedToHeadless" to routed.isNotEmpty(),
+                                "routedEvents" to routed,
                             ),
                         )
                     } catch (e: Throwable) {
@@ -513,6 +538,21 @@ class MainActivity : FlutterActivity() {
             .apply { isAccessible = true }.get(null)
         sender.javaClass.getDeclaredField("dispatchers")
             .apply { isAccessible = true }.get(sender) as? MutableList<*>
+    } catch (e: Throwable) {
+        null
+    }
+
+    /**
+     * `MultiEventSender.headlessFallback`, or null on a build without the #371
+     * fix (the field does not exist there).
+     *
+     * Wrapping it for the length of one send is how the probe observes that the
+     * composite actually routed the event, rather than inferring it from a log
+     * line that is only written once per process.
+     */
+    private fun fanOutFallbackField(sender: Any): java.lang.reflect.Field? = try {
+        sender.javaClass.getDeclaredField("headlessFallback")
+            .apply { isAccessible = true }
     } catch (e: Throwable) {
         null
     }

--- a/example/android/app/src/main/kotlin/com/ikolvi/tracelet/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/ikolvi/tracelet/example/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.ikolvi.tracelet.example
 
+import android.content.Intent
 import android.util.Base64
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingBackgroundService
 
 class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -363,10 +365,207 @@ class MainActivity : FlutterActivity() {
                     } catch (e: Throwable) {
                         result.error("ISSUE_364_ERROR", e.toString(), null)
                     }
+                } else if (call.method == "debugIssue371SpawnFcmEngine") {
+                    // #371 step 1 — get the REAL foreign engine into the process.
+                    //
+                    // Not a look-alike `FlutterEngine(applicationContext)` this
+                    // time (that is #364's card): this hands the work to
+                    // firebase_messaging's own JobIntentService, whose onCreate
+                    // runs FlutterFirebaseMessagingBackgroundExecutor
+                    // .startBackgroundIsolate() and constructs the engine. The
+                    // difference that matters for #371 is ownership — the service
+                    // holds that engine for the rest of the process, so it is
+                    // still attached when the app is swiped away, which is the
+                    // exact condition the reporter's failing branch depends on.
+                    //
+                    // The intent carries no RemoteMessage: the executor logs
+                    // "RemoteMessage byte array not found in Intent." and stops
+                    // there, which is all we want. The engine — and Tracelet's
+                    // auto-registered plugin instance on it — is already up by
+                    // then.
+                    //
+                    // Requires FirebaseMessaging.onBackgroundMessage() to have run
+                    // in Dart: startBackgroundIsolate() reads the callback handle
+                    // that call stores, and does nothing when it is absent.
+                    try {
+                        val before = fanOutSize()
+                        val enginesBefore = attachedEngineCount()
+                        FlutterFirebaseMessagingBackgroundService.enqueueMessageProcessing(
+                            applicationContext,
+                            Intent(applicationContext, MainActivity::class.java),
+                            false,
+                        )
+                        result.success(
+                            mapOf(
+                                "platform" to "android",
+                                "fanOutBefore" to before,
+                                "enginesBefore" to enginesBefore,
+                                "callbackHandleSet" to fcmCallbackHandleSet(),
+                            ),
+                        )
+                    } catch (e: Throwable) {
+                        result.error("ISSUE_371_SPAWN_ERROR", e.toString(), null)
+                    }
+                } else if (call.method == "debugIssue371FanOutState") {
+                    // Read-only: lets the card poll until the FCM engine has
+                    // actually attached before it measures anything.
+                    result.success(
+                        mapOf(
+                            "platform" to "android",
+                            "fanOut" to fanOutSize(),
+                            "engines" to attachedEngineCount(),
+                            "fanOutFallbackWired" to fanOutFallbackWired(),
+                            "headlessTaskRegistered" to headlessTaskRegistered(),
+                            "foreignEngineArmed" to fcmCallbackHandleSet(),
+                        ),
+                    )
+                } else if (call.method == "debugIssue371DisarmForeignEngine") {
+                    // Drops the handles firebase_messaging persisted, so the next
+                    // launch of the example is back to a single engine.
+                    applicationContext
+                        .getSharedPreferences(FCM_PREFS, MODE_PRIVATE)
+                        .edit()
+                        .remove("callback_handle")
+                        .remove("user_callback_handle")
+                        .apply()
+                    result.success(null)
+                } else if (call.method == "debugIssue371EmptyFanOutProbe") {
+                    // #371 step 2 — put the process into the post-swipe state and
+                    // dispatch one event through the SDK's real event sender.
+                    //
+                    // After task removal `onDetachedFromEngine` removes the
+                    // primary's dispatcher from the fan-out while the SDK keeps
+                    // that same composite as its event sender, so the composite is
+                    // left empty — and `dispatchers.forEach { … }` on an empty list
+                    // dropped every event in silence. That state cannot be reached
+                    // from a live isolate (it needs this app to be dead), so we
+                    // reproduce it exactly: empty the fan-out, send, restore.
+                    //
+                    // The restore is in a finally — leaving the app's own
+                    // dispatcher out would break event delivery for the rest of
+                    // the session, which is the very bug being tested.
+                    try {
+                        val dispatchers = fanOutDispatchers()
+                            ?: throw IllegalStateException(
+                                "fan-out not readable — run a debug build",
+                            )
+                        val sdk = com.ikolvi.tracelet.sdk.TraceletSdk
+                            .getInstance(applicationContext)
+                        val sender = sdk.getEventSender()
+                        val removed = ArrayList<Any?>(dispatchers)
+                        try {
+                            dispatchers.clear()
+                            sender.sendLocation(issue371ProbeLocation())
+                        } finally {
+                            @Suppress("UNCHECKED_CAST")
+                            (dispatchers as MutableList<Any?>).addAll(removed)
+                        }
+                        result.success(
+                            mapOf(
+                                "platform" to "android",
+                                "senderIsTheFanOut" to
+                                    (sender.javaClass.name ==
+                                        "com.ikolvi.tracelet.flutter.MultiEventSender"),
+                                "emptiedCount" to removed.size,
+                                "restoredCount" to fanOutSize(),
+                                "fanOutFallbackWired" to fanOutFallbackWired(),
+                                "headlessTaskRegistered" to headlessTaskRegistered(),
+                            ),
+                        )
+                    } catch (e: Throwable) {
+                        result.error("ISSUE_371_PROBE_ERROR", e.toString(), null)
+                    }
                 } else {
                     result.notImplemented()
                 }
             }
+    }
+
+    // ==== #371 verification helpers ====
+
+    /**
+     * A synthetic fix, tagged so anything it reaches can be told apart from a
+     * real one. Same shape the SDK's location pipeline emits.
+     */
+    private fun issue371ProbeLocation(): Map<String, Any?> = mapOf(
+        "uuid" to "issue-371-probe",
+        "event" to "issue371probe",
+        "timestamp" to java.time.Instant.now().toString(),
+        "is_moving" to true,
+        "odometer" to 0.0,
+        "coords" to mapOf(
+            "latitude" to 0.0,
+            "longitude" to 0.0,
+            "accuracy" to 5.0,
+            "speed" to 0.0,
+            "heading" to 0.0,
+            "altitude" to 0.0,
+        ),
+        "battery" to mapOf("level" to 1.0, "is_charging" to false),
+        "extras" to mapOf("issue" to "371"),
+    )
+
+    /** The live dispatcher list inside the global fan-out, or null (#371). */
+    private fun fanOutDispatchers(): MutableList<*>? = try {
+        val pluginClass =
+            Class.forName("com.ikolvi.tracelet.flutter.TraceletAndroidPlugin")
+        val sender = pluginClass.getDeclaredField("globalEventSender")
+            .apply { isAccessible = true }.get(null)
+        sender.javaClass.getDeclaredField("dispatchers")
+            .apply { isAccessible = true }.get(sender) as? MutableList<*>
+    } catch (e: Throwable) {
+        null
+    }
+
+    /**
+     * Whether the fan-out itself carries a headless fallback — the #371 fix.
+     * Without it an empty fan-out has nothing to fall back *from*, because the
+     * per-dispatcher fallbacks left with the dispatchers.
+     */
+    private fun fanOutFallbackWired(): Boolean = try {
+        val pluginClass =
+            Class.forName("com.ikolvi.tracelet.flutter.TraceletAndroidPlugin")
+        val sender = pluginClass.getDeclaredField("globalEventSender")
+            .apply { isAccessible = true }.get(null)
+        sender.javaClass.getDeclaredField("headlessFallback")
+            .apply { isAccessible = true }.get(sender) != null
+    } catch (e: Throwable) {
+        false
+    }
+
+    /** Engines Tracelet is currently attached to (the plugin's own counter). */
+    private fun attachedEngineCount(): Int = try {
+        val pluginClass =
+            Class.forName("com.ikolvi.tracelet.flutter.TraceletAndroidPlugin")
+        val counter = pluginClass.getDeclaredField("attachedEngineCount")
+            .apply { isAccessible = true }.get(null)
+        (counter as java.util.concurrent.atomic.AtomicInteger).get()
+    } catch (e: Throwable) {
+        -1
+    }
+
+    /**
+     * Whether `registerHeadlessTask()` has stored a callback — without it the
+     * headless route exists but has nowhere to deliver, and the probe would
+     * report a false negative.
+     */
+    private fun headlessTaskRegistered(): Boolean =
+        applicationContext
+            .getSharedPreferences("com.tracelet.headless", MODE_PRIVATE)
+            .getLong("dispatch_callback_id", -1L) != -1L
+
+    /**
+     * Whether `FirebaseMessaging.onBackgroundMessage()` stored its handle — the
+     * precondition for firebase_messaging creating its background engine.
+     */
+    private fun fcmCallbackHandleSet(): Boolean =
+        applicationContext
+            .getSharedPreferences(FCM_PREFS, MODE_PRIVATE)
+            .getLong("callback_handle", 0L) != 0L
+
+    private companion object {
+        /** firebase_messaging's own store (`FlutterFirebaseMessagingUtils`). */
+        const val FCM_PREFS = "io.flutter.firebase.messaging.callback"
     }
 
     /**

--- a/example/integration_test/issue_371_test.dart
+++ b/example/integration_test/issue_371_test.dart
@@ -37,19 +37,6 @@ void main() {
     return s ?? <String, dynamic>{};
   }
 
-  Future<int> latestLogId() async {
-    final logs = await Tracelet.getLogs(500);
-    return logs.fold<int>(0, (max, e) => e.id > max ? e.id : max);
-  }
-
-  Future<List<String>> logsSince(int sinceId, String marker) async {
-    final logs = await Tracelet.getLogs(500);
-    return logs
-        .where((e) => e.id > sinceId && e.message.contains(marker))
-        .map((e) => e.message)
-        .toList();
-  }
-
   setUpAll(() async {
     await Tracelet.registerHeadlessTask(issue371HeadlessTask);
     await Tracelet.ready(const Config());
@@ -114,7 +101,6 @@ void main() {
           'routed" look the same from here',
     );
 
-    final sinceId = await latestLogId();
     final probe = await debug.invokeMapMethod<String, dynamic>(
       'debugIssue371EmptyFanOutProbe',
     );
@@ -136,14 +122,13 @@ void main() {
     // The symptom first, the mechanism second: on a build without the fix this
     // is the assertion that should fail, and it fails saying what the reporter
     // saw rather than naming a field.
-    await Future<void>.delayed(const Duration(seconds: 2));
-    final routed = await logsSince(sinceId, 'routing to the headless task');
-    final spawned = await logsSince(
-      sinceId,
-      'headless: spawning a FlutterEngine',
-    );
+    //
+    // Observed by wrapping the fan-out's own fallback around the send, not by
+    // grepping the log: the "#371" line is written on the transition into
+    // headless routing and "headless: spawning" only while no engine exists, so
+    // both are once-per-process and a second probe would look like a failure.
     expect(
-      routed.isNotEmpty || spawned.isNotEmpty,
+      probe['routedToHeadless'],
       isTrue,
       reason:
           'the location sent into the empty fan-out reached nothing at all — '
@@ -157,6 +142,20 @@ void main() {
           'MultiEventSender.headlessFallback is null: with the members gone '
           'there is nothing left to fall back from (#371)',
     );
+
+    // Running the probe again must answer the same. It did not when this was
+    // read from the log: the first run latches the transition into headless
+    // routing and leaves a headless engine alive, so neither line is written a
+    // second time and a correctly-routed event looked like a failure.
+    final again = await debug.invokeMapMethod<String, dynamic>(
+      'debugIssue371EmptyFanOutProbe',
+    );
+    expect(
+      again!['routedToHeadless'],
+      isTrue,
+      reason: 'a repeated probe must route exactly as the first one did',
+    );
+    expect(again['restoredCount'], again['emptiedCount']);
   });
 
   tearDownAll(() async {

--- a/example/integration_test/issue_371_test.dart
+++ b/example/integration_test/issue_371_test.dart
@@ -1,0 +1,170 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:tracelet/tracelet.dart';
+import 'package:tracelet_example/foreign_fcm_engine.dart';
+
+/// Issue #371 — on-device regression coverage for the event fan-out that has
+/// no member able to receive.
+///
+/// The Robolectric tests
+/// (`MultiEventSenderFallbackTest`, `PluginSecondaryEngineGuardTest`) pin the
+/// routing decision and the wiring with mock bindings. What they cannot show is
+/// the situation that produces it, which needs a second **real** FlutterEngine
+/// in the process, built by another plugin: this drives
+/// firebase_messaging's own background service and then reproduces the
+/// post-task-removal state — fan-out emptied, SDK still holding it as its event
+/// sender — and checks that a location dispatched into it reaches the headless
+/// task instead of disappearing.
+///
+/// ```
+/// flutter test integration_test/issue_371_test.dart -d <android-device>
+/// ```
+///
+/// Android only, and a debug build: the probes read private fields
+/// reflectively.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const debug = MethodChannel('com.tracelet/debug');
+
+  Future<Map<String, dynamic>> state() async {
+    final s = await debug.invokeMapMethod<String, dynamic>(
+      'debugIssue371FanOutState',
+    );
+    return s ?? <String, dynamic>{};
+  }
+
+  Future<int> latestLogId() async {
+    final logs = await Tracelet.getLogs(500);
+    return logs.fold<int>(0, (max, e) => e.id > max ? e.id : max);
+  }
+
+  Future<List<String>> logsSince(int sinceId, String marker) async {
+    final logs = await Tracelet.getLogs(500);
+    return logs
+        .where((e) => e.id > sinceId && e.message.contains(marker))
+        .map((e) => e.message)
+        .toList();
+  }
+
+  setUpAll(() async {
+    await Tracelet.registerHeadlessTask(issue371HeadlessTask);
+    await Tracelet.ready(const Config());
+  });
+
+  testWidgets('the real firebase_messaging engine stays out of the fan-out', (
+    tester,
+  ) async {
+    if (!Platform.isAndroid) return;
+
+    final before = await state();
+    final baselineEngines = before['engines'] as int;
+    final baselineFanOut = before['fanOut'] as int;
+    expect(
+      baselineFanOut,
+      greaterThanOrEqualTo(1),
+      reason:
+          'the fan-out must be readable and hold this app engine — run a '
+          'debug build, release minification renames these fields',
+    );
+
+    expect(await ForeignFcmEngine.arm(), isNull);
+
+    // FlutterFirebaseMessagingBackgroundService builds the engine on the main
+    // thread; it is not up the instant onBackgroundMessage returns.
+    var after = await state();
+    for (
+      var i = 0;
+      i < 40 && (after['engines'] as int) <= baselineEngines;
+      i++
+    ) {
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      after = await state();
+    }
+
+    expect(
+      after['engines'] as int,
+      greaterThan(baselineEngines),
+      reason:
+          'firebase_messaging never created its background engine, so nothing '
+          'was measured — check that onBackgroundMessage stored its handle',
+    );
+    expect(
+      after['fanOut'] as int,
+      baselineFanOut,
+      reason:
+          'the foreign engine joined the event fan-out — it will swallow every '
+          'event once the UI engine dies (#364)',
+    );
+  });
+
+  testWidgets('an emptied fan-out still reaches the headless task', (
+    tester,
+  ) async {
+    if (!Platform.isAndroid) return;
+
+    expect(
+      (await state())['headlessTaskRegistered'],
+      isTrue,
+      reason:
+          'without a registered headless task, "routed and dropped" and "never '
+          'routed" look the same from here',
+    );
+
+    final sinceId = await latestLogId();
+    final probe = await debug.invokeMapMethod<String, dynamic>(
+      'debugIssue371EmptyFanOutProbe',
+    );
+
+    expect(probe, isNotNull);
+    expect(
+      probe!['senderIsTheFanOut'],
+      isTrue,
+      reason:
+          'the SDK must still hold MultiEventSender as its event sender — that '
+          'is what makes an empty fan-out fatal rather than irrelevant',
+    );
+    expect(
+      probe['restoredCount'],
+      probe['emptiedCount'],
+      reason: "the probe must put the app's own dispatcher back",
+    );
+
+    // The symptom first, the mechanism second: on a build without the fix this
+    // is the assertion that should fail, and it fails saying what the reporter
+    // saw rather than naming a field.
+    await Future<void>.delayed(const Duration(seconds: 2));
+    final routed = await logsSince(sinceId, 'routing to the headless task');
+    final spawned = await logsSince(
+      sinceId,
+      'headless: spawning a FlutterEngine',
+    );
+    expect(
+      routed.isNotEmpty || spawned.isNotEmpty,
+      isTrue,
+      reason:
+          'the location sent into the empty fan-out reached nothing at all — '
+          'this is #371',
+    );
+
+    expect(
+      probe['fanOutFallbackWired'],
+      isTrue,
+      reason:
+          'MultiEventSender.headlessFallback is null: with the members gone '
+          'there is nothing left to fall back from (#371)',
+    );
+  });
+
+  tearDownAll(() async {
+    if (Platform.isAndroid) await ForeignFcmEngine.disarm();
+  });
+}
+
+/// Registered so the headless route has somewhere to deliver. The probe's
+/// synthetic fix is tagged `issue-371-probe`.
+@pragma('vm:entry-point')
+void issue371HeadlessTask(HeadlessEvent event) {}

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,10 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '14.0'
+# 15.0 to match Runner.xcodeproj's IPHONEOS_DEPLOYMENT_TARGET, which has been
+# 15.0 for some time — and to satisfy firebase_messaging, which the example
+# depends on for the foreign background engine in issue_371_card.dart and whose
+# podspec requires 15.0. Tracelet itself is unaffected: tracelet_ios keeps its
+# own, lower minimum.
+platform :ios, '15.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/lib/foreign_fcm_engine.dart
+++ b/example/lib/foreign_fcm_engine.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// The foreign background FlutterEngine, created by the plugin that actually
+/// creates one in the field (#364, #371).
+///
+/// `FirebaseMessaging.onBackgroundMessage()` does more than remember a handler:
+/// the native side stores the callback handles and immediately calls
+/// `FlutterFirebaseMessagingBackgroundService.startBackgroundIsolate()`, which
+/// constructs a second `FlutterEngine` in this process. Flutter's plugin
+/// auto-registration attaches Tracelet to it, and the service holds it for the
+/// rest of the process — so it is still attached when the app is swiped from
+/// recents. That surviving engine is the precondition for #371's failing
+/// branch, and it is why the reporter sees the bug only on runs where a
+/// background message landed.
+///
+/// A real app calls this from `main()`. The example arms it on demand instead,
+/// so every other issue card keeps running against the ordinary
+/// one-engine topology — but arming is **sticky**: the handle the plugin
+/// persists is how [restoreIfArmed] knows to re-register on the next launch,
+/// which is what makes the swipe-kill test repeatable without touching the UI
+/// first.
+///
+/// No Firebase project configuration is involved. `onBackgroundMessage` runs
+/// through a stub platform instance, so no `Firebase.initializeApp()`, no
+/// `google-services.json`, and no network are needed to get the engine — this
+/// is the plugin's own code path, not a stand-in for it.
+class ForeignFcmEngine {
+  ForeignFcmEngine._();
+
+  static const _debug = MethodChannel('com.tracelet/debug');
+
+  static bool _registered = false;
+
+  /// Whether this isolate has registered the handler in this session.
+  static bool get registeredInThisSession => _registered;
+
+  /// Registers the FCM background handler, creating the foreign engine.
+  ///
+  /// Returns null on success, or a human-readable reason it could not run.
+  static Future<String?> arm() async {
+    if (!Platform.isAndroid) {
+      return 'firebase_messaging only creates a background FlutterEngine on '
+          'Android; there is no foreign-engine path to arm here.';
+    }
+    if (_registered) return null;
+    try {
+      FirebaseMessaging.onBackgroundMessage(
+        traceletExampleFcmBackgroundHandler,
+      );
+      _registered = true;
+      return null;
+    } on Object catch (e) {
+      return '$e';
+    }
+  }
+
+  /// Re-registers when a previous session armed it, so the foreign engine is
+  /// back before the app is swiped away again.
+  ///
+  /// Reads the handle firebase_messaging itself persisted rather than a flag of
+  /// our own: that is the same state the plugin consults, so "armed" cannot
+  /// drift from "the plugin will build an engine".
+  static Future<void> restoreIfArmed() async {
+    if (!Platform.isAndroid) return;
+    try {
+      final state = await _debug.invokeMapMethod<String, dynamic>(
+        'debugIssue371FanOutState',
+      );
+      if (state?['foreignEngineArmed'] == true) {
+        await arm();
+      }
+    } on PlatformException catch (e) {
+      debugPrint('[#371] could not read the armed flag: ${e.message}');
+    }
+  }
+
+  /// Clears the persisted handles, returning the example app to a single
+  /// engine on the next launch.
+  static Future<void> disarm() async {
+    if (!Platform.isAndroid) return;
+    await _debug.invokeMethod<void>('debugIssue371DisarmForeignEngine');
+    _registered = false;
+  }
+}
+
+/// The app-side background message handler.
+///
+/// Never invoked by the example — the repro spawns the engine without a
+/// RemoteMessage — but it must exist and be a top-level entry point, because
+/// registering it is what creates the engine.
+@pragma('vm:entry-point')
+Future<void> traceletExampleFcmBackgroundHandler(RemoteMessage message) async {
+  debugPrint('[FCM background] message ${message.messageId}');
+}

--- a/example/lib/issues/issue_364_card.dart
+++ b/example/lib/issues/issue_364_card.dart
@@ -35,6 +35,13 @@ import 'package:tracelet_example/issues/issue_card_state.dart';
 /// fires after the app is swiped away — needs the app to be dead, so no card
 /// can observe it. Those steps are printed at the end to run by hand.
 ///
+/// It also cannot see what happens *after* the primary detaches, which is where
+/// this fix left a second hole: with the foreign engine correctly held out, the
+/// fan-out was empty rather than hostile, and an empty fan-out dropped events
+/// just as quietly (#371). `issue_371_card.dart` covers that — with the real
+/// firebase_messaging engine rather than the look-alike one built here, because
+/// that failure needs the foreign engine to still be attached at swipe time.
+///
 /// **iOS.** The foreign-engine path does not exist there: `register(with:)`
 /// gives secondary registrars the Pigeon HostApi only and never wires them into
 /// event delivery. The iOS half of this fix is the detach path — the primary's

--- a/example/lib/issues/issue_371_card.dart
+++ b/example/lib/issues/issue_371_card.dart
@@ -1,0 +1,309 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/foreign_fcm_engine.dart';
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+
+/// Issue #371 — when nothing in the fan-out can receive an event, it must go
+/// to the headless task.
+///
+/// The regression #365 (for #364) left behind: with the foreign
+/// firebase_messaging engine correctly held out of `MultiEventSender`, task
+/// removal takes the primary's dispatcher out too — and the composite the SDK
+/// still holds as its event sender is then **empty**. Every `send*` was
+/// `dispatchers.forEach { … }`, a no-op on an empty list, and `headlessFallback`
+/// was a property of `EventDispatcher`, i.e. of the members that had just left.
+/// Native tracking kept producing fixes every few seconds; Dart received
+/// nothing, and not one line was logged to say so.
+///
+/// **Why this card exists when #364's already passes.** #364's card measures
+/// fan-out membership with a look-alike engine it constructs and destroys. That
+/// is the right measurement for #364 and it still passes — but it cannot show
+/// #371, for two reasons: the failure is in the *empty* fan-out, which only
+/// happens after the primary detaches, and it is conditional on a foreign
+/// engine still being attached at that moment. So this card uses
+/// firebase_messaging itself, whose background service *owns* its engine for
+/// the rest of the process, and then reproduces the detached state directly.
+///
+/// **What it proves.**
+/// 1. The real `FlutterFirebaseMessagingBackgroundService` engine attaches, and
+///    (the #364 guarantee, now with the actual plugin) does not join the fan-out.
+/// 2. With the fan-out emptied — the exact post-swipe state — one location sent
+///    through the SDK's own event sender reaches the registered headless task.
+///    Before the fix that dispatch vanished; the card fails on such a build.
+///
+/// **What it cannot prove.** That this still holds when the app is genuinely
+/// dead: that needs the process without a UI isolate, so no card can watch it.
+/// Arming leaves the foreign engine in place across launches, which is what
+/// makes the manual swipe-kill run repeatable — the steps are printed at the end.
+///
+/// **iOS.** Not applicable: `MultiEventSender` is Android-only, and
+/// `TraceletIosPlugin.register(with:)` never wires a secondary registrar into
+/// event delivery, so there is no fan-out to empty.
+///
+/// Run a **debug** build: the probe reads private fields reflectively.
+class Issue371Card extends StatefulWidget {
+  const Issue371Card({super.key});
+
+  @override
+  State<Issue371Card> createState() => _Issue371CardState();
+}
+
+class _Issue371CardState extends State<Issue371Card>
+    with IssueCardRun<Issue371Card> {
+  static const _debug = MethodChannel('com.tracelet/debug');
+
+  /// Written by HeadlessTaskService when it starts an engine for queued events.
+  static const _spawnMarker = 'headless: spawning a FlutterEngine';
+
+  /// The always-on line the fix adds when the fan-out cannot receive (#371).
+  static const _emptyFanOutMarker = 'routing to the headless task (#371)';
+
+  void _set(String s) => setStatus(s);
+
+  /// Manual only — Execute All must not arm this one.
+  ///
+  /// Running it leaves a second FlutterEngine attached for the rest of the
+  /// process and re-creates it on the next launch, which is the point of the
+  /// card but a poor thing to do to the app behind a sweep. It is also the
+  /// half-a-repro case the harness reserves this for: the other half needs the
+  /// app killed.
+  @override
+  IssueRunner? get cardRunner => null;
+
+  Future<int> _latestLogId() async {
+    final logs = await Tracelet.getLogs(500);
+    return logs.fold<int>(0, (max, e) => e.id > max ? e.id : max);
+  }
+
+  Future<List<String>> _logsSince(int sinceId, String marker) async {
+    final logs = await Tracelet.getLogs(500);
+    return logs
+        .where((e) => e.id > sinceId && e.message.contains(marker))
+        .map((e) => e.message)
+        .toList();
+  }
+
+  Future<Map<String, dynamic>?> _state() =>
+      _debug.invokeMapMethod<String, dynamic>('debugIssue371FanOutState');
+
+  /// Waits for the foreign engine to finish attaching.
+  ///
+  /// The engine is built on the main thread from the plugin's own service, so
+  /// it is not up the instant `onBackgroundMessage` returns.
+  Future<Map<String, dynamic>?> _awaitForeignEngine(int baseline) async {
+    for (var i = 0; i < 40; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      final s = await _state();
+      if ((s?['engines'] as int? ?? 0) > baseline) return s;
+    }
+    return _state();
+  }
+
+  Future<void> _run() async {
+    if (running) return;
+    setRunning(running: true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    try {
+      if (!Platform.isAndroid) {
+        _set(
+          'ℹ️ iOS — not applicable, and deliberately not reported as a pass.\n\n'
+          'MultiEventSender is the Android fan-out; there is no iOS equivalent '
+          'to leave empty. TraceletIosPlugin.register(with:) gives a secondary '
+          'registrar the Pigeon HostApi only and never wires one into event '
+          'delivery, so iOS has a single dispatcher whose headless fallback is '
+          'reached whenever its engine is gone.',
+        );
+        return;
+      }
+
+      final before = await _state();
+      if (before == null) {
+        _set('❌ ERROR: debug channel returned null.');
+        return;
+      }
+      final baselineEngines = before['engines'] as int? ?? -1;
+      final baselineFanOut = before['fanOut'] as int? ?? -1;
+      final beforeId = await _latestLogId();
+
+      // ---- 1. the real foreign engine -----------------------------------
+      _set('Arming firebase_messaging — its service builds the engine…');
+      final armError = await ForeignFcmEngine.arm();
+      if (armError != null) {
+        _set('❌ ERROR: could not arm firebase_messaging — $armError');
+        return;
+      }
+
+      final after = await _awaitForeignEngine(baselineEngines);
+      final engines = after?['engines'] as int? ?? -1;
+      final fanOut = after?['fanOut'] as int? ?? -1;
+
+      check(
+        'the real firebase_messaging engine attached',
+        engines > baselineEngines,
+        engines > baselineEngines
+            ? 'engineCount $baselineEngines → $engines '
+                  '(FlutterFirebaseMessagingBackgroundService built it)'
+            : 'engineCount stayed at $engines — the plugin never created its '
+                  'engine, so this run measured nothing. INCONCLUSIVE',
+      );
+
+      check(
+        'it did NOT join the event fan-out (#364 still holds)',
+        baselineFanOut >= 1 && fanOut == baselineFanOut,
+        fanOut == baselineFanOut
+            ? '$baselineFanOut → $fanOut dispatchers across the attach'
+            : '$baselineFanOut → $fanOut — the foreign engine was added and '
+                  'will swallow events once the UI engine dies',
+      );
+
+      // ---- 2. the #371 fix ------------------------------------------------
+      final headlessRegistered = after?['headlessTaskRegistered'] == true;
+      check(
+        'a headless task is registered',
+        headlessRegistered,
+        headlessRegistered
+            ? 'registerHeadlessTask() stored a callback, so a fallback has '
+                  'somewhere to deliver'
+            : 'no headless callback stored — call registerHeadlessTask() before '
+                  'runApp(). Without it the probe below cannot tell "routed and '
+                  'dropped" from "never routed". INCONCLUSIVE',
+      );
+
+      _set('Emptying the fan-out and sending one location through the SDK…');
+      final probe = await _debug.invokeMapMethod<String, dynamic>(
+        'debugIssue371EmptyFanOutProbe',
+      );
+      if (probe == null) {
+        _set('❌ ERROR: the probe returned null.');
+        return;
+      }
+
+      check(
+        "the SDK's event sender is the fan-out",
+        probe['senderIsTheFanOut'] == true,
+        probe['senderIsTheFanOut'] == true
+            ? 'setEventSender(globalEventSender) is still in force — which is '
+                  'why emptying it strands every event'
+            : 'the SDK holds a different sender; this probe does not describe '
+                  'the reported state',
+      );
+
+      check(
+        'the fan-out was restored',
+        probe['restoredCount'] == probe['emptiedCount'],
+        '${probe['emptiedCount']} dispatcher(s) removed, '
+            '${probe['restoredCount']} put back — the app keeps receiving events',
+      );
+
+      check(
+        'the fan-out itself carries a headless fallback',
+        probe['fanOutFallbackWired'] == true,
+        probe['fanOutFallbackWired'] == true
+            ? 'MultiEventSender.headlessFallback is wired, so an empty '
+                  'composite still has a route'
+            : 'MultiEventSender.headlessFallback is null — with no members '
+                  'left there is nothing to fall back from, and every event is '
+                  'dropped in silence',
+      );
+
+      // Give HeadlessTaskService a moment to log its spawn.
+      await Future<void>.delayed(const Duration(seconds: 2));
+      final routedLines = await _logsSince(beforeId, _emptyFanOutMarker);
+      final spawnLines = await _logsSince(beforeId, _spawnMarker);
+
+      check(
+        'the event was routed to the headless task',
+        routedLines.isNotEmpty || spawnLines.isNotEmpty,
+        routedLines.isNotEmpty
+            ? routedLines.last
+            : spawnLines.isNotEmpty
+            ? spawnLines.last
+            : 'neither "$_emptyFanOutMarker" nor "$_spawnMarker" was logged — '
+                  'the location sent into the empty fan-out reached nothing, '
+                  'which is #371',
+      );
+
+      final summary = StringBuffer()
+        ..writeln(allPass ? '✅ PASS' : '❌ FAIL')
+        ..writeln()
+        ..writeln(results.join('\n'))
+        ..writeln()
+        ..writeln('— Armed —')
+        ..writeln(
+          'The firebase_messaging background engine is now attached and stays '
+          'for the life of this process, and the example re-registers it on '
+          'the next launch (Disarm below undoes that).',
+        )
+        ..writeln()
+        ..writeln('— Not measured here: the killed-app run —')
+        ..writeln(
+          '1. Start tracking, with stopOnTerminate: false.\n'
+          '2. Swipe the app from recents.\n'
+          '3. adb logcat | grep -E '
+          '"remainingEngines|SDK preserved|#371|headless: spawning"\n'
+          'Expect: "secondary engines still active, SDK preserved", then '
+          '"no attached engine can receive events … routing to the headless '
+          'task (#371)" and "headless: spawning a FlutterEngine". Before the '
+          'fix, the log stops after the heartbeat lines.',
+        );
+      _set(summary.toString());
+    } on PlatformException catch (e) {
+      _set('❌ ERROR: ${e.code} — ${e.message}');
+    } on Object catch (e) {
+      _set('❌ ERROR: $e');
+    } finally {
+      setRunning(running: false);
+    }
+  }
+
+  Future<void> _disarm() async {
+    await ForeignFcmEngine.disarm();
+    _set(
+      'Disarmed. The persisted firebase_messaging callback handles are '
+      'cleared, so the next launch of the example runs with a single engine. '
+      'The engine created in *this* process stays until it is restarted.',
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        IssueCardShell(
+          title: '#371 — Empty fan-out swallows every event',
+          description:
+              'Uses firebase_messaging to create the real foreign background '
+              'engine, then empties the fan-out the way task removal does and '
+              'checks the event still reaches the headless task.',
+          status: status,
+          running: running,
+          keywords:
+              'firebase_messaging foreign engine empty fan-out MultiEventSender '
+              'headless task removal swipe kill dispatchers 364 regression',
+          onRun: _run,
+        ),
+        Padding(
+          padding: const EdgeInsets.only(right: 24, bottom: 8),
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: TextButton(
+              onPressed: running ? null : _disarm,
+              child: const Text('Disarm firebase_messaging'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/issues/issue_371_card.dart
+++ b/example/lib/issues/issue_371_card.dart
@@ -217,27 +217,46 @@ class _Issue371CardState extends State<Issue371Card>
                   'dropped in silence',
       );
 
+      // The routing itself, observed by wrapping the fan-out's fallback around
+      // this one send. Deliberately not the log lines below: both are written
+      // once per process — the "#371" line on the *transition* into headless
+      // routing, "headless: spawning" only while there is no engine yet — so
+      // pressing Run a second time reported a false failure on a build that
+      // routed the event perfectly well.
+      final routedEvents = (probe['routedEvents'] as List<Object?>? ?? [])
+          .map((e) => '$e')
+          .toList();
+      check(
+        'the event was routed to the headless task',
+        probe['routedToHeadless'] == true,
+        probe['routedToHeadless'] == true
+            ? "the fan-out handed '${routedEvents.join(', ')}' to the headless "
+                  'route while it had no member that could receive'
+            : 'the location sent into the empty fan-out reached nothing at '
+                  'all, which is #371',
+      );
+
       // Give HeadlessTaskService a moment to log its spawn.
       await Future<void>.delayed(const Duration(seconds: 2));
       final routedLines = await _logsSince(beforeId, _emptyFanOutMarker);
       final spawnLines = await _logsSince(beforeId, _spawnMarker);
 
-      check(
-        'the event was routed to the headless task',
-        routedLines.isNotEmpty || spawnLines.isNotEmpty,
-        routedLines.isNotEmpty
-            ? routedLines.last
-            : spawnLines.isNotEmpty
-            ? spawnLines.last
-            : 'neither "$_emptyFanOutMarker" nor "$_spawnMarker" was logged — '
-                  'the location sent into the empty fan-out reached nothing, '
-                  'which is #371',
-      );
-
       final summary = StringBuffer()
         ..writeln(allPass ? '✅ PASS' : '❌ FAIL')
         ..writeln()
         ..writeln(results.join('\n'))
+        ..writeln()
+        ..writeln('— Lifecycle log, first run of this process only —')
+        ..writeln(
+          routedLines.isNotEmpty || spawnLines.isNotEmpty
+              ? [...routedLines, ...spawnLines].join('\n')
+              : 'Nothing new. Expected from the second Run onwards: the '
+                    '"$_emptyFanOutMarker" line is written when routing '
+                    'switches to headless, not per event, and "$_spawnMarker" '
+                    'only while no headless engine exists yet. Both already '
+                    'happened on the first run. Restart the app to see them '
+                    'again.',
+        )
         ..writeln()
         ..writeln('— Armed —')
         ..writeln(

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -80,6 +80,7 @@ import 'package:tracelet_example/issues/issue_364_card.dart';
 import 'package:tracelet_example/issues/issue_366_card.dart';
 import 'package:tracelet_example/issues/issue_367_card.dart';
 import 'package:tracelet_example/issues/issue_368_card.dart';
+import 'package:tracelet_example/issues/issue_371_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1745,6 +1746,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                     // own title/description/keywords via IssueSearchScope, so they
                     // are rendered directly. Cards with a bespoke layout (no shell)
                     // stay wrapped in _searchableCard with explicit keywords.
+                    const Issue371Card(),
                     const Issue368Card(),
                     const Issue367Card(),
                     const Issue366Card(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:tracelet/tracelet.dart' as tl;
 import 'package:tracelet_doctor/tracelet_doctor.dart';
 import 'package:tracelet_example/behavior_page.dart';
 import 'package:tracelet_example/demo_config.dart';
+import 'package:tracelet_example/foreign_fcm_engine.dart';
 import 'package:tracelet_example/geofence_notifier.dart';
 import 'package:tracelet_example/provider_options_page.dart';
 import 'package:tracelet_example/map_page.dart';
@@ -138,6 +139,12 @@ void main() {
     // engine isn't running.
     tl.Tracelet.registerHeadlessHeadersCallback(headlessHeadersCallback);
     tl.Tracelet.registerHeadlessSyncBodyBuilder(headlessSyncBodyBuilder);
+    // #371: bring the foreign firebase_messaging engine back when a previous
+    // session armed it, the way an app that calls onBackgroundMessage() in
+    // main() has it from every launch. Without this the engine would be gone
+    // after the swipe-kill the repro is about, and the manual half of
+    // issue_371_card.dart would silently test the passing branch.
+    unawaited(ForeignFcmEngine.restoreIfArmed());
   }
 
   runApp(const TraceletApp());

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,6 +25,14 @@ dependencies:
   tracelet_doctor:
     path: ../packages/tracelet_doctor
   cupertino_icons: ^1.0.8
+  # #364/#371 — the foreign background FlutterEngine, from the plugin that
+  # actually creates one in the field. firebase_messaging's
+  # FlutterFirebaseMessagingBackgroundService builds an engine in the app
+  # process, plugin auto-registration attaches Tracelet to it, and it outlives
+  # the UI engine on task removal. issue_371_card.dart drives the real service
+  # rather than a look-alike engine, because the failure is conditional on that
+  # engine still being attached when the app is swiped away.
+  firebase_messaging: ^16.0.0
   # Terminated-state geofence testing (#355): a crossing that fires while
   # the app is killed has no UI to land in, so the notification IS the
   # observation. Posted from the headless isolate.

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/EventDispatcher.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/EventDispatcher.kt
@@ -56,6 +56,16 @@ class EventDispatcher : TraceletEventSender {
         eventApi = null
     }
 
+    /**
+     * Whether this dispatcher has a Flutter engine to post events to.
+     *
+     * The same condition every `send*` branches on, named so [MultiEventSender]
+     * can ask the question before broadcasting: when no member can receive, the
+     * event must go to the headless task instead of into an empty `forEach`
+     * (#371).
+     */
+    internal val canReceive: Boolean get() = eventApi != null
+
     // ---------------------------------------------------------------------------
     // TraceletEventSender implementation
     // ---------------------------------------------------------------------------

--- a/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
+++ b/packages/tracelet_android/android/src/main/kotlin/com/ikolvi/tracelet/flutter/TraceletAndroidPlugin.kt
@@ -18,45 +18,125 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Broadcasts events to multiple EventDispatchers.
+ *
+ * The fan-out can legitimately end up with **no member able to receive** — most
+ * often after task removal, when the primary engine detaches while another
+ * plugin's background engine keeps the process alive (#371). Every dispatcher
+ * has its own [EventDispatcher.headlessFallback] for the engine-is-gone case,
+ * but those are members of the list: once the list is empty there is nothing
+ * left to fall back *from*, and `forEach` on an empty list is a silent no-op.
+ * So the composite carries a fallback of its own — see [headlessFallback].
  */
 class MultiEventSender : com.ikolvi.tracelet.sdk.TraceletEventSender {
     private val dispatchers = CopyOnWriteArrayList<EventDispatcher>()
 
+    /**
+     * Where an event goes when no member of the fan-out can receive it (#371).
+     *
+     * Wired by the primary plugin instance to the same `HeadlessTaskService`
+     * the per-dispatcher fallbacks use, so the surviving process keeps a
+     * headless-capable receiver after the UI engine dies. Null before any
+     * primary attach — in that state the members keep their old behaviour of
+     * each falling back on their own.
+     */
+    @Volatile
+    var headlessFallback: ((eventName: String, data: Map<String, Any?>) -> Unit)? = null
+
+    /**
+     * Whether events are currently being routed to the headless task because
+     * the fan-out cannot receive them. Only used to log the *transitions*: the
+     * events themselves arrive every few seconds, and this whole class of bug
+     * is invisible precisely because the empty-fan-out path logged nothing.
+     */
+    private val routingToHeadless = AtomicBoolean(false)
+
     fun add(dispatcher: EventDispatcher) = dispatchers.addIfAbsent(dispatcher)
     fun remove(dispatcher: EventDispatcher) = dispatchers.remove(dispatcher)
-    
-    // Fallback getter - uses first available dispatcher for hasListener checks
-    private val first: EventDispatcher? get() = dispatchers.firstOrNull()
 
-    override fun sendLocation(data: Map<String, Any?>) { dispatchers.forEach { it.sendLocation(data) } }
-    override fun sendMotionChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendMotionChange(data) } }
-    override fun sendSpeedMotionChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendSpeedMotionChange(data) } }
-    override fun sendActivityChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendActivityChange(data) } }
-    override fun sendProviderChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendProviderChange(data) } }
-    override fun sendGeofence(data: Map<String, Any?>) { dispatchers.forEach { it.sendGeofence(data) } }
-    override fun sendGeofencesChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendGeofencesChange(data) } }
-    override fun sendHeartbeat(data: Map<String, Any?>) { dispatchers.forEach { it.sendHeartbeat(data) } }
-    override fun sendHttp(data: Map<String, Any?>) { dispatchers.forEach { it.sendHttp(data) } }
-    override fun sendSchedule(data: Map<String, Any?>) { dispatchers.forEach { it.sendSchedule(data) } }
-    override fun sendPowerSaveChange(isPowerSaveMode: Boolean) { dispatchers.forEach { it.sendPowerSaveChange(isPowerSaveMode) } }
-    override fun sendConnectivityChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendConnectivityChange(data) } }
-    override fun sendEnabledChange(enabled: Boolean) { dispatchers.forEach { it.sendEnabledChange(enabled) } }
-    override fun sendNotificationAction(action: String) { dispatchers.forEach { it.sendNotificationAction(action) } }
-    override fun sendAuthorization(data: Map<String, Any?>) { dispatchers.forEach { it.sendAuthorization(data) } }
-    override fun sendWatchPosition(data: Map<String, Any?>) { dispatchers.forEach { it.sendWatchPosition(data) } }
-    
-    override fun sendRemoteConfigEvent(data: Map<String, Any?>) { dispatchers.forEach { it.sendRemoteConfigEvent(data) } }
-    override fun sendTrip(data: Map<String, Any?>) { dispatchers.forEach { it.sendTrip(data) } }
-    override fun sendBudgetAdjustment(data: Map<String, Any?>) { dispatchers.forEach { it.sendBudgetAdjustment(data) } }
-    override fun sendDrivingEvent(data: Map<String, Any?>) { dispatchers.forEach { it.sendDrivingEvent(data) } }
-    override fun sendImpact(data: Map<String, Any?>) { dispatchers.forEach { it.sendImpact(data) } }
-    override fun sendModeChange(data: Map<String, Any?>) { dispatchers.forEach { it.sendModeChange(data) } }
-    override fun sendCrashModelStatus(data: Map<String, Any?>) { dispatchers.forEach { it.sendCrashModelStatus(data) } }
+    /**
+     * Sends one event, to the engines that can receive it or — when none can —
+     * to the headless task (#371).
+     *
+     * [send] is the per-dispatcher call; [eventName] and [data] are what the
+     * headless task needs, and are the same names `EventDispatcher.fallback`
+     * uses so the headless side sees one vocabulary.
+     */
+    private inline fun fanOut(
+        eventName: String,
+        data: Map<String, Any?>,
+        send: (EventDispatcher) -> Unit,
+    ) {
+        val members = dispatchers
+        if (members.any { it.canReceive }) {
+            if (routingToHeadless.compareAndSet(true, false)) {
+                TraceletLog.lifecycle(
+                    "engines: a Flutter engine can receive events again — " +
+                        "headless routing stopped (#371)",
+                )
+            }
+            members.forEach(send)
+            return
+        }
+
+        val fallback = headlessFallback
+        if (fallback == null) {
+            // No primary has attached in this process yet, so there is no
+            // HeadlessTaskService to route to. Let the members fall back
+            // individually, exactly as before.
+            if (members.isEmpty()) {
+                if (routingToHeadless.compareAndSet(false, true)) {
+                    TraceletLog.lifecycle(
+                        "engines: '$eventName' dispatched into an empty fan-out with " +
+                            "no headless fallback wired — delivery is being lost (#371)",
+                    )
+                }
+            }
+            members.forEach(send)
+            return
+        }
+
+        if (routingToHeadless.compareAndSet(false, true)) {
+            TraceletLog.lifecycle(
+                "engines: no attached engine can receive events (fan-out " +
+                    "size=${members.size}) — routing to the headless task (#371)",
+            )
+        }
+        fallback(eventName, data)
+    }
+
+    override fun sendLocation(data: Map<String, Any?>) = fanOut("location", data) { it.sendLocation(data) }
+    override fun sendMotionChange(data: Map<String, Any?>) = fanOut("motionchange", data) { it.sendMotionChange(data) }
+    override fun sendSpeedMotionChange(data: Map<String, Any?>) = fanOut("speedmotionchange", data) { it.sendSpeedMotionChange(data) }
+    override fun sendActivityChange(data: Map<String, Any?>) = fanOut("activitychange", data) { it.sendActivityChange(data) }
+    override fun sendProviderChange(data: Map<String, Any?>) = fanOut("providerchange", data) { it.sendProviderChange(data) }
+    override fun sendGeofence(data: Map<String, Any?>) = fanOut("geofence", data) { it.sendGeofence(data) }
+    override fun sendGeofencesChange(data: Map<String, Any?>) = fanOut("geofenceschange", data) { it.sendGeofencesChange(data) }
+    override fun sendHeartbeat(data: Map<String, Any?>) = fanOut("heartbeat", data) { it.sendHeartbeat(data) }
+    override fun sendHttp(data: Map<String, Any?>) = fanOut("http", data) { it.sendHttp(data) }
+    override fun sendSchedule(data: Map<String, Any?>) = fanOut("schedule", data) { it.sendSchedule(data) }
+    override fun sendPowerSaveChange(isPowerSaveMode: Boolean) =
+        fanOut("powersavechange", mapOf("value" to isPowerSaveMode)) { it.sendPowerSaveChange(isPowerSaveMode) }
+    override fun sendConnectivityChange(data: Map<String, Any?>) = fanOut("connectivitychange", data) { it.sendConnectivityChange(data) }
+    override fun sendEnabledChange(enabled: Boolean) =
+        fanOut("enabledchange", mapOf("value" to enabled)) { it.sendEnabledChange(enabled) }
+    override fun sendNotificationAction(action: String) =
+        fanOut("notificationaction", mapOf("value" to action)) { it.sendNotificationAction(action) }
+    override fun sendAuthorization(data: Map<String, Any?>) = fanOut("authorization", data) { it.sendAuthorization(data) }
+    override fun sendWatchPosition(data: Map<String, Any?>) = fanOut("watchposition", data) { it.sendWatchPosition(data) }
+
+    override fun sendRemoteConfigEvent(data: Map<String, Any?>) = fanOut("remoteconfig", data) { it.sendRemoteConfigEvent(data) }
+    override fun sendTrip(data: Map<String, Any?>) = fanOut("trip", data) { it.sendTrip(data) }
+    override fun sendBudgetAdjustment(data: Map<String, Any?>) = fanOut("budgetadjustment", data) { it.sendBudgetAdjustment(data) }
+    override fun sendDrivingEvent(data: Map<String, Any?>) = fanOut("drivingevent", data) { it.sendDrivingEvent(data) }
+    override fun sendImpact(data: Map<String, Any?>) = fanOut("impact", data) { it.sendImpact(data) }
+    override fun sendModeChange(data: Map<String, Any?>) = fanOut("modechange", data) { it.sendModeChange(data) }
+    override fun sendCrashModelStatus(data: Map<String, Any?>) = fanOut("crashmodelstatus", data) { it.sendCrashModelStatus(data) }
 
     override fun hasListener(eventName: String): Boolean = dispatchers.any { it.hasListener(eventName) }
 }
@@ -174,6 +254,18 @@ class TraceletAndroidPlugin :
             sdk.dartSyncInterceptor = this
 
             eventDispatcher.headlessFallback = { eventName, eventData ->
+                dispatchToHeadless(hs, eventName, eventData)
+            }
+
+            // The same route, one level up (#371). The per-dispatcher fallback
+            // above can only fire while this dispatcher is *in* the fan-out, and
+            // on task removal it is the first thing removed — leaving a composite
+            // with no members, whose `forEach` drops every event in silence when
+            // another plugin's background engine keeps the process alive. Wiring
+            // the composite to the same HeadlessTaskService instance matters:
+            // that object owns the spawn-in-flight guard and the pending-event
+            // queue, so both routes feed one engine rather than racing two.
+            globalEventSender.headlessFallback = { eventName, eventData ->
                 dispatchToHeadless(hs, eventName, eventData)
             }
 

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/MultiEventSenderFallbackTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/MultiEventSenderFallbackTest.kt
@@ -1,0 +1,156 @@
+package com.ikolvi.tracelet.flutter
+
+import io.flutter.plugin.common.BinaryMessenger
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * #371 — an event dispatched into a fan-out that cannot receive it must reach
+ * the headless task, not vanish.
+ *
+ * The state this pins is the one a swipe-kill leaves behind when another
+ * plugin's background engine keeps the process alive: #364 correctly holds that
+ * foreign engine out of [MultiEventSender], and `onDetachedFromEngine` then
+ * removes the primary's own dispatcher — so the composite is **empty**. Every
+ * `send*` was `dispatchers.forEach { … }`, a silent no-op on an empty list, and
+ * `headlessFallback` lived on [EventDispatcher], i.e. on the members that were
+ * no longer there. Native tracking kept running; Dart got nothing, with not
+ * even a log line to say so.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+internal class MultiEventSenderFallbackTest {
+
+    private fun location(uuid: String): Map<String, Any?> = mapOf(
+        "uuid" to uuid,
+        "coords" to mapOf("latitude" to 1.0, "longitude" to 2.0),
+    )
+
+    /** A dispatcher with a live Pigeon `eventApi`, i.e. an attached engine. */
+    private fun attachedDispatcher(): EventDispatcher = EventDispatcher().apply {
+        register(mock(BinaryMessenger::class.java))
+    }
+
+    @Test
+    fun emptyFanOut_routesToTheHeadlessTask() {
+        val routed = mutableListOf<Pair<String, Map<String, Any?>>>()
+        val sender = MultiEventSender()
+        sender.headlessFallback = { name, data -> routed.add(name to data) }
+
+        // The post-task-removal state: primary detached, foreign engine alive
+        // but (correctly, #364) never a member.
+        sender.sendLocation(location("after-swipe"))
+
+        assertEquals(1, routed.size, "an empty fan-out must fall back to the headless task")
+        assertEquals("location", routed.single().first)
+        assertEquals("after-swipe", routed.single().second["uuid"])
+    }
+
+    @Test
+    fun everyEventKind_reachesTheHeadlessTaskFromAnEmptyFanOut() {
+        val routed = mutableListOf<String>()
+        val sender = MultiEventSender()
+        sender.headlessFallback = { name, _ -> routed.add(name) }
+
+        sender.sendLocation(location("l"))
+        sender.sendMotionChange(location("m"))
+        sender.sendGeofence(mapOf("geofence" to mapOf("identifier" to "home")))
+        sender.sendHeartbeat(mapOf("location" to location("h")))
+        sender.sendGeofencesChange(mapOf("on" to emptyList<Any?>()))
+        sender.sendActivityChange(mapOf("activity" to "still"))
+        sender.sendProviderChange(mapOf("enabled" to true))
+        sender.sendEnabledChange(false)
+        sender.sendPowerSaveChange(true)
+
+        assertEquals(
+            listOf(
+                "location",
+                "motionchange",
+                "geofence",
+                "heartbeat",
+                "geofenceschange",
+                "activitychange",
+                "providerchange",
+                "enabledchange",
+                "powersavechange",
+            ),
+            routed,
+            "no event kind may be left without a route when the fan-out is empty",
+        )
+    }
+
+    /**
+     * The guard against over-correcting: while a real engine is attached, the
+     * event belongs to it and must NOT also be delivered to the headless task —
+     * that would run the app's background callback for every foreground fix.
+     */
+    @Test
+    fun liveFanOut_doesNotRouteToTheHeadlessTask() {
+        var routed = 0
+        val sender = MultiEventSender()
+        sender.headlessFallback = { _, _ -> routed++ }
+        sender.add(attachedDispatcher())
+
+        sender.sendLocation(location("foreground"))
+
+        assertEquals(0, routed, "an attached engine already received this event")
+    }
+
+    /**
+     * A member whose engine went away (`unregister()`, so `eventApi == null`)
+     * cannot receive either. It has its own fallback for that, but when the
+     * composite carries one the routing decision is taken once, at the top —
+     * otherwise N dead members would each dispatch the same event to the
+     * headless task.
+     */
+    @Test
+    fun membersThatCannotReceive_routeOnceNotPerMember() {
+        var routed = 0
+        val sender = MultiEventSender()
+        sender.headlessFallback = { _, _ -> routed++ }
+        repeat(3) { sender.add(EventDispatcher().apply { headlessFallback = { _, _ -> routed++ } }) }
+
+        sender.sendLocation(location("dead-engines"))
+
+        assertEquals(1, routed, "one event must produce one headless dispatch")
+    }
+
+    /**
+     * Before any primary attach there is no HeadlessTaskService to route to, so
+     * the members keep their previous behaviour rather than the event being
+     * dropped on a null composite fallback.
+     */
+    @Test
+    fun withoutACompositeFallback_membersStillFallBackThemselves() {
+        val routed = mutableListOf<String>()
+        val sender = MultiEventSender()
+        sender.add(EventDispatcher().apply { headlessFallback = { name, _ -> routed.add(name) } })
+
+        sender.sendLocation(location("no-composite-fallback"))
+
+        assertEquals(listOf("location"), routed)
+    }
+
+    @Test
+    fun removingTheLastMember_restoresHeadlessRouting() {
+        var routed = 0
+        val sender = MultiEventSender()
+        sender.headlessFallback = { _, _ -> routed++ }
+        val primary = attachedDispatcher()
+        sender.add(primary)
+
+        sender.sendLocation(location("before-detach"))
+        assertEquals(0, routed)
+
+        // Task removal: onDetachedFromEngine removes the primary's dispatcher.
+        sender.remove(primary)
+        sender.sendLocation(location("after-detach"))
+
+        assertTrue(routed == 1, "the same sender must switch to headless once emptied")
+    }
+}

--- a/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/PluginSecondaryEngineGuardTest.kt
+++ b/packages/tracelet_android/android/src/test/kotlin/com/ikolvi/tracelet/flutter/PluginSecondaryEngineGuardTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 /**
  * Tests that the primary-instance guard in [TraceletAndroidPlugin] prevents
@@ -210,6 +211,37 @@ internal class PluginSecondaryEngineGuardTest {
             0,
             globalDispatcherCount(),
             "the surviving foreign engine must not be left holding the fan-out",
+        )
+    }
+
+    /**
+     * #371, the other half of the state above: an empty fan-out is only safe if
+     * something still routes to the headless task.
+     *
+     * `sdk.setEventSender(globalEventSender)` happens once, at primary attach,
+     * and survives task removal — so after the primary detaches every event the
+     * still-running native tracking produces is dispatched into this composite.
+     * With the members gone, the per-dispatcher `headlessFallback` went with
+     * them; the composite needs its own, wired here and outliving the detach.
+     */
+    @Test
+    fun primaryDetachWithASurvivingEngine_leavesAHeadlessRouteOnTheFanOut() {
+        val primaryPlugin = TraceletAndroidPlugin()
+        val primaryBinding = createMockBinding("primary")
+        primaryPlugin.onAttachedToEngine(primaryBinding)
+        assertNotNull(
+            globalFanOutFallback(),
+            "the primary must wire the fan-out's headless fallback at attach",
+        )
+
+        TraceletAndroidPlugin().onAttachedToEngine(createMockBinding("fcm"))
+        primaryPlugin.onDetachedFromEngine(primaryBinding)
+
+        assertEquals(0, globalDispatcherCount())
+        assertNotNull(
+            globalFanOutFallback(),
+            "with the fan-out empty and the SDK still holding it as the event " +
+                "sender, losing this route means events reach nothing at all",
         )
     }
 
@@ -434,6 +466,24 @@ internal class PluginSecondaryEngineGuardTest {
      */
     private fun resetGlobalEventSender() {
         globalDispatchers().clear()
+        val sender = globalEventSenderInstance()
+        val fallback = sender.javaClass.getDeclaredField("headlessFallback")
+        fallback.isAccessible = true
+        fallback.set(sender, null)
+    }
+
+    /** The fan-out's own headless fallback, or null when none is wired (#371). */
+    private fun globalFanOutFallback(): Any? {
+        val sender = globalEventSenderInstance()
+        val field = sender.javaClass.getDeclaredField("headlessFallback")
+        field.isAccessible = true
+        return field.get(sender)
+    }
+
+    private fun globalEventSenderInstance(): Any {
+        val senderField = TraceletAndroidPlugin::class.java.getDeclaredField("globalEventSender")
+        senderField.isAccessible = true
+        return senderField.get(null)
     }
 
     private fun globalDispatchers(): MutableList<*> {


### PR DESCRIPTION
Fixes #371

## The bug

After #365 (for #364) the foreign firebase_messaging engine no longer joins the
event fan-out — correctly. But `onDetachedFromEngine` then removes the primary's
own dispatcher, and with the foreign engine keeping the process alive the SDK is
left holding a `MultiEventSender` with **no members at all**:

```kotlin
override fun sendLocation(data: Map<String, Any?>) { dispatchers.forEach { … } }  // empty list → no-op
```

`headlessFallback` was a property of `EventDispatcher`, i.e. of the members that
had just left, so there was nothing to fall back *from*. Same user-visible
symptom as #364 — native tracking runs forever, Dart gets nothing after task
removal — and this time not even a log line, because the empty-fan-out path
logged nothing at all.

## The fix

`MultiEventSender` now takes the routing decision itself
(`TraceletAndroidPlugin.kt`):

- it carries its own `headlessFallback`, wired by the primary instance to the
  **same** `HeadlessTaskService` instance the per-dispatcher fallbacks use (that
  object owns the spawn-in-flight guard and the pending-event queue, so both
  routes feed one engine rather than racing two);
- every `send*` goes through `fanOut(eventName, data) { … }`: if any member can
  receive (`EventDispatcher.canReceive`, the same `eventApi != null` each `send*`
  already branched on) it broadcasts as before; otherwise it routes once to the
  headless task — which also de-duplicates the case where several members have a
  dead `eventApi`;
- the transitions are logged on the always-on lifecycle channel
  (`no attached engine can receive events … routing to the headless task (#371)`
  and its inverse), because this class of bug is invisible precisely while that
  path stays silent.

With no fallback wired (no primary has ever attached in the process) the members
keep their previous per-dispatcher behaviour, so nothing changes before
`onAttachedToEngine`.

## Reproduction, with the plugin that actually causes it

#364's card creates a look-alike engine and destroys it, which is right for #364
but cannot show this: the failure needs a foreign engine that is **still
attached** when the app is swiped away. So the example app now drives
firebase_messaging itself.

- `example/lib/foreign_fcm_engine.dart` — `FirebaseMessaging.onBackgroundMessage()`
  makes the native side call `FlutterFirebaseMessagingBackgroundService
  .startBackgroundIsolate()`, which builds the real second `FlutterEngine`; the
  service holds it for the rest of the process. No Firebase project config is
  involved (the registration runs through a stub platform instance), so there is
  no `google-services.json`, no `Firebase.initializeApp()` and no network in the
  path. Arming is sticky across launches, which is what makes the swipe-kill run
  repeatable; the card has a Disarm button.
- `example/lib/issues/issue_371_card.dart` — arms it, checks the real engine
  attaches and stays out of the fan-out (#364, now with the actual plugin), then
  empties the fan-out exactly as task removal does, sends one location through
  the SDK's own event sender, and checks it reached the headless task. Manual
  only: Execute All must not leave a second engine attached behind a sweep.
- `example/integration_test/issue_371_test.dart` — the same sequence on-device
  without the UI: `flutter test integration_test/issue_371_test.dart -d <device>`.

## Tests

- `MultiEventSenderFallbackTest` (new): empty fan-out routes to the headless
  task, for every event kind; a live member does not; dead members route once,
  not per member; without a composite fallback the members still fall back
  themselves.
- `PluginSecondaryEngineGuardTest`: adds
  `primaryDetachWithASurvivingEngine_leavesAHeadlessRouteOnTheFanOut`, the
  wiring half — the fan-out's route must outlive the primary's detach.

## Also

`example/ios/Podfile` moves to `platform :ios, '15.0'` — required by
firebase_messaging's podspec, and already the Runner project's
`IPHONEOS_DEPLOYMENT_TARGET`. `tracelet_ios` keeps its own 14.0 minimum; this is
the example app only.

## Verified on-device (red → green)

Same device (LAVA LXX503, API 34), same everything, only the two Kotlin files
reverted for the red run:

```
# without the fix
00:01 +0: the real firebase_messaging engine stays out of the fan-out
00:03 +1: an emptied fan-out still reaches the headless task
  Expected: true  Actual: <false>
  the location sent into the empty fan-out reached nothing at all — this is #371

# with the fix
00:05 +2: All tests passed!
```

logcat on the green run, matching the reporter's sequence:

```
FLTFireBGExecutor: Creating background FlutterEngine instance, with args: [--enable-dart-profiling]
Tracelet: engines: secondary attach — UI (engineCount=2); events delivered to it once its Dart side subscribes
FLTFireMsgService: FlutterFirebaseMessagingBackgroundService started!
Tracelet: engines: no attached engine can receive events (fan-out size=0) — routing to the headless task (#371)
Tracelet: headless: spawning a FlutterEngine (1 event(s) queued)
Tracelet: engines: secondary attach — headless (engineCount=3); events routed to the headless task
```

Re-verified after the follow-up commit, with the two Kotlin files checked out
from `main` for the red run and back to HEAD for the green one.

Kotlin unit tests: `PluginSecondaryEngineGuardTest` 12/12, `MultiEventSenderFallbackTest` 6/6.
`melos format` and `melos analyze` clean.

## Follow-up: the card reported a false failure on a second Run

Both log lines the card asserted on are once-per-process — the `#371` line marks
the *transition* into headless routing (logging per event would flood the
always-on channel every few seconds) and `headless: spawning a FlutterEngine`
only appears while no headless engine exists. The first Run latched one and
created the other, so a second, correctly-routed probe found neither.

The probe now wraps `MultiEventSender.headlessFallback` for the duration of the
send and reports whether it was invoked — the mechanism itself, identical on
every run. The log lines remain in the card as context, with a note explaining
why they appear once. `issue_371_test.dart` runs the probe twice to pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
