### PR TITLE
fix(android): stop pause-only visibility from defeating stopOnTerminate (#378)

### DIFF
--- a/example/lib/issues/issue_378_card.dart
+++ b/example/lib/issues/issue_378_card.dart
@@ -1,0 +1,451 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+
+/// Issue #378 — `showNotificationOnPauseOnly: true` silently defeats
+/// `stopOnTerminate: false` on Android.
+///
+/// Pause-only visibility is implemented by *demoting* the service:
+/// `updateNotificationVisibility` calls `stopForeground(STOP_FOREGROUND_REMOVE)`
+/// while the app is on screen (`LocationService.kt:1784-1790`) and calls
+/// `startForeground` again when `ProcessLifecycleOwner` reports the app
+/// backgrounded (`:1791-1797`). Between those two points the process is running
+/// a *plain* started service, not a foreground one.
+///
+/// That gap is what the report is about. On task removal `ActivityManager`
+/// decides whether to kill the hosting process from `proc.foregroundServices`,
+/// and it decides while holding its own lock — before the `onTaskRemoved`
+/// callback has run on the app's main thread. So a swipe from recents inside
+/// the gap kills the process, and `stopOnTerminate: false` buys nothing: no
+/// headless engine, no events, no `onDetachedFromEngine`, no logs. The reporter
+/// measured 0.7 s and 1.5 s gaps on an API 35 device and got one kill out of
+/// three swipes.
+///
+/// The existing mitigation in `onTaskRemoved` (`:823-828`) forces the
+/// notification on when the task is removed. It is not sufficient, and this
+/// card exists partly to show why: it runs after the kill decision.
+///
+/// **What each row is read from**, tagged in the output the way #376's card
+/// tags its own evidence:
+///
+/// * `[Dart mirror]` — the configured combination, from
+///   [Tracelet.activeConfig]. It says what this app asked for, not what native
+///   stored; the `[native log]` rows below are what confirm native agrees.
+/// * `[native log]` — lines written by Kotlin and read back through
+///   [Tracelet.getLogs]: `Suppressing notification (App in foreground)`,
+///   `Showing notification (App in background)`, and the always-on lifecycle
+///   channel (`service: sticky restart after process death`,
+///   `boot-tracking: bootstrapping`).
+/// * `[native State]` — `lastForegroundTransitionAt` out of
+///   [Tracelet.getForegroundServiceHealth], which `recordPromotion` stamps on
+///   every successful `startForeground`. That epoch-ms value is what makes the
+///   window *measurable* rather than merely visible: the log table stores
+///   `datetime('now')`, one-second resolution, and the window is shorter than
+///   that.
+///
+/// **How the window is measured.** The card observes its own
+/// `AppLifecycleState.paused` — the moment the UI leaves the screen, which is
+/// the moment the app becomes swipeable in recents — and on resume reads the
+/// last promotion stamp. `promotionAt - uiLeftAt` is the interval during which
+/// a swipe would have found no foreground service. It is captured in the
+/// lifecycle callback rather than on the Run tap because re-entering the app
+/// re-demotes the service, and any intent that reaches the service afterwards
+/// would re-stamp the value.
+///
+/// **What it cannot do.** No foreground card can swipe itself out of recents,
+/// so the kill row is only measured when the operator actually performs the
+/// swipe inside the window. Its absence is reported as NOT MEASURED, never as a
+/// pass. The window row, by contrast, needs nothing but a Home press and is the
+/// reproduction proper: a non-zero window *is* the bug, whether or not a swipe
+/// happened to land in it.
+///
+/// Android only — iOS has no foreground service and no task-removal kill.
+class Issue378Card extends StatefulWidget {
+  const Issue378Card({super.key});
+
+  @override
+  State<Issue378Card> createState() => _Issue378CardState();
+}
+
+class _Issue378CardState extends State<Issue378Card>
+    with IssueCardRun<Issue378Card>, WidgetsBindingObserver {
+  @override
+  IssueRunner? get cardRunner => _run;
+
+  /// Written by this card, so the verify phase can tell this run's trail from
+  /// everything the app logged before it. The arm phase clears the log first;
+  /// this is the belt to that braces, and it survives a killed process because
+  /// the log table is on disk.
+  static const _armedMarker = 'issue378: armed at ';
+
+  /// Stamped when the UI leaves the screen — the instant the app becomes
+  /// swipeable. The durable copy of [_uiLeftAtMs].
+  static const _uiLeftMarker = 'issue378: ui left the screen at ';
+
+  /// `updateNotificationVisibility` demoting the service while the app is
+  /// visible. Its presence proves the process is running without a foreground
+  /// service — the precondition for the reported kill.
+  static const _suppressedMarker =
+      'Suppressing notification (App in foreground)';
+
+  /// The re-promotion on the background transition. Present in the trail, it
+  /// corroborates the measured window; the exact instant comes from
+  /// `lastForegroundTransitionAt`, not from this line's timestamp.
+  static const _shownMarker = 'Showing notification (App in background)';
+
+  /// Lifecycle channel, always persisted. `onStartCommand` writes it when the
+  /// system restarts the START_STICKY service with a null intent — which only
+  /// happens after the process died.
+  static const _stickyRestartMarker = 'sticky restart after process death';
+
+  /// The surviving path: `onTaskRemoved` ran, background permission was there,
+  /// and tracking continued natively.
+  static const _taskRemovalMarker = 'continuing tracking after task removal';
+
+  /// #318's killed-state anchor — the background pipeline actually came up.
+  static const _bootstrapMarker = 'boot-tracking: bootstrapping';
+
+  /// A service instance being constructed. After a kill the restarted process
+  /// writes this again, which is the second death signature.
+  static const _serviceCreatedMarker = 'service: onCreate';
+
+  // Static rather than instance state: the Issues page is a virtualized
+  // ListView, so this card's State is routinely disposed while the app is in
+  // the background — exactly the interval being measured.
+  static int? _uiLeftAtMs;
+  static int? _promotionAtResumeMs;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+    if (state == AppLifecycleState.paused) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      _uiLeftAtMs = now;
+      _promotionAtResumeMs = null;
+      unawaited(_logQuietly('$_uiLeftMarker$now'));
+    } else if (state == AppLifecycleState.resumed) {
+      unawaited(_captureResumeStamp());
+    }
+  }
+
+  Future<void> _logQuietly(String message) async {
+    try {
+      await Tracelet.log('info', message);
+    } catch (_) {
+      // A card must never crash the app it is diagnosing. The measurement
+      // falls back to the in-memory stamp.
+    }
+  }
+
+  /// Reads the promotion stamp the instant the app comes back, before the Run
+  /// tap can disturb it.
+  Future<void> _captureResumeStamp() async {
+    try {
+      final health = await Tracelet.getForegroundServiceHealth();
+      final at = health['lastForegroundTransitionAt'];
+      _promotionAtResumeMs = at is num ? at.toInt() : null;
+    } catch (_) {
+      _promotionAtResumeMs = null;
+    }
+  }
+
+  Future<void> _run() async {
+    setRunning(running: true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    void note(String name, String detail) =>
+        results.add('➖ NOT MEASURED $name — $detail');
+
+    try {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+        setStatus(
+          'ℹ️ Not applicable on this platform. #378 is the Android '
+          'foreground-service demotion that pause-only visibility performs; '
+          'iOS has no foreground service and no task-removal process kill.',
+        );
+        return;
+      }
+
+      final logs = await Tracelet.getLogs(800);
+      final ordered = [...logs]..sort((a, b) => a.id.compareTo(b.id));
+      final armedAtId = _lastIdContaining(ordered, _armedMarker);
+
+      if (armedAtId == null) {
+        await _arm(results, check);
+        return;
+      }
+
+      // ── Verify phase ──────────────────────────────────────────────────────
+      final trail = ordered.where((e) => e.id > armedAtId).toList();
+      final config = Tracelet.activeConfig;
+      final pauseOnly =
+          config.android.foregroundService.showNotificationOnPauseOnly;
+      final stopOnTerminate = config.app.stopOnTerminate;
+
+      check(
+        '[Dart mirror] the reported combination is in force',
+        pauseOnly && !stopOnTerminate,
+        pauseOnly && !stopOnTerminate
+            ? 'showNotificationOnPauseOnly=true with stopOnTerminate=false — '
+                  'the app has asked for a hidden notification AND for tracking '
+                  'to outlive task removal'
+            : 'this run is NOT the reported combination '
+                  '(showNotificationOnPauseOnly=$pauseOnly, '
+                  'stopOnTerminate=$stopOnTerminate), so the rows below do not '
+                  'describe #378. The demo baseline sets both; something '
+                  'reconfigured the SDK after prepareIssueRun().',
+      );
+
+      final suppressed = trail.where(
+        (e) => e.message.contains(_suppressedMarker),
+      );
+      check(
+        '[native log] the service stays promoted while the app is on screen',
+        suppressed.isEmpty,
+        suppressed.isEmpty
+            ? 'no "$_suppressedMarker" entry since arming — the foreground '
+                  'service was never demoted, so there is no interval in which '
+                  'task removal can kill the process'
+            : 'REPRODUCED — ${suppressed.length} demotion(s) since arming, the '
+                  'first at ${suppressed.first.timestamp}. '
+                  'stopForeground(STOP_FOREGROUND_REMOVE) ran while the app was '
+                  'visible, so from that point the process holds no foreground '
+                  'service and ActivityManager will kill it on task removal.',
+      );
+
+      final uiLeftAt =
+          _uiLeftAtMs ?? _lastStampFromMarker(ordered, _uiLeftMarker);
+      final promotedAt = _promotionAtResumeMs;
+      final reShown = trail.any((e) => e.message.contains(_shownMarker));
+
+      if (uiLeftAt == null) {
+        note(
+          '[native State] the kill window',
+          'the app has not been backgrounded since arming. Press Home, count '
+              'to three, reopen, and press Run again — that round trip is what '
+              'measures the window.',
+        );
+      } else if (promotedAt == null) {
+        note(
+          '[native State] the kill window',
+          'no promotion stamp was captured on resume '
+              '(lastForegroundTransitionAt was null). Either the service never '
+              'promoted at all — check the foreground-service rows on the '
+              '#255 card — or the app was reopened while this card was '
+              'scrolled off screen. Keep the card visible across the round '
+              'trip and repeat.',
+        );
+      } else {
+        final windowMs = promotedAt - uiLeftAt;
+        check(
+          '[native State] no window between the UI leaving and the service '
+          'being promoted',
+          windowMs <= 0,
+          windowMs <= 0
+              ? 'the last promotion (${_hms(promotedAt)}) predates the UI '
+                    'leaving the screen (${_hms(uiLeftAt)}) — the foreground '
+                    'service was already up throughout, so a swipe at any '
+                    'instant finds one'
+              : 'REPRODUCED — ${windowMs}ms with no foreground service. The UI '
+                    'left the screen at ${_hms(uiLeftAt)} and startForeground '
+                    'did not succeed until ${_hms(promotedAt)}'
+                    '${reShown ? ' ("$_shownMarker" is in the trail)' : ''}. '
+                    'A swipe from recents inside those ${windowMs}ms is what '
+                    "killed the reporter's process; the reporter measured "
+                    '700ms and 1500ms.',
+        );
+      }
+
+      final died = trail.any((e) => e.message.contains(_stickyRestartMarker));
+      final survived = trail.any(
+        (e) =>
+            e.message.contains(_taskRemovalMarker) ||
+            e.message.contains(_bootstrapMarker),
+      );
+      final recreatedAfterBackground = _sawAfterMarker(
+        trail,
+        marker: _uiLeftMarker,
+        needle: _serviceCreatedMarker,
+      );
+
+      if (!died && !survived && !recreatedAfterBackground) {
+        note(
+          '[native log] the process survives a swipe inside the window',
+          'no task removal in this trail. To test the kill itself: press Run '
+              'to re-arm, press Recents, and swipe the app away immediately — '
+              'inside the window measured above — then reopen and press Run.',
+        );
+      } else {
+        check(
+          '[native log] the process survives a swipe inside the window',
+          survived && !died,
+          survived && !died
+              ? 'onTaskRemoved ran and tracking continued natively '
+                    '(task-removal and/or boot-tracking entries are in the '
+                    'trail, with no sticky restart) — stopOnTerminate: false '
+                    'did what it promises'
+              : 'REPRODUCED — the process was killed on task removal. '
+                    '${died ? 'The system restarted the START_STICKY service '
+                              'with a null intent ("$_stickyRestartMarker"), which '
+                              'only happens after the hosting process died. ' : ''}'
+                    '${recreatedAfterBackground && !died ? 'A fresh '
+                              '"$_serviceCreatedMarker" appears after the app was '
+                              'backgrounded, with no task-removal handling before '
+                              'it — a new process, not a survivor. ' : ''}'
+                    'Nothing ran onTaskRemoved to completion, so the headless '
+                    'engine never attached and the events of that run are gone.',
+        );
+      }
+
+      final header = allPass
+          ? '✅ SUCCESS: pause-only visibility no longer opens a window in '
+                'which task removal kills the process.'
+          : '❌ #378 REPRODUCED — see the failing rows below.';
+
+      setStatus(
+        '$header\n\n${results.join('\n')}\n\n'
+        'Scope: the window row is a real measurement of this device and this '
+        "run — Dart's pause callback against the native promotion stamp. It "
+        'is a lower bound on the exposure: the process also has no foreground '
+        'service for however long it takes ActivityManager to notice, which is '
+        'not observable from here. The kill row is only ever as good as the '
+        'swipe you performed; a green kill row after a slow swipe proves '
+        'nothing about a fast one, which is why the window row is the one that '
+        'matters.\n\n'
+        'Press Run again to re-arm and repeat.',
+      );
+    } catch (e) {
+      setStatus('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      setRunning(running: false);
+    }
+  }
+
+  /// Clears the trail, starts tracking, and marks the log so the verify phase
+  /// reads only what this run produced.
+  Future<void> _arm(
+    List<String> results,
+    void Function(String, bool, String) check,
+  ) async {
+    final auth = await Tracelet.getLocationAuthorization();
+    check(
+      'background location is granted',
+      auth == AuthorizationStatus.always,
+      auth == AuthorizationStatus.always
+          ? 'ACCESS_BACKGROUND_LOCATION is granted, so onTaskRemoved will take '
+                'the continue-tracking branch rather than standing the service '
+                'down'
+          : 'authorization is $auth. onTaskRemoved stops tracking outright '
+                'without "always" (LocationService.kt:776-788), so a kill row '
+                'measured now would be that guard, not #378. Grant background '
+                'location before arming.',
+    );
+
+    _uiLeftAtMs = null;
+    _promotionAtResumeMs = null;
+
+    await Tracelet.clearLogs();
+    await _logQuietly('$_armedMarker${DateTime.now().millisecondsSinceEpoch}');
+    await Tracelet.start();
+
+    setStatus(
+      'ARMED — the log was cleared, tracking is running, and the demo baseline '
+      'has the reported combination (stopOnTerminate: false, '
+      'showNotificationOnPauseOnly: true).\n\n'
+      '${results.join('\n')}\n\n'
+      'To measure the window (no kill, repeatable):\n'
+      '1. Keep this card on screen and press Home.\n'
+      '2. Count to three.\n'
+      '3. Reopen the app and press Run.\n\n'
+      'To reproduce the kill itself:\n'
+      '1. Press Recents.\n'
+      '2. Swipe this app away IMMEDIATELY — the window is under two seconds.\n'
+      '3. Reopen the app and press Run.\n'
+      "Swipe slowly and it will survive; that is the reporter's whole point, "
+      'so a survival here is only meaningful next to the measured window.\n\n'
+      'Do not force-stop the app — that kills the process by a different route '
+      'and tells you nothing about this bug.',
+    );
+  }
+
+  /// Id of the newest entry containing [needle], or null.
+  int? _lastIdContaining(List<LogEntry> ordered, String needle) {
+    for (var i = ordered.length - 1; i >= 0; i--) {
+      if (ordered[i].message.contains(needle)) return ordered[i].id;
+    }
+    return null;
+  }
+
+  /// The epoch-ms this card embedded in the newest [marker] entry — the durable
+  /// copy of a stamp lost when the card's State was recycled.
+  int? _lastStampFromMarker(List<LogEntry> ordered, String marker) {
+    for (var i = ordered.length - 1; i >= 0; i--) {
+      final message = ordered[i].message;
+      final at = message.indexOf(marker);
+      if (at < 0) continue;
+      return int.tryParse(message.substring(at + marker.length).trim());
+    }
+    return null;
+  }
+
+  /// Whether [needle] appears after the newest [marker] entry.
+  bool _sawAfterMarker(
+    List<LogEntry> trail, {
+    required String marker,
+    required String needle,
+  }) {
+    final markerId = _lastIdContaining(trail, marker);
+    if (markerId == null) return false;
+    return trail.any((e) => e.id > markerId && e.message.contains(needle));
+  }
+
+  String _hms(int epochMs) {
+    final t = DateTime.fromMillisecondsSinceEpoch(epochMs).toLocal();
+    final h = t.hour.toString().padLeft(2, '0');
+    final m = t.minute.toString().padLeft(2, '0');
+    final s = t.second.toString().padLeft(2, '0');
+    final ms = t.millisecond.toString().padLeft(3, '0');
+    return '$h:$m:$s.$ms';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'showNotificationOnPauseOnly stopOnTerminate task removal swipe '
+          'recents killed process foreground service demoted stopForeground '
+          'notification gap window headless 378',
+      title: '#378: pause-only notification defeats stopOnTerminate: false',
+      description:
+          'Hiding the notification while the app is open demotes the '
+          'foreground service, so a swipe from recents before it is re-posted '
+          'kills the process. Measures the window in milliseconds, and '
+          'classifies a swipe you perform inside it as survived or killed.',
+      status: status,
+      running: running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/issue_378_card.dart
+++ b/example/lib/issues/issue_378_card.dart
@@ -11,9 +11,9 @@ import 'package:tracelet_example/issues/issue_card_state.dart';
 ///
 /// Pause-only visibility is implemented by *demoting* the service:
 /// `updateNotificationVisibility` calls `stopForeground(STOP_FOREGROUND_REMOVE)`
-/// while the app is on screen (`LocationService.kt:1784-1790`) and calls
+/// while the app is on screen (`LocationService.kt:1870-1880`) and calls
 /// `startForeground` again when `ProcessLifecycleOwner` reports the app
-/// backgrounded (`:1791-1797`). Between those two points the process is running
+/// backgrounded (`:1881-1887`). Between those two points the process is running
 /// a *plain* started service, not a foreground one.
 ///
 /// That gap is what the report is about. On task removal `ActivityManager`
@@ -25,9 +25,17 @@ import 'package:tracelet_example/issues/issue_card_state.dart';
 /// measured 0.7 s and 1.5 s gaps on an API 35 device and got one kill out of
 /// three swipes.
 ///
-/// The existing mitigation in `onTaskRemoved` (`:823-828`) forces the
-/// notification on when the task is removed. It is not sufficient, and this
-/// card exists partly to show why: it runs after the kill decision.
+/// The mitigation that was already in `onTaskRemoved` forces the notification
+/// on when the task is removed. It cannot work, and this card exists partly to
+/// show why: it runs after the kill decision.
+///
+/// **The fix** is `pauseOnlyVisibilityAllowed` (`LocationService.kt:1842`):
+/// while `stopOnTerminate` is false the service is never demoted, so no window
+/// exists to swipe into, and the refusal is announced once per `start()` on the
+/// always-on lifecycle channel. `stopOnTerminate: true` keeps the feature
+/// unchanged — nothing is promised past the swipe there. The card scores the
+/// announcement too: a fix that traded a silent kill for a silent override
+/// would have solved only half of what was reported.
 ///
 /// **What each row is read from**, tagged in the output the way #376's card
 /// tags its own evidence:
@@ -91,6 +99,12 @@ class _Issue378CardState extends State<Issue378Card>
   /// service — the precondition for the reported kill.
   static const _suppressedMarker =
       'Suppressing notification (App in foreground)';
+
+  /// The fix announcing itself on the always-on lifecycle channel: pause-only
+  /// visibility refused because `stopOnTerminate` is false. Written once per
+  /// explicit `start()`, so it is in the trail of any armed run.
+  static const _overrideMarker =
+      'showNotificationOnPauseOnly ignored because stopOnTerminate=false';
 
   /// The re-promotion on the background transition. Present in the trail, it
   /// corroborates the measured window; the exact instant comes from
@@ -217,6 +231,31 @@ class _Issue378CardState extends State<Issue378Card>
                   'describe #378. The demo baseline sets both; something '
                   'reconfigured the SDK after prepareIssueRun().',
       );
+
+      if (!pauseOnly || stopOnTerminate) {
+        note(
+          '[native log] the override announces itself',
+          'only meaningful for the reported combination, which this run is not',
+        );
+      } else {
+        final announced = trail.where(
+          (e) => e.message.contains(_overrideMarker),
+        );
+        check(
+          '[native log] the override announces itself',
+          announced.isNotEmpty,
+          announced.isNotEmpty
+              ? 'the lifecycle channel carries "${announced.first.message}" — '
+                    'a developer who wonders why the notification is visible '
+                    'has the answer in the log, at every log level, including '
+                    'from a killed-state run'
+              : 'nothing in the trail explains the notification. Either the '
+                    'override is not applied at all (see the rows below) or it '
+                    'is applied silently, which is the half of #378 that made '
+                    'it cost the reporter a debugging session rather than a '
+                    'config change.',
+        );
+      }
 
       final suppressed = trail.where(
         (e) => e.message.contains(_suppressedMarker),
@@ -368,6 +407,13 @@ class _Issue378CardState extends State<Issue378Card>
 
     await Tracelet.clearLogs();
     await _logQuietly('$_armedMarker${DateTime.now().millisecondsSinceEpoch}');
+
+    // stop() before start() on purpose: `start()` while tracking is already
+    // live returns before it ever reaches the service ("start ignored — already
+    // tracking continuously"), so the arm phase would produce no ACTION_START,
+    // no fresh service instance, and none of the entries the verify phase reads.
+    await Tracelet.stop();
+    await Future<void>.delayed(const Duration(milliseconds: 600));
     await Tracelet.start();
 
     setStatus(

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -82,6 +82,7 @@ import 'package:tracelet_example/issues/issue_367_card.dart';
 import 'package:tracelet_example/issues/issue_368_card.dart';
 import 'package:tracelet_example/issues/issue_371_card.dart';
 import 'package:tracelet_example/issues/issue_376_card.dart';
+import 'package:tracelet_example/issues/issue_378_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1747,6 +1748,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                     // own title/description/keywords via IssueSearchScope, so they
                     // are rendered directly. Cards with a bespoke layout (no shell)
                     // stay wrapped in _searchableCard with explicit keywords.
+                    const Issue378Card(),
                     const Issue376Card(),
                     const Issue371Card(),
                     const Issue368Card(),

--- a/packages/tracelet/doc/motion-and-notifications.md
+++ b/packages/tracelet/doc/motion-and-notifications.md
@@ -84,7 +84,9 @@ Android 14 introduced strict constraints regarding when Foreground Services (FGS
 The **Smart Foreground Notification Visibility** feature allows you to only show the persistent notification when the app enters the background or when a specific state is reached, while seamlessly keeping the FGS alive.
 
 ### How It Works
-If `showNotificationOnPauseOnly` is enabled, the SDK starts the Foreground Service but hides the notification while the user is actively using the app. It only reveals the notification when the app goes into the background or when tracking demands it. 
+If `showNotificationOnPauseOnly` is enabled, the SDK starts the Foreground Service and then hides the notification while the user is actively using the app, revealing it again when the app goes into the background.
+
+Hiding it means **demoting the service**: Android has no such thing as a foreground service without a notification, so `stopForeground()` is what takes it down. The service keeps running and tracking is unaffected — but while it is demoted the process holds no foreground service, which is the state Android kills when the user swipes the app out of recents. See the constraint below.
 
 ### Common Scenarios & Setup Examples
 
@@ -106,6 +108,24 @@ final config = TlConfig(
 ```
 
 > **Warning**: Disabling `showNotificationOnPauseOnly` (setting it to `false`) means the notification is always visible while tracking is enabled. On Android 14+, attempting to start an FGS without immediate notification visibility from a background state may result in exceptions if not handled properly by this smart logic.
+
+### Constraint: it is ignored under `stopOnTerminate: false` (#378)
+
+The two settings ask for incompatible things, and the survival promise wins.
+
+While the notification is hidden the process holds no foreground service, and `ActivityManager` chooses which processes to kill on task removal from exactly that fact — before the SDK's `onTaskRemoved` handler runs, so nothing the SDK does at removal time can undo it. A swipe from recents in the few hundred milliseconds between the app leaving the screen and the notification coming back therefore killed the process outright: no headless task, no events, no logs, nothing that `stopOnTerminate: false` exists to guarantee. The window was measured at 285 ms on a Pixel Fold and 700–1500 ms on the reporting user's Android 15 device.
+
+So when `stopOnTerminate: false` is set, `showNotificationOnPauseOnly` is not applied and the notification stays visible. It is not silent — the SDK writes one line to the always-on lifecycle log channel, readable via `Tracelet.getLogs()`:
+
+```text
+notification: showNotificationOnPauseOnly ignored because stopOnTerminate=false — …
+```
+
+`Tracelet.getForegroundServiceHealth()` reports the same thing from the other side: when the notification *is* legitimately hidden (`stopOnTerminate: true`), `serviceForeground` is `false` and `lastForegroundPromotionResult` is `suppressed` — a demotion you asked for, distinct from a promotion the OS refused.
+
+To keep the hidden notification, set `stopOnTerminate: true` and accept that tracking ends with the swipe. On Android 14+ a location foreground service must show its notification anyway once the app is not on screen, so what you gain is limited to the period the app is open.
+
+This is Android-only. iOS has no foreground service, no notification to hide and no task-removal kill of this kind; `showNotificationOnPauseOnly` lives on `AndroidConfig` and is not read by the iOS SDK.
 
 ---
 

--- a/packages/tracelet/lib/src/models/android_config.dart
+++ b/packages/tracelet/lib/src/models/android_config.dart
@@ -558,6 +558,17 @@ class ForegroundServiceConfig {
   /// When `true`, the persistent notification is automatically dismissed when the app
   /// enters the foreground and restored when it enters the background.
   ///
+  /// **Ignored while `AppConfig.stopOnTerminate` is `false` (#378.)** Hiding the
+  /// notification means demoting the foreground service — Android has no
+  /// foreground service without one — and a process holding no foreground
+  /// service is killed when its task is removed. Swiping the app away in the
+  /// few hundred milliseconds between the app leaving the screen and the
+  /// notification being re-posted therefore killed the process outright,
+  /// silently costing you everything `stopOnTerminate: false` promises. The
+  /// promise wins: the notification stays up, and the SDK says so once on the
+  /// lifecycle log channel. Set `stopOnTerminate: true` if you would rather
+  /// have the hidden notification.
+  ///
   /// Defaults to `false`.
   bool get showNotificationOnPauseOnly => _showNotificationOnPauseOnly ?? false;
 

--- a/packages/tracelet/lib/src/tracelet.dart
+++ b/packages/tracelet/lib/src/tracelet.dart
@@ -1644,12 +1644,17 @@ class Tracelet {
   /// - `serviceForeground` (`bool`): whether it is currently promoted to the
   ///   foreground.
   /// - `foregroundNotificationId` (`int?`): the notification id while promoted.
-  /// - `lastForegroundPromotionResult` (`String?`): `success`, `deferred`, or
-  ///   `failed` (null before any attempt).
+  /// - `lastForegroundPromotionResult` (`String?`): `success`, `deferred`,
+  ///   `failed`, or `suppressed` (null before any attempt). `suppressed` means
+  ///   the notification is hidden on purpose while the app is on screen
+  ///   (`showNotificationOnPauseOnly`) — tracking is running and the service is
+  ///   alive, unlike `deferred` and `failed`.
   /// - `lastForegroundPromotionFailureClass` (`String?`): exception class of
   ///   the last failed/deferred promotion.
   /// - `lastForegroundPromotionFailureMessage` (`String?`): its message.
-  /// - `lastForegroundTransitionAt` (`int?`): epoch-ms of the last transition.
+  /// - `lastForegroundTransitionAt` (`int?`): epoch-ms of the last *transition*
+  ///   — a promotion that changed the state, not a re-post of a notification
+  ///   the service already held (#378).
   /// - `platform` (`String`): `android` or `ios`.
   ///
   /// On iOS the promotion fields are null/`false` — iOS has no foreground

--- a/packages/tracelet_doctor/lib/src/widgets/foreground_service_card.dart
+++ b/packages/tracelet_doctor/lib/src/widgets/foreground_service_card.dart
@@ -11,7 +11,7 @@ import 'package:tracelet_doctor/src/widgets/common.dart';
 /// actually operational. This card renders the map returned by
 /// `Tracelet.getForegroundServiceHealth()`, surfacing whether the service is
 /// running and promoted, and the last promotion result (`success` / `deferred`
-/// / `failed`) with its failure class and message.
+/// / `failed` / `suppressed`) with its failure class and message.
 ///
 /// On iOS and web there is no foreground service; the card reflects that.
 class ForegroundServiceCard extends StatelessWidget {
@@ -42,6 +42,13 @@ class ForegroundServiceCard extends StatelessWidget {
     }
     if (_serviceForeground) {
       return (label: 'Healthy', color: DoctorTheme.success);
+    }
+    // Hidden on purpose: `showNotificationOnPauseOnly` demotes the service
+    // while the app is on screen (#378). Tracking is running and the service
+    // is alive — this is not the OS refusing a promotion, and colouring it as
+    // a failure would be crying wolf at a configured behaviour.
+    if (_result == 'suppressed') {
+      return (label: 'Suppressed', color: DoctorTheme.accent);
     }
     if (_result == 'deferred') {
       return (label: 'Deferred', color: DoctorTheme.warning);
@@ -117,7 +124,14 @@ class ForegroundServiceCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(
-                  _result == 'deferred'
+                  _result == 'suppressed'
+                      ? 'Notification hidden while the app is on screen '
+                            '(showNotificationOnPauseOnly). Tracking continues; '
+                            'the service is promoted again when the app '
+                            'backgrounds. Ignored under stopOnTerminate: false, '
+                            'where the gap would let a swipe from recents kill '
+                            'the process (#378).'
+                      : _result == 'deferred'
                       ? 'Promotion deferred — Android will retry when the app '
                             'returns to the foreground.'
                       : _result == 'failed'

--- a/packages/tracelet_doctor/test/foreground_service_card_suppressed_test.dart
+++ b/packages/tracelet_doctor/test/foreground_service_card_suppressed_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tracelet_doctor/src/doctor_theme.dart';
+import 'package:tracelet_doctor/src/widgets/foreground_service_card.dart';
+
+/// Pins how [ForegroundServiceCard] reports a service that is deliberately
+/// demoted (#378).
+///
+/// `showNotificationOnPauseOnly` hides the notification by demoting the
+/// service, so `serviceForeground` is legitimately false while the app is on
+/// screen. Read off that boolean alone it is indistinguishable from a promotion
+/// the OS refused — and the card used to say "Tracking requested but the
+/// foreground service is not confirmed yet", which is a false alarm about a
+/// configured behaviour. `lastForegroundPromotionResult: suppressed` is what
+/// separates the two.
+void main() {
+  Map<String, Object?> health({
+    required bool serviceForeground,
+    String? result,
+  }) => <String, Object?>{
+    'desiredEnabled': true,
+    'foregroundServiceEnabled': true,
+    'serviceRunning': true,
+    'serviceForeground': serviceForeground,
+    'foregroundNotificationId': serviceForeground ? 7701 : null,
+    'lastForegroundPromotionResult': result,
+    'lastForegroundPromotionFailureClass': null,
+    'lastForegroundPromotionFailureMessage': null,
+    'lastForegroundTransitionAt': 1_760_000_000_000,
+    'platform': 'android',
+  };
+
+  Future<void> pump(WidgetTester tester, Map<String, Object?> map) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          backgroundColor: DoctorTheme.sheetBackground,
+          body: SingleChildScrollView(
+            child: ForegroundServiceCard(health: map),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color? chipColor(WidgetTester tester, String label) =>
+      tester.widget<Text>(find.text(label.toUpperCase())).style?.color;
+
+  group('ForegroundServiceCard', () {
+    testWidgets('a suppressed notification is not reported as a failure', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        health(serviceForeground: false, result: 'suppressed'),
+      );
+
+      expect(chipColor(tester, 'Suppressed'), DoctorTheme.accent);
+      expect(
+        find.textContaining('showNotificationOnPauseOnly'),
+        findsOneWidget,
+        reason: 'the reader has to be told why the notification is gone',
+      );
+      expect(
+        find.textContaining('not confirmed yet'),
+        findsNothing,
+        reason: 'nothing is pending — the demotion was asked for',
+      );
+    });
+
+    testWidgets('a demotion still explains that it is refused under '
+        'stopOnTerminate: false', (tester) async {
+      await pump(
+        tester,
+        health(serviceForeground: false, result: 'suppressed'),
+      );
+
+      expect(find.textContaining('#378'), findsOneWidget);
+    });
+
+    testWidgets('an unexplained missing promotion is still a warning', (
+      tester,
+    ) async {
+      await pump(tester, health(serviceForeground: false));
+
+      expect(chipColor(tester, 'Pending'), DoctorTheme.warning);
+      expect(find.textContaining('not confirmed yet'), findsOneWidget);
+    });
+
+    testWidgets('a failed promotion is still an error', (tester) async {
+      await pump(tester, health(serviceForeground: false, result: 'failed'));
+
+      expect(chipColor(tester, 'Failed'), DoctorTheme.error);
+      expect(
+        find.textContaining('NOT operational'),
+        findsOneWidget,
+        reason: 'the suppressed branch must not swallow a real failure',
+      );
+    });
+  });
+}

--- a/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
+++ b/packages/tracelet_platform_interface/lib/src/tracelet_platform.dart
@@ -522,10 +522,12 @@ abstract class TraceletPlatform extends PlatformInterface {
   /// - `serviceForeground` (`bool`)
   /// - `foregroundNotificationId` (`int?`)
   /// - `lastForegroundPromotionResult` (`String?`): `success` | `deferred` |
-  ///   `failed`
+  ///   `failed` | `suppressed` (hidden on purpose by
+  ///   `showNotificationOnPauseOnly`, tracking unaffected — #378)
   /// - `lastForegroundPromotionFailureClass` (`String?`)
   /// - `lastForegroundPromotionFailureMessage` (`String?`)
-  /// - `lastForegroundTransitionAt` (`int?`): epoch-ms
+  /// - `lastForegroundTransitionAt` (`int?`): epoch-ms of a state *transition*,
+  ///   not of every `startForeground` call (#378)
   /// - `platform` (`String`)
   ///
   /// On iOS the promotion fields are null/false (no foreground service exists),

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -2938,12 +2938,17 @@ class TraceletSdk private constructor(private val context: Context) {
      *   foreground (last `startForeground()` succeeded and not since demoted).
      * - `foregroundNotificationId` (Long?): the notification id while promoted.
      * - `lastForegroundPromotionResult` (String?): `success` | `deferred` |
-     *   `failed` (null before any attempt).
+     *   `failed` | `suppressed` (null before any attempt). `suppressed` is a
+     *   deliberate demotion by `showNotificationOnPauseOnly` while the app is
+     *   on screen — the service is alive and tracking, unlike `deferred` and
+     *   `failed` (#378).
      * - `lastForegroundPromotionFailureClass` (String?): exception class of the
      *   last failed/deferred promotion.
      * - `lastForegroundPromotionFailureMessage` (String?): its message.
      * - `lastForegroundTransitionAt` (Long?): epoch-ms of the last promotion
-     *   transition.
+     *   transition — a change of state, not every `startForeground` call, so
+     *   the interval a process spent without a foreground service is
+     *   measurable from it (#378).
      * - `platform` (String): `android`.
      */
     /**

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/service/LocationService.kt
@@ -160,11 +160,41 @@ class LocationService : Service(), DefaultLifecycleObserver {
             failureClass: String? = null,
             failureMessage: String? = null,
         ) {
+            // #378: stamp genuine transitions only. startForeground() is also
+            // called to re-post a notification the service already holds — a
+            // config change, or the background transition in persistent mode —
+            // and counting those as transitions made
+            // lastForegroundTransitionAt useless for the one question it can
+            // answer: how long the process spent with no foreground service,
+            // which is what decides whether a task removal kills it.
+            val transitioned = promoted != foregroundPromoted || result != lastPromotionResult
             lastPromotionResult = result
             foregroundPromoted = promoted
             lastPromotionFailureClass = failureClass
             lastPromotionFailureMessage = failureMessage
-            lastPromotionTimestampMs = System.currentTimeMillis()
+            if (transitioned) lastPromotionTimestampMs = System.currentTimeMillis()
+        }
+
+        /**
+         * Records a *deliberate* demotion — pause-only visibility taking the
+         * notification down while the app is on screen (#378).
+         *
+         * Without this the health snapshot kept reporting `serviceForeground =
+         * true` from the last successful promotion, so the API whose entire
+         * purpose is to say whether background tracking is operational claimed
+         * a foreground service precisely during the window where there was
+         * none. `suppressed` is a fourth `lastForegroundPromotionResult` value
+         * alongside `success`, `deferred` and `failed`, and it separates
+         * "hidden on purpose, still tracking" from "the OS refused" — which
+         * look identical on the boolean alone.
+         */
+        private fun recordDemotion() {
+            val transitioned = foregroundPromoted || lastPromotionResult != "suppressed"
+            lastPromotionResult = "suppressed"
+            foregroundPromoted = false
+            lastPromotionFailureClass = null
+            lastPromotionFailureMessage = null
+            if (transitioned) lastPromotionTimestampMs = System.currentTimeMillis()
         }
 
         /**
@@ -581,6 +611,9 @@ class LocationService : Service(), DefaultLifecycleObserver {
 
     private var isForegroundService = false
     private var lastInForeground: Boolean? = null
+
+    /** One override notice per start, not per transition — see [pauseOnlyVisibilityAllowed] (#378). */
+    private var pauseOnlyOverrideLogged = false
     private var wakeLock: PowerManager.WakeLock? = null
 
     // Renews the OEM-safe wakelock before its auto-expiry timeout so continuous
@@ -686,6 +719,14 @@ class LocationService : Service(), DefaultLifecycleObserver {
         // We set isRunning true immediately so updateNotificationVisibility() works on the first call.
         if (intent?.action == ACTION_START || intent?.action == null) {
             isRunning = true
+            // #378: re-announce the pause-only override once per explicit start
+            // (and per sticky restart), rather than once per service instance.
+            // A service that has been alive since before the config changed
+            // would otherwise never say why the notification is visible, and
+            // that line is the whole difference between this override and the
+            // silent failure it replaces. Bounded by how often an app starts
+            // tracking, not by how often it is backgrounded.
+            pauseOnlyOverrideLogged = false
         }
 
         if (!isForegroundService) {
@@ -821,9 +862,14 @@ class LocationService : Service(), DefaultLifecycleObserver {
             }
 
             // The UI is gone — for foreground-service tracking modes the
-            // persistent notification must now be visible (with
-            // showNotificationOnPauseOnly it was suppressed while the app was
-            // open). Force it on before the process is torn down.
+            // persistent notification must now be visible. Since #378 this is
+            // a backstop, not the guarantee: pause-only visibility no longer
+            // demotes the service while stopOnTerminate is false, so there is
+            // normally nothing to restore here. It cannot be the guarantee,
+            // because ActivityManager has already chosen which processes to
+            // kill by the time this callback runs — see
+            // [pauseOnlyVisibilityAllowed]. It still matters for a service that
+            // was demoted for some other reason before the task was removed.
             lastInForeground = false
             updateNotificationVisibility(forcedForeground = false)
 
@@ -1770,9 +1816,48 @@ class LocationService : Service(), DefaultLifecycleObserver {
         nm.notify(NOTIFICATION_ID, buildNotification())
     }
 
+    /**
+     * Whether `showNotificationOnPauseOnly` may take the notification down
+     * while the app is on screen (#378).
+     *
+     * Hiding it is implemented by *demoting* the service — there is no such
+     * thing as a foreground service without a notification — and a process
+     * whose services are all demoted is one `ActivityManager` kills on task
+     * removal. It picks the processes to kill from `proc.foregroundServices`
+     * under its own lock, **before** [onTaskRemoved] is dispatched to the app's
+     * main thread, so forcing the notification back on there cannot win that
+     * race: the decision is already made. A swipe from recents inside that
+     * window — measured at 285ms on a Pixel Fold and 700-1500ms on the
+     * reporter's API 35 device — therefore killed the process outright, taking
+     * the headless engine, the queued events and the logs with it.
+     *
+     * `stopOnTerminate = false` is a promise that tracking outlives task
+     * removal, and it outranks a cosmetic preference: pause-only visibility is
+     * refused while it is set, once and out loud on the always-on lifecycle
+     * channel, because the failure it replaces was silent. With
+     * `stopOnTerminate = true` nothing is promised past the swipe and the
+     * suppression is honored exactly as before.
+     */
+    private fun pauseOnlyVisibilityAllowed(): Boolean {
+        if (!configManager.getShowNotificationOnPauseOnly()) return false
+        if (configManager.getStopOnTerminate()) return true
+        if (!pauseOnlyOverrideLogged) {
+            pauseOnlyOverrideLogged = true
+            TraceletLog.lifecycle(
+                "notification: showNotificationOnPauseOnly ignored because " +
+                    "stopOnTerminate=false — hiding the notification demotes the " +
+                    "foreground service, and a swipe from recents in that window " +
+                    "kills the process (#378). Set stopOnTerminate=true to hide it " +
+                    "while the app is open, or showNotificationOnPauseOnly=false " +
+                    "to stop asking."
+            )
+        }
+        return false
+    }
+
     private fun updateNotificationVisibility(forcedForeground: Boolean? = null) {
         if (!isRunning) return
-        val showOnPauseOnly = configManager.getShowNotificationOnPauseOnly()
+        val showOnPauseOnly = pauseOnlyVisibilityAllowed()
         // Lifecycle callbacks pass the real UI state; isAppInForeground() is only
         // a fallback for the onStartCommand / boot path where no authoritative
         // signal is available.
@@ -1787,6 +1872,10 @@ class LocationService : Service(), DefaultLifecycleObserver {
                     TraceletLog.debug("Suppressing notification (App in foreground)")
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     isForegroundService = false
+                    // #378: the health snapshot must say the service is no
+                    // longer promoted — this is the state in which a task
+                    // removal is fatal, and it used to report the opposite.
+                    recordDemotion()
                 }
             } else {
                 // Show in background if not already shown OR if we just transitioned.

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/service/LocationServicePauseOnlySurvivalTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/service/LocationServicePauseOnlySurvivalTest.kt
@@ -1,0 +1,214 @@
+package com.ikolvi.tracelet.sdk.service
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.test.core.app.ApplicationProvider
+import com.ikolvi.tracelet.sdk.ConfigManager
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for GitHub issue #378:
+ *   "showNotificationOnPauseOnly: true silently defeats stopOnTerminate: false"
+ *
+ * Pause-only visibility hides the notification by demoting the service, and a
+ * demoted service is not a foreground service — so `ActivityManager` kills the
+ * hosting process on task removal. It chooses which processes to kill from
+ * `proc.foregroundServices` while holding its own lock, before `onTaskRemoved`
+ * reaches the app's main thread, so the forced promotion there cannot rescue
+ * it. Everything `stopOnTerminate = false` promises was lost to a swipe timed
+ * inside that window: no headless engine, no events, no logs.
+ *
+ * These tests pin the resolution: the promise wins over the preference. With
+ * `stopOnTerminate = false` the service is never demoted; with
+ * `stopOnTerminate = true` — where nothing is promised past the swipe —
+ * pause-only visibility works exactly as it did.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class LocationServicePauseOnlySurvivalTest {
+
+    private lateinit var context: Context
+    private var controller: ServiceController<LocationService>? = null
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        ConfigManager.getInstance(context).reset(null)
+    }
+
+    @After
+    fun tearDown() {
+        try {
+            controller?.destroy()
+        } catch (_: Throwable) {
+        }
+        controller = null
+        ConfigManager.getInstance(context).reset(null)
+    }
+
+    /** The reported configuration, minus the field under test. */
+    private fun configure(stopOnTerminate: Boolean, pauseOnly: Boolean) {
+        ConfigManager.getInstance(context).setConfig(
+            mapOf(
+                "app" to mapOf("stopOnTerminate" to stopOnTerminate),
+                "android" to mapOf(
+                    "foregroundService" to mapOf(
+                        "enabled" to true,
+                        "channelId" to "tl_test_channel",
+                        "showNotificationOnPauseOnly" to pauseOnly,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    private fun startService(): LocationService {
+        val intent = Intent().apply { action = LocationService.ACTION_START }
+        val c = Robolectric.buildService(LocationService::class.java)
+        controller = c
+        return c.create().withIntent(intent).startCommand(0, 1).get()
+    }
+
+    /**
+     * The authoritative foreground/background signal. The service observes
+     * `ProcessLifecycleOwner` and passes the real UI state to
+     * `updateNotificationVisibility`, rather than depending on the
+     * process-importance heuristic its own foreground service skews.
+     */
+    private fun appOnScreen(service: LocationService) =
+        (service as DefaultLifecycleObserver).onStart(ProcessLifecycleOwner.get())
+
+    private fun appBackgrounded(service: LocationService) =
+        (service as DefaultLifecycleObserver).onStop(ProcessLifecycleOwner.get())
+
+    /**
+     * The fix. This is the exact state the report was filed from, and the whole
+     * bug is one `stopForeground` call away.
+     */
+    @Test
+    fun `pause-only never demotes the service while stopOnTerminate is false`() {
+        configure(stopOnTerminate = false, pauseOnly = true)
+        val service = startService()
+
+        appOnScreen(service)
+
+        val shadow = shadowOf(service)
+        assertFalse(
+            shadow.isForegroundStopped,
+            "stopForeground() must not run while stopOnTerminate=false: a process " +
+                "with no foreground service is one ActivityManager kills on task " +
+                "removal, and it decides that before onTaskRemoved can post the " +
+                "notification back (#378)",
+        )
+        assertNotNull(
+            shadow.lastForegroundNotification,
+            "the notification must still be attached — it is what keeps the " +
+                "process alive across a swipe from recents",
+        )
+        assertEquals(
+            true,
+            LocationService.foregroundServiceHealth()["serviceForeground"],
+            "health must report the service as promoted, because it is",
+        )
+    }
+
+    /**
+     * The other half of the contract: an app that has not asked to outlive task
+     * removal keeps the feature it configured. Without this, the fix above
+     * would just be a removal of `showNotificationOnPauseOnly`.
+     */
+    @Test
+    fun `pause-only still hides the notification while stopOnTerminate is true`() {
+        configure(stopOnTerminate = true, pauseOnly = true)
+        val service = startService()
+
+        appOnScreen(service)
+
+        val shadow = shadowOf(service)
+        assertTrue(
+            shadow.isForegroundStopped,
+            "with stopOnTerminate=true nothing is promised past the swipe, so the " +
+                "notification is still hidden while the app is on screen",
+        )
+        assertNull(
+            shadow.lastForegroundNotification,
+            "STOP_FOREGROUND_REMOVE takes the notification down with the promotion",
+        )
+
+        val health = LocationService.foregroundServiceHealth()
+        assertEquals(
+            false,
+            health["serviceForeground"],
+            "#378: the demotion must be visible in the health snapshot — it used to " +
+                "keep reporting the last successful promotion, so the API that " +
+                "exists to say whether background tracking is operational claimed a " +
+                "foreground service during the window where there was none",
+        )
+        assertEquals(
+            "suppressed",
+            health["lastForegroundPromotionResult"],
+            "a deliberate demotion must be distinguishable from an OS refusal: " +
+                "`suppressed` still means tracking, `failed` does not",
+        )
+    }
+
+    /**
+     * `lastForegroundTransitionAt` is what makes the window measurable — the
+     * log table stores whole seconds and the window is shorter than one. It is
+     * only meaningful if a re-post of a notification the service already holds
+     * does not masquerade as a transition.
+     */
+    @Test
+    fun `the transition stamp moves on a real transition and not on a re-post`() {
+        configure(stopOnTerminate = false, pauseOnly = true)
+        val service = startService()
+        appOnScreen(service)
+
+        val afterStart = LocationService.foregroundServiceHealth()["lastForegroundTransitionAt"]
+        assertNotNull(afterStart, "the first successful promotion is a transition")
+
+        // Persistent mode re-posts on the background transition, in case the
+        // notification was dismissed while the app was open. Nothing about the
+        // service's foreground state changed.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(5))
+        appBackgrounded(service)
+
+        assertEquals(
+            afterStart,
+            LocationService.foregroundServiceHealth()["lastForegroundTransitionAt"],
+            "a re-post of an already-promoted notification is not a transition; " +
+                "counting it as one would report a fresh promotion after every " +
+                "backgrounding and hide the window it exists to measure (#378)",
+        )
+
+        // A genuine demotion is a transition, and must move the stamp.
+        ConfigManager.getInstance(context).setConfig(mapOf("app" to mapOf("stopOnTerminate" to true)))
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(5))
+        appOnScreen(service)
+
+        val afterSuppression =
+            LocationService.foregroundServiceHealth()["lastForegroundTransitionAt"] as Long
+        assertTrue(
+            afterSuppression > afterStart as Long,
+            "the demotion is a transition and must be stamped, or the window has no " +
+                "measurable start",
+        )
+    }
+}

--- a/website/app/en/api-reference/page.mdx
+++ b/website/app/en/api-reference/page.mdx
@@ -194,6 +194,7 @@ Android specific OS constraints. [See Android Story 📖](/en/getting-started/pl
 - **`notificationPriority`**: `NotificationPriority` *(Default: `NotificationPriority.defaultPriority`)*
 - **`notificationOngoing`**: `bool` *(Default: `true`)*
 - **`showNotificationOnPauseOnly`**: `bool` *(Default: `false`)*
+  Hides the notification while the app is on screen. **Ignored while `app.stopOnTerminate` is `false`** — hiding it demotes the foreground service, and a swipe from recents in that window kills the process ([#378](https://github.com/Ikolvi/Tracelet/issues/378)). The override is logged once per `start()`. [See Hiding the notification 📖](/en/getting-started/platform-setup/android#hiding-the-notification-while-the-app-is-open-shownotificationonpauseonly)
 - **`actions`**: `List<String>` *(Default: `[]`)*
 - **`notificationStartedAt`**: `int?` *(Default: `null`)*
   Epoch milliseconds (wall clock) the elapsed timer counts up from. Only rendered when `notificationShowTimer` is `true`. A value in the future is clamped to the current time each time the notification is posted, so a device clock correction self-heals. [See Elapsed timer 📖](/en/getting-started/platform-setup/android#showing-an-elapsed-timer-in-the-notification)

--- a/website/app/en/core/foreground-service-health/page.mdx
+++ b/website/app/en/core/foreground-service-health/page.mdx
@@ -61,10 +61,10 @@ Returns a `Map<String, Object?>` with the following keys:
 | `serviceRunning` | `bool` | Whether the native location service process is alive. |
 | `serviceForeground` | `bool` | Whether the service is **currently promoted** to the foreground (last `startForeground()` succeeded and it hasn't been demoted/stopped since). |
 | `foregroundNotificationId` | `int?` | The notification id while promoted; `null` otherwise. |
-| `lastForegroundPromotionResult` | `String?` | `success`, `deferred`, or `failed` — the outcome of the most recent promotion attempt (`null` before any attempt). |
+| `lastForegroundPromotionResult` | `String?` | `success`, `deferred`, `failed`, or `suppressed` — the outcome of the most recent promotion attempt (`null` before any attempt). |
 | `lastForegroundPromotionFailureClass` | `String?` | Exception class of the last failed/deferred promotion (e.g. `ForegroundServiceStartNotAllowedException`). |
 | `lastForegroundPromotionFailureMessage` | `String?` | The exception message. |
-| `lastForegroundTransitionAt` | `int?` | Epoch-milliseconds of the last promotion transition. |
+| `lastForegroundTransitionAt` | `int?` | Epoch-milliseconds of the last promotion **transition** — a change of state, not every `startForeground()` call, so the interval a process spent unpromoted is measurable from it. |
 | `platform` | `String` | `android`, `ios`, or `web`. |
 
 <Callout type="info">
@@ -85,7 +85,15 @@ whole story:
 | `true` | `true` | `success` | ✅ **Healthy** — the foreground service is running and promoted. |
 | `true` | `false` | `deferred` | ⏳ **Deferred** — Android refused the start while backgrounded; Tracelet will retry when the app returns to the foreground. |
 | `true` | `false` | `failed` | ❌ **Failed** — promotion failed; background tracking is **not** operational. Inspect the failure class/message. |
+| `true` | `false` | `suppressed` | 🙈 **Hidden on purpose** — `showNotificationOnPauseOnly` took the notification down while the app is on screen. Tracking is running and the service is alive. Only possible with `stopOnTerminate: true` ([why](/en/getting-started/platform-setup/android#hiding-the-notification-while-the-app-is-open-shownotificationonpauseonly)). |
 | `true` | `false` | `null` | ⌛ Requested but not confirmed yet (transient — poll again shortly). |
+
+<Callout type="warning">
+  Do not treat `serviceForeground: false` as a failure on its own. A `suppressed`
+  service is demoted because you configured it that way, and it is still
+  tracking — reporting it as broken is a false alarm. `deferred` and `failed`
+  are the results that mean something is wrong.
+</Callout>
 
 ---
 
@@ -106,6 +114,9 @@ Future<String> describeTrackingHealth() async {
   if (h['serviceForeground'] == true) return 'Tracking active';
 
   switch (h['lastForegroundPromotionResult']) {
+    case 'suppressed':
+      // Demoted on purpose by showNotificationOnPauseOnly. Still tracking.
+      return 'Tracking active';
     case 'deferred':
       return 'Waiting to start — reopen the app to resume background tracking';
     case 'failed':

--- a/website/app/en/getting-started/platform-setup/android/page.mdx
+++ b/website/app/en/getting-started/platform-setup/android/page.mdx
@@ -182,7 +182,7 @@ android: tl.AndroidConfig(
     channelName: 'Delivery Tracking',
     notificationText: 'Tracking your route to the customer',
     notificationOngoing: true, // User cannot swipe it away
-    showNotificationOnPauseOnly: false, // Auto-hides when app is open
+    showNotificationOnPauseOnly: false, // Always visible — see the section below
     actions: ['Pause', 'Complete'], // Adds interactive buttons to the notification
   ),
 )
@@ -271,6 +271,56 @@ This is worth setting for **any** notification whose content changes while track
 
 <Callout type="warning">
   It defaults to `false`, which preserves the behaviour of every existing app. Nothing changes until you opt in.
+</Callout>
+
+### Hiding the Notification While the App Is Open (`showNotificationOnPauseOnly`)
+
+`showNotificationOnPauseOnly: true` takes the tracking notification down while the user is actually looking at your app, and puts it back when they leave. It is a genuinely nicer experience — the notification tray stays clean while the app is on screen — but it comes with one hard constraint, and the constraint is not obvious.
+
+**Hiding the notification means demoting the service.** Android has no concept of a foreground service without a notification, so the only way to hide it is `stopForeground()`. Tracking continues and the service keeps running, but for as long as the notification is hidden your process holds **no foreground service**.
+
+That is exactly the state Android kills when the user swipes your app out of recents.
+
+<Callout type="warning">
+  **`showNotificationOnPauseOnly` is ignored while `stopOnTerminate: false`** ([#378](https://github.com/Ikolvi/Tracelet/issues/378)). The two settings ask for incompatible things and the survival promise wins: the notification stays visible.
+</Callout>
+
+#### Why it cannot be made to work
+
+When a task is removed, `ActivityManager` decides which processes to kill from `proc.foregroundServices` — and it decides **before** `onTaskRemoved` is dispatched to your app's main thread. So an SDK cannot rescue the situation by posting the notification at removal time; by then the verdict is in. Tracelet had exactly that mitigation, and it did not help.
+
+The result was a race nobody could see. Swipe the app away in the gap between it leaving the screen and the notification coming back, and the process died: no headless task, no events, no logs, none of what `stopOnTerminate: false` exists to guarantee. Swipe a second later and everything worked perfectly. The gap was measured at **285 ms** on a Pixel Fold and **700–1500 ms** on an Android 15 device.
+
+#### What Tracelet does instead
+
+| Your config | Behaviour |
+|---|---|
+| `stopOnTerminate: false` + `showNotificationOnPauseOnly: true` | The flag is **ignored**. The notification stays visible, the service is never demoted, and a swipe from recents can never kill the process. |
+| `stopOnTerminate: true` + `showNotificationOnPauseOnly: true` | Works exactly as documented — hidden while the app is on screen. Nothing is promised past the swipe here, so there is nothing to protect. |
+| `showNotificationOnPauseOnly: false` | The notification is always visible. This is the default. |
+
+The override is **not silent** — that was half of what made the original bug expensive. One line is written to the always-on lifecycle log channel per `start()`, readable with `Tracelet.getLogs()` at any log level, including from a killed-state run:
+
+```text
+notification: showNotificationOnPauseOnly ignored because stopOnTerminate=false — hiding the
+notification demotes the foreground service, and a swipe from recents in that window kills the
+process (#378). Set stopOnTerminate=true to hide it while the app is open, or
+showNotificationOnPauseOnly=false to stop asking.
+```
+
+[`getForegroundServiceHealth()`](/en/core/foreground-service-health) reports the same thing from the other side. When the notification is legitimately hidden (`stopOnTerminate: true`), `serviceForeground` is `false` and `lastForegroundPromotionResult` is `suppressed` — a demotion you asked for, which is a different thing from a promotion the OS refused.
+
+#### Choosing
+
+Decide which one you actually need:
+
+- **Tracking must survive the user swiping the app away** → keep `stopOnTerminate: false` and let the notification show. This is the right default for delivery, fleet, workforce and safety apps.
+- **A clean notification tray matters more than surviving the swipe** → set `stopOnTerminate: true`. Tracking ends when the app is removed from recents, which for many consumer apps is exactly what the user expects anyway.
+
+Note what you gain in the second case is bounded: on Android 14+ a location foreground service must show its notification once your app is off screen regardless, so the hiding only ever applies while the user is in your app.
+
+<Callout type="info">
+  This is Android-only. iOS has no foreground service, no notification to hide and no task-removal kill of this kind — `showNotificationOnPauseOnly` lives on `AndroidConfig` and the iOS SDK does not read it.
 </Callout>
 
 ### Showing an Elapsed Timer in the Notification

--- a/website/app/en/reference/faq/page.mdx
+++ b/website/app/en/reference/faq/page.mdx
@@ -240,6 +240,16 @@ Future<tl.Location?> bestPosition() async {
 
 **iOS — it depends on how the app was closed.** If iOS terminates the app for memory/system reasons, it **relaunches** it in the background on the next significant-location-change and resumes. If the **user** force-quits the app (swipe up in the app switcher), iOS deliberately suspends all of its location services until the app is opened again — Apple does not let any SDK override this.
 
+### I set `showNotificationOnPauseOnly: true` but the notification is always visible. Why?
+
+Because `stopOnTerminate` is `false`, and the two settings cannot both be honoured.
+
+Hiding the notification means demoting the foreground service — Android has no foreground service without a notification — and a process holding no foreground service is the one Android kills when the user swipes the app out of recents. So while the notification was hidden, `stopOnTerminate: false` guaranteed nothing: a swipe timed inside the gap (measured at 285 ms on a Pixel Fold, 700–1500 ms on an Android 15 device) killed the process outright, with no headless task, no events and no logs. Nothing an SDK does at task-removal time can prevent it — Android has already chosen which processes to kill before it tells your app the task was removed.
+
+Tracelet resolves it in favour of the survival promise: with `stopOnTerminate: false` the flag is ignored and the notification stays up. It logs the reason once per `start()` on the lifecycle channel, so `Tracelet.getLogs()` will show it.
+
+Set `stopOnTerminate: true` if you would rather have the hidden notification and are happy for tracking to end when the app is swiped away. [Full explanation 📖](/en/getting-started/platform-setup/android#hiding-the-notification-while-the-app-is-open-shownotificationonpauseonly)
+
 ---
 
 ## Offline & Sync


### PR DESCRIPTION
## The bug

`showNotificationOnPauseOnly: true` hides the notification by **demoting the service** — Android has no foreground service without a notification, so `stopForeground(STOP_FOREGROUND_REMOVE)` is what takes it down. While the app is on screen the process therefore holds no foreground service, and that is the state `ActivityManager` kills on task removal.

The mitigation already in `onTaskRemoved` — force the notification on when the task is removed — cannot fix it. AMS picks the processes to kill from `proc.foregroundServices` while holding its own lock, **before** `onTaskRemoved` is dispatched to the app's main thread. The decision is made before our code runs. A swipe from recents inside the window killed the process outright: no headless engine, no events, no `onDetachedFromEngine`, no logs. Everything `stopOnTerminate: false` promises, gone, silently.

## Reproduced before it was fixed

The verification card (first commit) was written against the unfixed SDK and measured the window on a Pixel Fold:

```
❌ [native log] the service stays promoted while the app is on screen — REPRODUCED — 3 demotion(s) since arming
❌ [native State] no window between the UI leaving and the service being promoted — REPRODUCED — 285ms with no
   foreground service. The UI left the screen at 18:42:03.938 and startForeground did not succeed until 18:42:04.223
```

The reporter measured 700ms and 1500ms on an API 35 device. The card stamps `AppLifecycleState.paused` — the instant the app becomes swipeable — against `lastForegroundTransitionAt` from `getForegroundServiceHealth()`. Log timestamps cannot measure this: the table stores `datetime('now')`, and the window is shorter than a second.

## The fix

`pauseOnlyVisibilityAllowed()` arbitrates between the two settings, and the survival promise outranks the cosmetic preference:

- **`stopOnTerminate: false`** — the service is never demoted, so no window exists to swipe into. The refusal is announced once per `start()` on the always-on lifecycle channel. Silence is what made this cost a debugging session instead of a config change, so the override is not silent either.
- **`stopOnTerminate: true`** — nothing is promised past the swipe; pause-only visibility behaves exactly as before.

## Diagnostics the report exposed

Both fixed here, because the first is what makes the window measurable at all:

- **The demotion never reached the health snapshot.** `serviceForeground` kept reporting the last successful promotion, so the API whose whole purpose is to say whether background tracking is operational claimed a foreground service *precisely* during the window where there was none. Demotions are now recorded as a fourth `lastForegroundPromotionResult` value, `suppressed` — distinct from `deferred`/`failed` because the service is alive and tracking. `tracelet_doctor` renders it as its own state instead of "not confirmed yet".
- **`lastForegroundTransitionAt` was stamped on every `startForeground` call**, including re-posts of a notification the service already held. Documented as a transition timestamp, it was in practice a "last touched" one. It now stamps state changes only.

## iOS parity

Nothing to change. `showNotificationOnPauseOnly` crosses the Pigeon wire in the shared foreground-service type, but nothing in `sdk/ios` reads it — iOS has no foreground service, no notification to hide, and no task-removal kill of this kind. Its nearest analogue already takes this fix's position: starting a stream or a `CLBackgroundActivitySession` forces the location indicator on regardless of `showsBackgroundLocationIndicator: false` (#210).

## Tests

`LocationServicePauseOnlySurvivalTest` (Robolectric): no demotion under `stopOnTerminate: false`; suppression preserved under `stopOnTerminate: true`; the stamp moves on a real transition and not on a re-post. **All three fail against the unfixed service** — verified by stashing the fix and re-running.

`foreground_service_card_suppressed_test.dart`: the doctor card reports `suppressed` as its own state, and still reports `failed` as an error and an unexplained missing promotion as a warning.

Verified: `melos format` + `melos analyze` clean; full `tracelet-sdk` JVM suite green; 543 `tracelet` tests and 36 `tracelet_doctor` tests pass.

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)
