### PR TITLE
fix(ci): unbreak main — adopt Flutter 3.47 analysis_options excludes, scope the bindings check (#381)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,15 @@ jobs:
         working-directory: packages/tracelet_platform_interface
         run: flutter_rust_bridge_codegen generate
       - name: Check for uncommitted generated files
+        # Scoped to the only codegen output that is tracked: the Dart bindings
+        # and the C header are both gitignored. A repo-wide `git status` also
+        # trips on files no codegen step writes — Flutter's own `pub get`
+        # rewrites every analysis_options.yaml since 3.47 (#381).
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
+          if [ -n "$(git status --porcelain -- sdk/rust-core/core/src/frb_generated.rs)" ]; then
             echo "❌ Generated files are out of date!"
             echo "Please run 'flutter_rust_bridge_codegen generate' locally and commit the changes."
-            git diff
+            git diff -- sdk/rust-core/core/src/frb_generated.rs
             exit 1
           fi
           echo "✅ Generated files are up to date."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,11 +128,15 @@ jobs:
 
       - name: Check for uncommitted generated files
         if: ${{ !(inputs.skip_flutter && inputs.skip_native_sdks) }}
+        # Scoped to the only codegen output that is tracked: the Dart bindings
+        # and the C header are both gitignored. A repo-wide `git status` also
+        # trips on files no codegen step writes — Flutter's own `pub get`
+        # rewrites every analysis_options.yaml since 3.47 (#381).
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
+          if [ -n "$(git status --porcelain -- sdk/rust-core/core/src/frb_generated.rs)" ]; then
             echo "❌ Generated files are out of date!"
             echo "Please run 'flutter_rust_bridge_codegen generate' locally and commit the changes."
-            git diff
+            git diff -- sdk/rust-core/core/src/frb_generated.rs
             exit 1
           fi
           echo "✅ Generated files are up to date."

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,12 @@ analyzer:
     - "**/*.freezed.dart"
     - "packages/tracelet_platform_interface/lib/src/rust/**"
     - "**/frb_generated*.dart"
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
   language:
     strict-raw-types: false

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../analysis_options.yaml
 linter:
   rules:

--- a/example_firebase/analysis_options.yaml
+++ b/example_firebase/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../analysis_options.yaml
 linter:
   rules:

--- a/example_supabase/analysis_options.yaml
+++ b/example_supabase/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../analysis_options.yaml
 linter:
   rules:

--- a/packages/tracelet_sync/analysis_options.yaml
+++ b/packages/tracelet_sync/analysis_options.yaml
@@ -10,6 +10,12 @@ analyzer:
     - "**/*.freezed.dart"
     - "packages/tracelet_platform_interface/lib/src/rust/**"
     - "**/frb_generated*.dart"
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
   language:
     strict-raw-types: false


### PR DESCRIPTION
Fixes #381

`main` has been red since 2026-08-13 07:48 UTC — five consecutive pushes failed **Analyze &
Format** at `Check for uncommitted generated files`, before formatting or analysis ran, so
every downstream job was skipped.

## It was not Melos

Worth stating up front, because the step's error message points at
`flutter_rust_bridge_codegen` and the timing overlapped with the Melos 8 migration (#379).
Neither is involved: melos 8.2.2 and frb 2.12.0 were both already in use in the **last green
run** ([31621730359](https://github.com/Ikolvi/Tracelet/actions/runs/31621730359)). Running
`melos bootstrap` and `flutter_rust_bridge_codegen generate` locally against `c14ed21f` on
Flutter 3.44 leaves the tree clean.

The one variable that moved is the Flutter version `subosito/flutter-action@v2` resolves from
`channel: stable`:

| run | Flutter | melos | frb | result |
|---|---|---|---|---|
| 31621730359 | 3.44.9 | 8.2.2 | 2.12.0 | green |
| 31679309979 → 31706188343 | **3.47.0** | 8.2.2 | 2.12.0 | red |

Flutter 3.47 ships `flutter_tools/lib/src/migrations/analysis_options_migration.dart`, invoked
from `project.dart` during `flutter pub get` — so it runs inside `melos bootstrap`. It appends
`build/**`, `android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**`, `linux/**` to
`analyzer.exclude` of every `analysis_options.yaml` in the tree, creating the `analyzer`
section when there isn't one. It self-skips only once all seven entries are present, and has
no opt-out flag.

## What this PR does

**1. Commits the migration's output** for the five `analysis_options.yaml` files. These are the
exact bytes 3.47 produced on the runner — the blobs hash to `a2f850a` (root,
`tracelet_sync`) and `66b4a87` (the three examples), matching the diff CI printed. Once
committed the migration becomes a no-op, so the tree stays clean on every subsequent run.

The globs are relative to each options file's own directory, and the repo root has no
`android/`, `ios/`, `web/`, `windows/`, `macos/` or `linux/` directory, so nothing that was
previously analyzed is now excluded. `melos run format` and `melos run analyze` are both clean.

**2. Scopes the check to what it can actually assert.** It ran a repo-wide `git status
--porcelain`, so any file any tool touched during bootstrap surfaced as "generated files are
out of date" alongside an instruction to re-run a codegen command unrelated to the diff. Of
the codegen's three outputs only `sdk/rust-core/core/src/frb_generated.rs` is tracked —
`packages/tracelet_platform_interface/lib/src/rust/` and the generated C header are both
gitignored — so that path is the entire surface the check can meaningfully guard.
`release.yml` carried an identical copy of the step and would have failed the next release run
the same way; both are updated.

## Verification

- `melos run format` — SUCCESS
- `melos run analyze` — SUCCESS, no issues across all 12 packages
- Both workflow files re-parse as valid YAML
- Reproduced the clean-tree baseline in a detached worktree at `c14ed21f`: `melos bootstrap`
  then `flutter_rust_bridge_codegen generate` produced no diff locally, isolating the Flutter
  version as the trigger

No example issue card: there is no runtime behavior to verify — the change is CI configuration
and analyzer scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
