### PR TITLE
fix(geofence): honour persistMode for geofence transitions (#383)

### DIFF
--- a/example/lib/issues/issue_383_card.dart
+++ b/example/lib/issues/issue_383_card.dart
@@ -1,0 +1,241 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:tracelet/tracelet.dart' hide State;
+import 'package:tracelet_example/issues/issue_card_shell.dart';
+import 'package:tracelet_example/issues/issue_card_state.dart';
+
+/// Issue #383 — `persistMode` was not honoured for geofence ENTER/EXIT
+/// transitions.
+///
+/// `PersistenceConfig.persistMode` decides which record types reach the local
+/// database. It was applied to ordinary GPS fixes by
+/// `LocationEngine.persistLocationIfAllowed` — the only place either platform
+/// ever read `getPersistMode()` — and geofence transitions never went through
+/// it. `GeofenceManager.onGeofenceEvent` was wired straight to the SDK's
+/// unconditional `insertLocation`, so `location` ("persist only location
+/// records") and `none` ("do not persist any records") both wrote every
+/// crossing to the DB and handed it to the sync provider for the next HTTP
+/// batch.
+///
+/// It is a privacy bug rather than a bookkeeping one: `persistMode: none` is a
+/// reasonable choice for an app that wants geofence *callbacks* — a check-in
+/// screen built on `onGeofence` — without the SDK keeping a location history.
+/// That app was silently accumulating a record of every fence the device
+/// crossed, and uploading it if `http` was configured.
+///
+/// The fix routes the geofence path through
+/// `ConfigManager.shouldPersistGeofenceRecords()`, mirroring what the location
+/// path already did. Only the DB write is gated — the listener event is
+/// dispatched separately, so `none` keeps its documented "events are still
+/// fired" behaviour, which is the half of the contract that was always correct.
+///
+/// **What this card proves.** Each phase registers a *fresh* fence around your
+/// current position and lets the initial-entry trigger fire ENTER, then reads
+/// the DB back. Fence identifiers are distinct per phase on purpose: the #292
+/// dedup suppresses a repeat ENTER for a stationary device, so reusing one id
+/// would make later phases silently observe nothing.
+///
+/// The `all` phase at the end is the control, and is what makes the two zeroes
+/// above it mean anything — without it, "no geofence rows" is equally
+/// consistent with "the gate works" and "no transition ever fired on this
+/// device". Both must hold for the card to pass.
+class Issue383Card extends StatefulWidget {
+  const Issue383Card({super.key});
+
+  @override
+  State<Issue383Card> createState() => _Issue383CardState();
+}
+
+class _Issue383CardState extends State<Issue383Card>
+    with IssueCardRun<Issue383Card> {
+  /// Comfortably larger than a typical fix error, so registering while standing
+  /// inside reliably trips the initial ENTER. Also above the ~100 m floor, so
+  /// the OS path is exercised rather than only the in-app evaluator.
+  static const _radiusMeters = 200.0;
+
+  void _set(String s) => setStatus(s);
+
+  @override
+  IssueRunner? get cardRunner => _run;
+
+  Future<void> _run() async {
+    setRunning(running: true);
+    final results = <String>[];
+    var allPass = true;
+
+    void check(String name, bool pass, String detail) {
+      results.add('${pass ? '✅' : '❌'} $name — $detail');
+      if (!pass) allPass = false;
+    }
+
+    StreamSubscription<GeofenceEvent>? sub;
+    final seenEvents = <String>[];
+
+    try {
+      await Tracelet.requestLocationAuthorization();
+      await Tracelet.removeGeofences();
+
+      // autoSync: false so nothing drains the queue underneath the reads — a
+      // sync that uploaded and pruned a geofence row would make an unenforced
+      // mode look enforced, which is the one way this card could pass falsely.
+      await Tracelet.ready(
+        const Config(
+          http: HttpConfig(autoSync: false),
+          persistence: PersistenceConfig(persistMode: PersistMode.none),
+          logger: LoggerConfig(logLevel: LogLevel.debug),
+        ),
+      );
+      await Tracelet.start();
+
+      sub = Tracelet.onGeofence(
+        (e) => seenEvents.add('${e.action} ${e.identifier}'),
+      );
+
+      final here = await Tracelet.getCurrentPosition(
+        desiredAccuracy: DesiredAccuracy.high,
+        timeout: 30,
+      );
+      final lat = here.coords.latitude;
+      final lng = here.coords.longitude;
+
+      final state = await Tracelet.getState();
+      check(
+        'persistMode: none is accepted and read back',
+        state.config?.persistence.persistMode == PersistMode.none,
+        'State.config reports ${state.config?.persistence.persistMode} — this '
+            'much always passed, including on the broken build',
+      );
+
+      /// Registers a fence around the current position and waits for the
+      /// initial-entry trigger, returning the geofence rows written meanwhile.
+      Future<List<Location>> runPhase(String fenceId) async {
+        await Tracelet.destroyLocations();
+        seenEvents.clear();
+        await Tracelet.addGeofence(
+          Geofence(
+            identifier: fenceId,
+            latitude: lat,
+            longitude: lng,
+            radius: _radiusMeters,
+          ),
+        );
+        // The initial ENTER is dispatched off the registration callback; a few
+        // seconds covers the OS round-trip on both platforms.
+        await Future<void>.delayed(const Duration(seconds: 5));
+        final rows = await Tracelet.getLocations();
+        return rows.where((Location l) => l.event == 'geofence').toList();
+      }
+
+      // ---------------------------------------------------------------------
+      // 1. persistMode.none — the privacy-relevant case
+      // ---------------------------------------------------------------------
+      final noneRows = await runPhase('issue-383-none');
+      final noneFired = seenEvents.isNotEmpty;
+      check(
+        'under none, the geofence event still fires',
+        noneFired,
+        noneFired
+            ? 'onGeofence delivered ${seenEvents.join(", ")} — "events are '
+                  'still fired" is the half of the doc that was always true'
+            : 'no ENTER arrived, so this run cannot say anything about '
+                  'persistence — are you inside the fence, with location '
+                  'permission granted?',
+      );
+      check(
+        'under none, nothing is written to the database',
+        noneRows.isEmpty,
+        noneRows.isEmpty
+            ? '0 geofence rows after the crossing'
+            : '${noneRows.length} geofence row(s) persisted despite '
+                  'persistMode.none — this is #383',
+      );
+
+      // ---------------------------------------------------------------------
+      // 2. persistMode.location — excludes geofence records by name
+      // ---------------------------------------------------------------------
+      await Tracelet.setConfig(
+        const Config(
+          persistence: PersistenceConfig(persistMode: PersistMode.location),
+        ),
+      );
+      final locationRows = await runPhase('issue-383-location');
+      check(
+        'under location, no geofence row is written',
+        locationRows.isEmpty,
+        locationRows.isEmpty
+            ? '0 geofence rows — "persist only location records" now excludes '
+                  'the records it names'
+            : '${locationRows.length} geofence row(s) persisted under '
+                  'persistMode.location',
+      );
+
+      // ---------------------------------------------------------------------
+      // 3. persistMode.all — the control
+      // ---------------------------------------------------------------------
+      await Tracelet.setConfig(
+        const Config(
+          persistence: PersistenceConfig(persistMode: PersistMode.all),
+        ),
+      );
+      final allRows = await runPhase('issue-383-all');
+      check(
+        'under all, the geofence row IS written',
+        allRows.isNotEmpty,
+        allRows.isNotEmpty
+            ? '${allRows.length} geofence row(s) persisted — so the two zeroes '
+                  'above are the gate working, not a transition that never '
+                  'fired'
+            : 'no geofence row under persistMode.all. The control failed, so '
+                  'the phases above prove nothing on this run — the fix may '
+                  'still be fine; re-run while standing inside the fence',
+      );
+
+      await Tracelet.removeGeofences();
+      await Tracelet.destroyLocations();
+      await Tracelet.stop();
+
+      final header = allPass
+          ? '✅ SUCCESS: persistMode gates geofence rows, and the event fires '
+                'either way.'
+          : '❌ FAILED — #383 not satisfied on this build. See the failing rows.';
+
+      _set(
+        '$header\n\n${results.join('\n')}\n\n'
+        'The gate lives in ConfigManager.shouldPersistGeofenceRecords() on both '
+        'platforms, read live at each transition rather than latched at setup, '
+        'so a setConfig mid-session takes effect on the next crossing — which '
+        'is what phases 2 and 3 rely on. It sits on the single callback both '
+        'transition sources funnel through (OS-delivered handleGeofenceEvent '
+        'and software-evaluated proximity), so the sub-100 m in-app evaluator '
+        'is covered by the same check. An unrecognised mode falls back to '
+        'persisting: a gate is not worth silent data loss.',
+      );
+    } catch (e) {
+      _set('❌ FAILED: $e\n\n${results.join('\n')}');
+    } finally {
+      await sub?.cancel();
+      setRunning(running: false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueCardShell(
+      keywords:
+          'persistMode PersistMode none location geofence PersistenceConfig '
+          'persist geofence transitions ENTER EXIT database rows synced http '
+          'privacy location history getLocations onGeofence not honoured',
+      title: '#383: persistMode ignored for geofence transitions',
+      description:
+          'Registers a fresh fence at your position under persistMode.none, '
+          'then .location, then .all, and reads the DB back after each initial '
+          'ENTER. The first two must write no geofence row while still firing '
+          'the event; the third must write one — that control is what makes '
+          'the two zeroes meaningful rather than a crossing that never fired.',
+      status: status,
+      running: running,
+      onRun: _run,
+    );
+  }
+}

--- a/example/lib/issues/recent_issues_tab.dart
+++ b/example/lib/issues/recent_issues_tab.dart
@@ -83,6 +83,7 @@ import 'package:tracelet_example/issues/issue_368_card.dart';
 import 'package:tracelet_example/issues/issue_371_card.dart';
 import 'package:tracelet_example/issues/issue_376_card.dart';
 import 'package:tracelet_example/issues/issue_378_card.dart';
+import 'package:tracelet_example/issues/issue_383_card.dart';
 import 'package:tracelet_example/issues/battery_budget_remote_config_card.dart';
 import 'package:tracelet_example/issues/mock_rejection_card.dart';
 import 'package:tracelet_example/issues/remote_config_card.dart';
@@ -1748,6 +1749,7 @@ class _RecentIssuesTabState extends State<RecentIssuesTab> {
                     // own title/description/keywords via IssueSearchScope, so they
                     // are rendered directly. Cards with a bespoke layout (no shell)
                     // stay wrapped in _searchableCard with explicit keywords.
+                    const Issue383Card(),
                     const Issue378Card(),
                     const Issue376Card(),
                     const Issue371Card(),

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/ConfigManager.kt
@@ -798,6 +798,22 @@ class ConfigManager(context: Context) {
     fun getPersistMode(): Int =
         getInt("persistMode", DEFAULT_PERSIST_MODE)
 
+    /**
+     * Whether geofence ENTER/EXIT records may be written to the local DB (#383).
+     *
+     * The geofence counterpart of the `persistMode` check `LocationEngine`
+     * applies to ordinary locations. Gates persistence only — the geofence
+     * listener event is dispatched separately and fires in every mode, so
+     * `none` keeps its documented "events are still fired" behaviour.
+     *
+     * persistMode: 0 = all, 1 = location only, 2 = geofence only, 3 = none
+     */
+    fun shouldPersistGeofenceRecords(): Boolean =
+        when (getPersistMode()) {
+            1, 3 -> false // location only / none
+            else -> true // all / geofence only
+        }
+
     fun getMaxDaysToPersist(): Int =
         getInt("maxDaysToPersist", DEFAULT_MAX_DAYS_TO_PERSIST)
 

--- a/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
+++ b/sdk/android/tracelet-sdk/src/main/kotlin/com/ikolvi/tracelet/sdk/TraceletSdk.kt
@@ -670,7 +670,7 @@ class TraceletSdk private constructor(private val context: Context) {
             },
         ).apply {
             onGeofenceEvent = { eventMap ->
-                insertLocation(eventMap)
+                persistGeofenceIfAllowed(eventMap)
             }
         }
         GeofenceBroadcastReceiver.geofenceManager = geofenceManager
@@ -2118,6 +2118,25 @@ class TraceletSdk private constructor(private val context: Context) {
      * DB writes from the same GPS fix (e.g. from PeriodicLocationWorker).
      */
     private var lastInsertedTimestamp: String? = null
+
+    /**
+     * Persists a geofence ENTER/EXIT record only if allowed by persistMode (#383).
+     *
+     * The geofence counterpart of `LocationEngine.persistLocationIfAllowed` — geofence
+     * transitions used to be wired straight to [insertLocation], so `location` and
+     * `none` still wrote (and HTTP-synced) every crossing despite documenting otherwise.
+     *
+     * Only the DB write is gated. The listener event is dispatched separately by
+     * `GeofenceManager` via `events.sendGeofence`, so `none` keeps its documented
+     * "events are still fired" behaviour.
+     *
+     * Read live rather than latched at setup, so a `setConfig` mid-session takes
+     * effect on the next transition.
+     */
+    private fun persistGeofenceIfAllowed(eventMap: Map<String, Any?>) {
+        if (!configManager.shouldPersistGeofenceRecords()) return
+        insertLocation(eventMap)
+    }
 
     /**
      * Inserts a location record into the Rust database and notifies registered sync sinks.

--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/TraceletSdkGeofencePersistModeTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/TraceletSdkGeofencePersistModeTest.kt
@@ -1,0 +1,180 @@
+package com.ikolvi.tracelet.sdk
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import uniffi.tracelet_core.DatabaseManager
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * #383: guard that `persistMode` gates geofence ENTER/EXIT rows, not just
+ * ordinary location rows.
+ *
+ * Geofence transitions were wired straight from `GeofenceManager.onGeofenceEvent`
+ * to [TraceletSdk.insertLocation], bypassing the only persist-mode check on the
+ * platform (`LocationEngine.persistLocationIfAllowed`). `location` and `none`
+ * therefore persisted — and HTTP-synced — every crossing, contradicting their
+ * documented meaning.
+ *
+ * The test fires the **production** callback (`geofenceManager.onGeofenceEvent`,
+ * installed during SDK setup) rather than calling the gate directly, so it covers
+ * the wiring as well as the mode arithmetic. That callback is the single funnel
+ * both transition sources — OS-delivered `handleGeofenceEvent` and
+ * software-evaluated `evaluateHighAccuracyProximity` — pass through.
+ *
+ * The SDK is a process-wide singleton shared by every Robolectric suite in the
+ * JVM, and `initialize()` latches on `initStarted`, so the callback under test
+ * survives only until some other suite clears it (`GeofenceStartIdempotencyTest`
+ * nulls it in teardown). This suite therefore drops the singleton before and
+ * after each test, so every case re-runs the real setup and asserts against
+ * freshly installed production wiring instead of whatever the previous class
+ * left behind. It reads the SDK's own DB rather than injecting one, so it never
+ * leaves `rustDatabase` null for a later suite.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class TraceletSdkGeofencePersistModeTest {
+
+    private lateinit var context: Context
+    private lateinit var sdk: TraceletSdk
+    private lateinit var db: DatabaseManager
+
+    /** Drops the process-wide SDK singleton so the next `getInstance` rebuilds it. */
+    private fun resetSdkSingleton() {
+        val field = TraceletSdk::class.java.getDeclaredField("instance")
+        field.isAccessible = true
+        field.set(null, null)
+    }
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        shadowOf(context as Application).grantPermissions(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+        )
+
+        resetSdkSingleton()
+        sdk = TraceletSdk.getInstance(context)
+        sdk.setEventSender(ListenerEventSender())
+        // Wires geofenceManager and installs the production onGeofenceEvent
+        // callback — the code path under test. initialize() hands the wiring to
+        // the background "tracelet-init" thread, so block on awaitInit() before
+        // touching the lateinit managers.
+        sdk.initialize()
+        assertTrue(sdk.awaitInit(), "test precondition: SDK init must complete")
+
+        db = assertNotNull(sdk.rustDatabase, "test precondition: the Rust DB must be open")
+        db.destroyLocations()
+
+        sdk.configManager.reset(null)
+        assertNotNull(
+            sdk.geofenceManager.onGeofenceEvent,
+            "test precondition: the production geofence callback must be wired",
+        )
+        assertEquals(0, db.getLocationsCount(), "test precondition: DB starts empty")
+    }
+
+    @After
+    fun tearDown() {
+        try { db.destroyLocations() } catch (_: Exception) {}
+        sdk.configManager.reset(null)
+        ConfigManager.resetInstance()
+        // Hand the next suite a clean singleton rather than this suite's SDK.
+        resetSdkSingleton()
+    }
+
+    /**
+     * Fires one geofence transition through the production callback, using the
+     * same payload shape `GeofenceManager` builds.
+     */
+    private fun fireTransition(identifier: String, action: String = "ENTER") {
+        sdk.geofenceManager.onGeofenceEvent?.invoke(
+            mapOf(
+                "uuid" to java.util.UUID.randomUUID().toString(),
+                "event" to "geofence",
+                "timestamp" to Instant.now().toString(),
+                "coords" to mapOf(
+                    "latitude" to 10.787929,
+                    "longitude" to 76.684183,
+                    "accuracy" to 8.0,
+                ),
+                "geofence" to mapOf(
+                    "identifier" to identifier,
+                    "action" to action,
+                    "extras" to null,
+                ),
+            ),
+        )
+    }
+
+    private fun setPersistMode(mode: Int) {
+        sdk.configManager.setConfig(mapOf("persistence" to mapOf("persistMode" to mode)))
+        assertEquals(mode, sdk.configManager.getPersistMode(), "config precondition")
+    }
+
+    /** Mode 0 = all: geofence rows are persisted, as documented. */
+    @Test
+    fun geofenceTransition_persistsUnderModeAll() {
+        setPersistMode(0)
+        fireTransition("fence-all")
+        assertEquals(1, db.getLocationsCount(), "mode `all` must persist geofence rows")
+    }
+
+    /**
+     * Mode 1 = location only. The regression: documented as "persist only
+     * location records", it persisted geofence records too.
+     */
+    @Test
+    fun geofenceTransition_isSkippedUnderModeLocation() {
+        setPersistMode(1)
+        fireTransition("fence-location")
+        assertEquals(0, db.getLocationsCount(), "mode `location` must not persist geofence rows")
+    }
+
+    /** Mode 2 = geofence only: the one mode that exists to keep these rows. */
+    @Test
+    fun geofenceTransition_persistsUnderModeGeofence() {
+        setPersistMode(2)
+        fireTransition("fence-geofence")
+        assertEquals(1, db.getLocationsCount(), "mode `geofence` must persist geofence rows")
+    }
+
+    /**
+     * Mode 3 = none. The privacy-relevant half of #383: an app asking for no
+     * persistence still accumulated a history of every fence it crossed, and
+     * handed it to the sync provider for the next HTTP batch.
+     */
+    @Test
+    fun geofenceTransition_isSkippedUnderModeNone() {
+        setPersistMode(3)
+        repeat(5) { fireTransition("fence-none-$it", if (it % 2 == 0) "ENTER" else "EXIT") }
+        assertEquals(0, db.getLocationsCount(), "mode `none` must not persist geofence rows")
+    }
+
+    /**
+     * The gate reads config live, so a mode change mid-session takes effect on
+     * the next transition — it is not latched at setup time.
+     */
+    @Test
+    fun geofenceTransition_honoursModeChangedAfterSetup() {
+        setPersistMode(0)
+        fireTransition("fence-before")
+        assertEquals(1, db.getLocationsCount(), "baseline insert under `all`")
+
+        setPersistMode(3)
+        fireTransition("fence-after")
+        assertEquals(1, db.getLocationsCount(), "switching to `none` must stop new geofence rows")
+    }
+}

--- a/sdk/ios/Package.swift
+++ b/sdk/ios/Package.swift
@@ -94,6 +94,11 @@ let package = Package(
                 // Both keys were accepted and enforced by nothing after the
                 // 3.1.0 DB migration dropped the calls that implemented them.
                 "DatabaseRetentionCapsTests.swift",
+                // #383: persistMode gates geofence ENTER/EXIT rows, not just
+                // ordinary locations. The geofence path was wired straight to
+                // insertLocation, so `location` and `none` persisted — and
+                // HTTP-synced — every crossing they document as excluded.
+                "ConfigManagerGeofencePersistModeTests.swift",
             ]
         ),
     ]

--- a/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
+++ b/sdk/ios/Sources/TraceletSDK/ConfigManager.swift
@@ -376,6 +376,22 @@ public final class ConfigManager {
 
     // PersistenceConfig
     public func getPersistMode() -> Int { (cache["persistMode"] as? NSNumber)?.intValue ?? 0 }
+
+    /// Whether geofence ENTER/EXIT records may be written to the local DB (#383).
+    ///
+    /// The geofence counterpart of the `persistMode` check `LocationEngine`
+    /// applies to ordinary locations. Gates persistence only — the geofence
+    /// listener event is dispatched separately and fires in every mode, so
+    /// `none` keeps its documented "events are still fired" behaviour.
+    ///
+    /// persistMode: 0 = all, 1 = location only, 2 = geofence only, 3 = none
+    public func shouldPersistGeofenceRecords() -> Bool {
+        switch getPersistMode() {
+        case 1, 3: return false // location only / none
+        default: return true // all / geofence only
+        }
+    }
+
     public func getLocationTemplate() -> String? { cache["locationTemplate"] as? String }
     public func getGeofenceTemplate() -> String? { cache["geofenceTemplate"] as? String }
     public func getDisableProviderChangeRecord() -> Bool { cache["disableProviderChangeRecord"] as? Bool ?? false }

--- a/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
+++ b/sdk/ios/Sources/TraceletSDK/TraceletSdk.swift
@@ -1596,6 +1596,23 @@ public final class TraceletSdk {
     /// DB writes from the same GPS fix.
     private var lastInsertedTimestamp: String? = nil
 
+    /// Persists a geofence ENTER/EXIT record only if allowed by persistMode (#383).
+    ///
+    /// The geofence counterpart of `LocationEngine.persistLocationIfAllowed` — geofence
+    /// transitions used to be wired straight to `insertLocation`, so `location` and
+    /// `none` still wrote (and HTTP-synced) every crossing despite documenting otherwise.
+    ///
+    /// Only the DB write is gated. The listener event is dispatched separately by
+    /// `GeofenceManager` via `eventDispatcher.sendGeofence`, so `none` keeps its
+    /// documented "events are still fired" behaviour.
+    ///
+    /// Read live rather than latched at setup, so a `setConfig` mid-session takes
+    /// effect on the next transition.
+    private func persistGeofenceIfAllowed(_ eventData: [String: Any]) {
+        guard configManager.shouldPersistGeofenceRecords() else { return }
+        let _ = insertLocation(eventData)
+    }
+
     /// Insert a custom location into the store.
     ///
     /// - Parameter params: Location data dictionary.
@@ -2630,7 +2647,7 @@ public final class TraceletSdk {
             rustDatabase: rustDatabase
         )
         geofenceManager.onGeofenceEvent = { [weak self] eventData in
-            let _ = self?.insertLocation(eventData)
+            self?.persistGeofenceIfAllowed(eventData)
         }
         
         // Smart motion coordinator

--- a/sdk/ios/Tests/TraceletSDKTests/ConfigManagerGeofencePersistModeTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/ConfigManagerGeofencePersistModeTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import TraceletSDK
+
+/// #383 — `persistMode` was not honoured for geofence ENTER/EXIT transitions.
+///
+/// `GeofenceManager.onGeofenceEvent` was wired straight to
+/// `TraceletSdk.insertLocation`, bypassing the only persist-mode check on the
+/// platform (`LocationEngine.persistLocationIfAllowed`). `location` and `none`
+/// therefore persisted — and HTTP-synced — every crossing, contradicting their
+/// documented meaning. `none` is the privacy-relevant case: an app wanting
+/// geofence callbacks without a location history still accumulated one.
+///
+/// **Scope.** This suite covers the decision itself —
+/// `ConfigManager.shouldPersistGeofenceRecords`, the predicate the fix routes
+/// the geofence path through. It does not cover `TraceletSdk`'s wiring, whose
+/// `rustDatabase` is `public private(set)` and so cannot be injected from a
+/// test; that wiring is a mirror of the Android one covered by
+/// `TraceletSdkGeofencePersistModeTest`, and is verified end-to-end on device by
+/// the #383 example card. This is the same split `DatabaseRetentionCapsTests`
+/// documents for #361.
+final class ConfigManagerGeofencePersistModeTests: XCTestCase {
+
+    private var config: ConfigManager!
+
+    override func setUp() {
+        super.setUp()
+        config = ConfigManager()
+        config.reset(nil)
+    }
+
+    override func tearDown() {
+        config.reset(nil)
+        config = nil
+        super.tearDown()
+    }
+
+    /// Sets the mode through the nested `persistence` section — the shape every
+    /// transport actually sends — rather than the flat key.
+    private func setPersistMode(_ mode: Int) {
+        _ = config.setConfig(["persistence": ["persistMode": mode]])
+        XCTAssertEqual(config.getPersistMode(), mode, "config precondition")
+    }
+
+    /// Mode 0 = all, and the default when the key was never set. Both must keep
+    /// persisting geofence rows — the fix must not turn into data loss for the
+    /// apps that never configured `persistMode` at all.
+    func testModeAllPersistsGeofenceRecords() {
+        XCTAssertEqual(config.getPersistMode(), 0, "default is `all`")
+        XCTAssertTrue(config.shouldPersistGeofenceRecords(), "unset default must persist")
+
+        setPersistMode(0)
+        XCTAssertTrue(config.shouldPersistGeofenceRecords(), "mode `all` must persist")
+    }
+
+    /// Mode 1 = location only. Documented as "persist only location records",
+    /// it persisted the geofence records it excludes by name.
+    func testModeLocationSkipsGeofenceRecords() {
+        setPersistMode(1)
+        XCTAssertFalse(
+            config.shouldPersistGeofenceRecords(),
+            "mode `location` must not persist geofence rows"
+        )
+    }
+
+    /// Mode 2 = geofence only: the one mode that exists to keep these rows.
+    func testModeGeofencePersistsGeofenceRecords() {
+        setPersistMode(2)
+        XCTAssertTrue(
+            config.shouldPersistGeofenceRecords(),
+            "mode `geofence` must persist geofence rows"
+        )
+    }
+
+    /// Mode 3 = none. The privacy-relevant half of #383.
+    func testModeNoneSkipsGeofenceRecords() {
+        setPersistMode(3)
+        XCTAssertFalse(
+            config.shouldPersistGeofenceRecords(),
+            "mode `none` must not persist geofence rows"
+        )
+    }
+
+    /// The predicate reads config live, so a `setConfig` mid-session takes effect
+    /// on the next transition rather than being latched at SDK setup.
+    func testModeChangeTakesEffectImmediately() {
+        setPersistMode(0)
+        XCTAssertTrue(config.shouldPersistGeofenceRecords())
+
+        setPersistMode(3)
+        XCTAssertFalse(
+            config.shouldPersistGeofenceRecords(),
+            "switching to `none` must stop new geofence rows"
+        )
+
+        setPersistMode(2)
+        XCTAssertTrue(
+            config.shouldPersistGeofenceRecords(),
+            "switching back to `geofence` must resume them"
+        )
+    }
+
+    /// An out-of-range mode must not silently disable persistence — the enum has
+    /// four values today, and an unknown one falls back to the `all` default the
+    /// rest of the config layer uses.
+    func testUnknownModeFallsBackToPersisting() {
+        setPersistMode(99)
+        XCTAssertTrue(
+            config.shouldPersistGeofenceRecords(),
+            "unknown mode must fall back to persisting, not to silent data loss"
+        )
+    }
+}


### PR DESCRIPTION
## Issue validity

Verified against `main` (3.8.4) before writing anything. The report holds on both platforms:

- `getPersistMode()` has exactly **one** behavioural read per platform — `LocationEngine.persistLocationIfAllowed` (`LocationEngine.kt:1736`, `LocationEngine.swift:1741`). Nothing in the Rust core reads persist mode at all.
- The geofence path never reaches it: `GeofenceManager.onGeofenceEvent` was wired straight to the unconditional `insertLocation` (`TraceletSdk.kt:672`, `TraceletSdk.swift:2632`).

So `location` and `none` both persisted — and made HTTP-sync-eligible — every ENTER/EXIT, contradicting their own documented meaning. `persistMode: none` is a plausible choice for an app that wants geofence callbacks without a location history; that app was silently building a database of every fence it crossed.

The reporter's framing that this is *not* a repeat of #361 also checks out: `2afc926f` predates `b1cfb7dd` and never touched `handleGeofenceEvent`. Nothing was lost in a refactor — this is a persistence pathway added after the gate existed that was never routed through it.

## The fix

A new `ConfigManager.shouldPersistGeofenceRecords()` on both platforms, with the geofence path routed through a `persistGeofenceIfAllowed` gate that mirrors what the location path already had.

- **Only the DB write is gated.** The listener event is dispatched separately by `GeofenceManager`, so `none` keeps its documented "events are still fired" behaviour — the half of the contract that was always correct.
- **One funnel.** The gate sits on the single callback both transition sources pass through: OS-delivered `handleGeofenceEvent` and software-evaluated proximity, so the sub-100 m in-app evaluator is covered by the same check.
- **Read live**, not latched at setup, so a mid-session `setConfig` takes effect on the next crossing.
- **An unrecognised mode falls back to persisting.** A config gate is not worth silent data loss, and `all` is the default every unconfigured app is on.

| `persistMode` | Location rows | Geofence rows (before) | Geofence rows (after) |
|---|---|---|---|
| `all` | Yes | Yes | Yes |
| `location` | Yes | **Yes — contrary to docs** | No |
| `geofence` | No | Yes | Yes |
| `none` | No | **Yes — contrary to docs** | No |

## Tests

- `TraceletSdkGeofencePersistModeTest` (Android) fires the **production** `onGeofenceEvent` callback across all four modes, so it covers the wiring as well as the mode arithmetic. **Verified to fail on the pre-fix wiring** — 3 of 5 cases red, exactly the `location`/`none` ones — then pass with the gate in place.
- `ConfigManagerGeofencePersistModeTests` (iOS) covers the predicate, including the unset default and an out-of-range mode. It stops short of the `TraceletSdk` wiring because `rustDatabase` is `public private(set)` and cannot be injected from a test — the same scope split `DatabaseRetentionCapsTests` documents for #361, with the wiring covered on device by the example card. Registered in `Package.swift`'s `sources:` allowlist, without which it would never run.

Full suites green on both platforms: **Android 394 tests, iOS 121 tests**. `melos format` and `melos analyze` clean.

One note on the Android suite: `TraceletSdk` is a process-wide singleton shared across Robolectric classes, and `GeofenceStartIdempotencyTest` nulls `onGeofenceEvent` in teardown. The new suite drops the singleton around each test rather than injecting and nulling a DB, so it neither depends on nor damages state other suites rely on — an earlier draft that injected a DB broke 4 unrelated boot tests.

## Example card

`example/lib/issues/issue_383_card.dart`, registered at the top of the Recent Issues tab. Runs three phases with distinct fence ids (the #292 dedup would suppress a repeat ENTER on a stationary device): `none` and `location` must write no geofence row while still firing the event, then `all` **must** write one. That last phase is the control — without it, "no geofence rows" is equally consistent with the gate working and with no transition ever having fired on the device.

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
