### PR TITLE
test(motion): stop StationaryStartInitialFixTest inheriting geofence config (#385)

### DIFF
--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/StationaryStartInitialFixTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/StationaryStartInitialFixTest.kt
@@ -143,10 +143,39 @@ class StationaryStartInitialFixTest {
                 "foregroundService" to false,
                 "stopOnStationary" to false,
                 "isMoving" to isMoving,
+                // Pinned, not inherited: ready() merges into the persisted
+                // config, and `hasEvaluatorOwnedGeofences()` is true whenever
+                // this flag is — no stored fence required. Left to whatever an
+                // earlier class wrote, start() runs the stream for in-app
+                // evaluation (#357) and skips the anchor as "already
+                // acquiring", so the class failed on whichever test JUnit
+                // scheduled first and passed on a re-run.
+                "geofenceModeHighAccuracy" to false,
             ) + extra,
         ) { done = true }
         idle()
         check(done) { "ready() did not complete" }
+        // `TraceletSdk.isTracking` also consults `LocationService.isRunning`, a
+        // static that outlives the singleton this class resets — a foreground
+        // service left "running" by an earlier class makes start() take its
+        // already-tracking early return, and every assertion below then
+        // measures nothing. Checked rather than assumed: the failure is
+        // otherwise a silent zero three steps later.
+        check(!sdk.isTracking) {
+            "a previous test left tracking active — start() would no-op"
+        }
+
+        // The other half of the same trap: geofences live in the Rust DB under
+        // filesDir, which is shared by the whole test run and survives both the
+        // singleton reset and Robolectric's sandbox. A single sub-100 m fence
+        // left by another class is evaluator-owned on its own merits, config
+        // flag or not.
+        sdk.removeGeofences()
+        idle()
+        check(!sdk.geofenceManager.hasEvaluatorOwnedGeofences()) {
+            "an evaluator-owned fence or the high-accuracy flag survived; " +
+                "start() would run the stream and skip the anchor"
+        }
 
         // The motion subsystems are process-scoped and outlive stop(), so a
         // leftover moving input from whichever test ran before this one would
@@ -219,8 +248,16 @@ class StationaryStartInitialFixTest {
         idle()
 
         // The anchor lands and takes the processor's first-fix slot.
+        assertEquals("precondition: the anchor was requested", 1, client.getCurrentLocationCalls)
         client.deliverCurrentLocation(fix(lat = 10.787929, ageSeconds = 0))
         idle()
+        assertEquals(
+            "precondition: the anchor was accepted — without it there is no slot " +
+                "to hand back and nothing under test",
+            10.787929,
+            sdk.locationEngine.getLastLocation()?.latitude ?: 0.0,
+            1e-6,
+        )
         clearInvocations(events)
 
         // The device wakes without having moved — the phone is still on the


### PR DESCRIPTION
## main is red

`StationaryStartInitialFixTest > the fix that wakes the session is still delivered after the anchor` fails about one run in two. The [#386](https://github.com/Ikolvi/Tracelet/pull/386) merge commit has both a [failing run](https://github.com/Ikolvi/Tracelet/actions/runs/31835820885) and a passing one at the same SHA — it is a dirty fixture, not a product bug.

## Cause

`ready()` merges into the persisted config rather than replacing it, so the test inherited `geofenceModeHighAccuracy` from whichever class Gradle scheduled before it. `hasEvaluatorOwnedGeofences()` is true whenever that flag is — **no stored fence required**:

```kotlin
fun hasEvaluatorOwnedGeofences(): Boolean =
    config.getGeofenceModeHighAccuracy() || getCachedGeofences().any { isEvaluatorOwned(it) }
```

With it set, `start()` runs the stream for in-app evaluation (#357), `requestStartupFix()` sees `isTracking` and skips the anchor as "already acquiring", and the class measures nothing. It hits whichever test JUnit orders first, which is why re-running appeared to fix it.

## Fix

Pin the flag instead of inheriting it, and clear stored fences too — those live in the Rust DB under `filesDir`, shared by the whole test run and surviving both the singleton reset and Robolectric's sandbox, so a single sub-100 m fence left by another class is evaluator-owned on its own merits.

Both are now checked as preconditions, along with `sdk.isTracking`. The failure was otherwise a silent zero three assertions later, which is exactly what made it look like a real regression.

**Test-only — no SDK behaviour changes.** Three consecutive full-suite runs clean (396 tests).

Split out of [#388](https://github.com/Ikolvi/Tracelet/pull/388) so main goes green without waiting on that review; #388 carries the identical change and will merge cleanly on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)