### PR TITLE
test(motion): cover the pace regressions the existing tests let through

### DIFF
--- a/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/StartCommittedPaceTest.kt
+++ b/sdk/android/tracelet-sdk/src/test/kotlin/com/ikolvi/tracelet/sdk/StartCommittedPaceTest.kt
@@ -153,6 +153,40 @@ class StartCommittedPaceTest {
         )
     }
 
+    /**
+     * The regression these tests missed.
+     *
+     * `a resume still inherits the restored moving pace` asserts
+     * `stateManager.isMoving`, and SLOWING counts as moving — so a machine that
+     * has *already begun standing down* satisfies it. The seed a few lines after
+     * the pace is adopted fed `lastEffectiveSpeed`, which is 0.0 in a process
+     * that has handled no fix (a killed-state relaunch, exactly this case), and
+     * that fabricated zero pushed MOVING -> SLOWING immediately. The session then
+     * reached STATIONARY when the countdown expired and switched the continuous
+     * stream off, which is what a user reports as tracking stopping after the app
+     * is backgrounded or killed.
+     *
+     * Asserting the machine's own state rather than the boolean is what catches
+     * it: MOVING and SLOWING are different, and only one of them is healthy.
+     */
+    @Test
+    fun `a resumed session is not stood down by the startup seed`() {
+        ready(mode = 2, isMoving = false)
+        leaveSpeedMachineMoving()
+        sdk.stateManager.isMoving = false
+
+        sdk.start(isResume = true)
+        idle()
+
+        assertEquals(
+            SpeedMotionState.MOVING,
+            sdk.stateManager.speedMotionState,
+            "a resume came up MOVING and no fix has been handled yet, so nothing has " +
+                "reported a speed — seeding 0.0 starts the countdown to STATIONARY and " +
+                "takes the continuous stream down with it",
+        )
+    }
+
     @Test
     fun `a moving committed pace is unaffected`() {
         ready(mode = 2, isMoving = true)

--- a/sdk/ios/Tests/TraceletSDKTests/SpeedMotionManagerTests.swift
+++ b/sdk/ios/Tests/TraceletSDKTests/SpeedMotionManagerTests.swift
@@ -55,6 +55,51 @@ final class SpeedMotionManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .stationary)
     }
 
+    // MARK: - Hysteresis band
+
+    /// Leaving MOVING takes a clearer signal than entering it did.
+    ///
+    /// One threshold used to govern both directions, so a pace that varied
+    /// either side of it — every ordinary walk does — oscillated
+    /// MOVING → SLOWING → STATIONARY → MOVING, and a completed countdown took
+    /// the continuous stream down while the user was still walking. The default
+    /// entry threshold was 1.5 m/s, above an average walking pace of ~1.4.
+    func testAWalkingPaceStaysMovingInsideTheHysteresisBand() {
+        makeManager(movingThreshold: 0.9, stationaryDelaySeconds: 60)
+
+        // Enters on a brisk fix, then drifts across the entry threshold the way
+        // a real walk does.
+        manager.onLocation(speed: 1.5)
+        XCTAssertEqual(manager.state, .moving)
+
+        for speed in [1.31, 0.85, 1.48, 0.72, 1.40] {
+            manager.onLocation(speed: speed)
+            XCTAssertEqual(
+                manager.state, .moving,
+                "\(speed) m/s is above the stationary threshold — a walk must not stand down"
+            )
+        }
+    }
+
+    func testDroppingBelowTheStationaryThresholdStillSlows() {
+        makeManager(movingThreshold: 0.9, stationaryDelaySeconds: 60)
+
+        manager.onLocation(speed: 1.5)
+        // 0.9 * 0.65 = 0.585, so this is genuinely stopped rather than walking.
+        manager.onLocation(speed: 0.2)
+        XCTAssertEqual(manager.state, .slowing)
+    }
+
+    func testAnExplicitStationaryThresholdIsClampedToTheMovingOne() {
+        makeManager(movingThreshold: 2.0, stationaryDelaySeconds: 60)
+        manager.speedStationaryThreshold = 5.0
+
+        XCTAssertEqual(
+            manager.effectiveStationaryThreshold, 2.0,
+            "an exit threshold above the entry one would re-create the flapping"
+        )
+    }
+
     // MARK: - MOVING -> SLOWING
 
     func testMovingTransitionsToSlowingBelowThreshold() {


### PR DESCRIPTION
Follow-up to #399. Those pace fixes all shipped past a green suite; this adds the coverage that would have caught them.

## Why the existing tests missed it

`StartCommittedPaceTest` was written *for* `80a60f67` — the 3.8.1 change that exposed the regression — so the area was tested. The gap was in what it asserted:

```kotlin
assertTrue(sdk.stateManager.isMoving, "a relaunched process must come back up in the pace it was killed in")
```

**SLOWING counts as moving.** A machine that had already begun its countdown to STATIONARY satisfied that assertion perfectly. The startup seed fired a few lines after the pace was adopted, pushed MOVING → SLOWING immediately, and the test stayed green while the session was already on its way to shutting the location stream off.

The test even records the mechanism in its own message — *"a MOVING machine falls to SLOWING on the first low-speed fix and writes isMoving back to true"* — but uses it in the other direction, as the reason the flag is trustworthy.

Two further reasons no unit test could have expressed the other defects:

- `SpeedMotionManager.onLocation(speed: Double)` takes a bare speed with **no timestamp**, so "this fix is 40 seconds old" is not sayable at that layer. The staleness guard therefore lives in `LocationEngine`, where the fix and its age are both in scope.
- On iOS nothing asserted threshold behaviour at all, which is why changing the default from 1.5 to 0.9 m/s broke no test.

## What this adds

**`StartCommittedPaceTest.a resumed session is not stood down by the startup seed`** — asserts `speedMotionState == MOVING` rather than the `isMoving` boolean, which is the distinction that matters: MOVING and SLOWING are different states and only one is healthy.

Verified red/green rather than assumed:

```
# seed guard reverted
StartCommittedPaceTest > a resumed session is not stood down by the startup seed FAILED
tests="5" failures="1"

# guard restored
BUILD SUCCESSFUL
```

**`SpeedMotionManagerTests`** — three cases for the hysteresis band: a walking pace drifting either side of the entry threshold (1.31, 0.85, 1.48, 0.72, 1.40 m/s — the spread from the field trace) stays MOVING; a genuine stop still slows; and an explicit stationary threshold above the moving one is clamped rather than re-creating the flap.

Appended to the existing Swift file deliberately: a new test file absent from `Package.swift`'s `sources:` never runs, and `xcodebuild` still reports success.

## Both suites gate PRs

- Kotlin: `ci.yml:254`, `./gradlew :tracelet-sdk:testDebugUnitTest`, in **Build Android**
- Swift: `ci.yml:388`, `xcodebuild test -scheme TraceletSDK`, in **Build iOS**

Local: Android suite green, iOS 132 tests green (up from 129), Rust 163 green, `melos format`/`analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
